### PR TITLE
Makefile Bugfix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,27 +2,25 @@
 # LIO MAKEFILE
 ################################################################################
 
-all: liosolo/liosolo lioamber/liblio-g2g.so g2g/libg2g.so
+all: liosolo liblio g2g
 
 
 .PHONY: liosolo
-liosolo: liosolo/liosolo
-liosolo/liosolo: lioamber/liblio-g2g.so
+liosolo: liblio
 	$(MAKE) -C liosolo
 
 
 .PHONY: liblio
-liblio: lioamber/liblio-g2g.so
-lioamber/liblio-g2g.so: g2g/libg2g.so
+liblio: g2g
 	$(MAKE) -C lioamber
 
 
 .PHONY: g2g
-g2g: g2g/libg2g.so
-g2g/libg2g.so:
+g2g:
 	$(MAKE) -C g2g
 
 
+.PHONY: clean
 clean:
 	$(MAKE) clean -C liosolo
 	$(MAKE) clean -C lioamber

--- a/lioamber/Makefile.depends
+++ b/lioamber/Makefile.depends
@@ -102,7 +102,7 @@ include ehrenfest.mk
 OBJECTS += ehrenfest.o
 
 tmplist :=
-tmplist += SCF.o
+tmplist += SCF.o SCF_exter.o init_lio.o liomain.o
 $(tmplist:%.o=$(OBJPATH)/%.o) : $(OBJPATH)/ehrenfest.mod
 
 


### PR DESCRIPTION
Having libraries dependencies proved not to be good idea since the
outermost Makefile does not see internal dependencies. Order should
be stablished by .PHONY commands dependencies.