### PR TITLE
Bugfix + New Subroutines

### DIFF
--- a/lioamber/Makefile.depends
+++ b/lioamber/Makefile.depends
@@ -72,6 +72,8 @@ OBJECTS += fterm_biaspot.o
 OBJECTS += elec.o
 OBJECTS += properties.o
 OBJECTS += write_output.o
+OBJECTS += lio_keywords.o
+OBJECTS += errlog.o
 
 
 ################################################################################
@@ -206,7 +208,14 @@ $(tmplist:%.o=$(OBJPATH)/%.o) : $(OBJPATH)/maskrmm.mod
 ################################################################################
 OBJECTS += liosubs.o
 SRCDIRS += liosubs
+vpath %.f90 liosubs
 include liosubs/liosubs.mk
+
+tmplist :=
+tmplist += SCF.o
+tmplist += lio_keywords.o
+$(tmplist:%.o=$(OBJPATH)/%.o) : $(OBJPATH)/liosubs.mod
+
 
 OBJECTS += general_module.o
 SRCDIRS += general_module

--- a/lioamber/Makefile.depends
+++ b/lioamber/Makefile.depends
@@ -72,7 +72,7 @@ OBJECTS += fterm_biaspot.o
 OBJECTS += elec.o
 OBJECTS += properties.o
 OBJECTS += write_output.o
-OBJECTS += lio_keywords.o
+OBJECTS += liokeys.o
 OBJECTS += errlog.o
 
 
@@ -213,7 +213,7 @@ include liosubs/liosubs.mk
 
 tmplist :=
 tmplist += SCF.o
-tmplist += lio_keywords.o
+tmplist += liokeys.o
 $(tmplist:%.o=$(OBJPATH)/%.o) : $(OBJPATH)/liosubs.mod
 
 

--- a/lioamber/cublasmath/cublasmath.mk
+++ b/lioamber/cublasmath/cublasmath.mk
@@ -19,6 +19,6 @@ INCLUDES += cupredictor.f cupredictor_h.f
 INCLUDES += magnus_cublas.f magnus_cublas_h.f
 INCLUDES += cu_fock_commuts.f
 
-$(obj_path)/cublasmath.o : $(INCLUDES) cublasmath.mk
+$(OBJPATH)/cublasmath.o : $(INCLUDES) cublasmath.mk
 
 ######################################################################

--- a/lioamber/errlog.f90
+++ b/lioamber/errlog.f90
@@ -1,0 +1,174 @@
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+module errlog
+
+   implicit none
+   integer                        :: errlog_count = 0
+   integer,           allocatable :: errlog_statids(:)
+   integer,           allocatable :: errlog_infoids(:)
+   character(len=80), allocatable :: errlog_sources(:)
+
+contains
+!------------------------------------------------------------------------------!
+! GENERAL DESCRIPTION
+!
+!     This module was designed to keep track of errors and to help identify
+!  their cause and exact location in the code. To do so, the following arrays
+!  are used:
+!
+!     errlog_statids: List of the status that describe the cause of all the
+!                     errors that occurred.
+!
+!     errlog_infoids: List of numbers that help identify the context and/or
+!                     location of the error.
+!
+!     errlog_sources  => List of the subroutines where the errors ocurred.
+!
+!
+!     Two subroutines are provided to control this module, and there are two
+!  ways of using it. If you have optional status arguments in your procedures,
+!  you can call errlog_Checkin with those optional arguments and whenever a
+!  problem araises, the first subroutine that was not provided such an
+!  argument will unload the whole error chain:
+!
+!
+!     subroutine example_sub( argA1, ..., argAN, extern_stat )
+!        (...)
+!        use errlog, only: errlog_Checkin
+!        (...)
+!        integer, intent(out), optional :: intern_stat
+!        (...)
+!        call internal_sub( argB1, ..., argBN, intern_stat )
+!   =>   call errlog_Checkin("example_sub", intern_stat, [IDNUM], extern_stat)
+!   =>   if ( intern_stat /= 0 ) return
+!        (...)
+!     end subroutine
+!
+!
+!     The second posibility, if you don't have optional status argument in
+!  one of your subroutines, is to call errlog_Checkin with a dummy variable
+!  in the position of extern_stat
+!
+!     Notice how errlog_Checkin has the same argument structure as the more
+!  simple catch_error (see module liosubs). This allows programers to easily
+!  switch from the simple one to this one by using the following alias:
+!
+!     use liosubs, only: catch_error                     ! (remove this)
+!     use errlog,  only: errlog_Checkin => catch_error   ! (add this)
+!
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine errlog_Checkin( caller_name, statid, infoid, passid )
+
+   implicit none
+   character(len=*), intent(in)            :: caller_name
+   integer,          intent(in)            :: statid
+   integer,          intent(in)            :: infoid
+   integer,          intent(out), optional :: passid
+
+   integer                        :: nn, pi, pf
+   integer,           allocatable :: tmplog_statids(:)
+   integer,           allocatable :: tmplog_infoids(:)
+   character(len=80), allocatable :: tmplog_sources(:)
+
+
+   if ( present(passid) ) passid=0
+   if ( statid == 0 ) return
+
+
+   if ( errlog_count > 0 ) then
+      allocate( tmplog_statids(errlog_count) )
+      allocate( tmplog_infoids(errlog_count) )
+      allocate( tmplog_sources(errlog_count) )
+
+      tmplog_statids = errlog_statids
+      tmplog_infoids = errlog_infoids
+      tmplog_sources = errlog_sources
+
+      deallocate( errlog_statids )
+      deallocate( errlog_infoids )
+      deallocate( errlog_sources )
+   end if
+
+
+   errlog_count = errlog_count + 1
+   allocate( errlog_statids(errlog_count) )
+   allocate( errlog_infoids(errlog_count) )
+   allocate( errlog_sources(errlog_count) )
+
+
+   pi = 1
+   pf = min( 80, len(caller_name) )
+   errlog_sources(1) = caller_name( pi : pf )
+   errlog_infoids(1) = infoid
+   errlog_statids(1) = statid
+   do nn = 2, errlog_count
+      errlog_sources(nn) = tmplog_sources(nn-1)
+      errlog_infoids(nn) = tmplog_infoids(nn-1)
+      errlog_statids(nn) = tmplog_statids(nn-1)
+   end do
+
+
+   if ( present(passid) ) then
+      passid = infoid
+
+   else
+      print "(A)", ""
+      print "(A)", "CRITICAL ERROR DETECTED!"
+      call errlog_Printlog()
+      print "(A)", "Aborting run..."
+      print "(A)", ""
+      stop
+
+   end if
+end subroutine errlog_Checkin
+
+
+
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine errlog_Checkout( last_errid )
+   integer, intent(out), optional :: last_errid
+   integer                        :: nn
+
+
+   if ( present(last_errid) ) last_errid=0
+   if ( errlog_count == 0 ) return
+
+
+   if ( present(last_errid) ) then
+      last_errid = errlog_infoids(1)
+
+   else
+      print "(A)", ""
+      print "(A)", "CRITICAL ERROR DETECTED!"
+      call errlog_Printlog()
+      print "(A)", "Aborting run..."
+      print "(A)", ""
+      stop
+
+   end if
+end subroutine errlog_Checkout
+
+
+
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine errlog_Printlog()
+   integer :: nn
+   print "(A)", "Printing log from last to first ..."
+   print "(A)", ""
+   do nn = 1, errlog_count
+      print "(A,I8)", "ERROR NUMBER: ", errlog_count-nn
+      print "(2A)",   "   * Inside Procedure:  ", adjustl( errlog_sources(nn) )
+      print "(A,I8)", "   * Location ID:       ", errlog_infoids(nn)
+      print "(A,I8)", "   * Error Status:      ", errlog_statids(nn)
+   end do
+   print "(A)", ""
+   print "(A)", "If you don't know and can't find out what caused any of this"
+   print "(A)", "these errors, please report it back to us through our github"
+   print "(A)", "website: https://github.com/MALBECC/lio"
+   print "(A)", ""
+end subroutine errlog_Printlog
+
+
+
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+end module
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!

--- a/lioamber/general_module/general_module.mk
+++ b/lioamber/general_module/general_module.mk
@@ -6,5 +6,5 @@ INCLUDES += atmorb.f atmorb_h.f
 INCLUDES += vector_selection.f
 INCLUDES += sdcmp_cholesky.f sdiag_canonical.f
 
-$(obj_path)/general_module.o : $(INCLUDES) general_module.mk
+$(OBJPATH)/general_module.o : $(INCLUDES) general_module.mk
 ######################################################################

--- a/lioamber/linear_algebra/linear_algebra.mk
+++ b/lioamber/linear_algebra/linear_algebra.mk
@@ -7,12 +7,12 @@ internal_files += matrix_diagon_d.f90
 internal_files += matrix_diagon_dsyevd.f90  matrix_diagon_dsyevr.f90
 internal_files += matmult_interface.f90
 internal_files += matmult_procedures.f90 matmult_body.f90
-$(obj_path)/linear_algebra.o : $(internal_files)
+$(OBJPATH)/linear_algebra.o : $(internal_files)
 
 ######################################################################
 # EXTERNAL DEPENDENCIES
 ######################################################################
 object_users := SCF.o
-$(object_users:%.o=$(obj_path)/%.o) : $(obj_path)/linear_algebra.mod
+$(object_users:%.o=$(OBJPATH)/%.o) : $(OBJPATH)/linear_algebra.mod
 
 ######################################################################

--- a/lioamber/lio_keywords.f90
+++ b/lioamber/lio_keywords.f90
@@ -1,0 +1,265 @@
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+module lio_keywords
+!
+!    This module contains a set of keywords/options that the user can provide
+! in order to customize the calculations. A description of each with posible
+! values should be included within each definition. Notice how the module and
+! this file are called "lio_keywords", whereas the actual namelist is called
+! liokeys,
+!
+!    Some procedures are provided as well: checknml_liokeys allows to do a
+! consistency check for all related variables, whereas the readnml_liokeys
+! and writenml_liokeys allows the whole list to be read from or writen to a
+! given file or unit (two versions exist of each):
+!
+!    checknml_liokeys( return_stat )
+!    readnml_liokeys( file_unit, return_stat )
+!    readnml_liokeys( file_name, return_stat )
+!    writenml_liokeys( file_unit, return_stat )
+!    writenml_liokeys( file_name, return_stat )
+!
+!    The parameters are self explanatory: file_unit is the unit of an already
+! opened file, file_name is the name of a non-opened file, you can chose which
+! one to provide. The parameter return_stat is optional and provides a way to
+! handle any error (if not provided, errors will halt the program).
+!
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+   implicit none
+
+   integer :: runtype = 0  ! for SCF 
+!                     = 1  ! for TD
+!                     = 2  ! for Ehrenfest returning forces = 0
+!                     = 3  ! for Ehrenfest returning correct forces
+!
+!
+!  External Electrical Field
+!------------------------------------------------------------------------------!
+   logical :: extEfld_is_on     = .false.
+   logical :: extEfld_is_light  = .false.
+   logical :: extEfld_is_finite = .false.
+
+   real*8  :: extEfld_wavelength = 0.0d0 ! in nm
+   real*8  :: extEfld_timeamp    = 0.0d0 ! in ps
+   real*8  :: extEfld_timepos    = 0.0d0 ! in ps
+
+   real*8  :: extEfld_ampx = 0.0d0 ! in au
+   real*8  :: extEfld_ampy = 0.0d0 ! in au
+   real*8  :: extEfld_ampz = 0.0d0 ! in au
+!
+!
+!  Namelist definition and interfaces
+!------------------------------------------------------------------------------!
+   namelist /liokeys/ &
+   &  runtype                                                                   &
+   &, extEfld_is_on, extEfld_is_light, extEfld_is_finite                        &
+   &, extEfld_wavelength, extEfld_timeamp, extEfld_timepos                      &
+   &, extEfld_ampx, extEfld_ampy, extEfld_ampz
+
+   interface readnml_liokeys
+      module procedure readnml_liokeys_fn
+      module procedure readnml_liokeys_fu
+   end interface readnml_liokeys
+
+   interface writenml_liokeys
+      module procedure writenml_liokeys_fn
+      module procedure writenml_liokeys_fu
+   end interface writenml_liokeys
+
+contains
+!
+!
+!
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine checknml_liokeys( return_stat )
+
+   use liosubs, only: catch_error
+   implicit none
+   integer, intent(out), optional :: return_stat
+
+   integer                        :: mystat
+   character(len=*), parameter    :: myname="checknml_liokeys"
+
+   mystat = 0
+!  PERFORM CHECKS
+   call catch_error( myname, mystat, mystat, return_stat )
+
+   if ( present(return_stat) ) return_stat = 0
+end subroutine checknml_liokeys
+!
+!
+!
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine readnml_liokeys_fu( file_unit, return_stat )
+
+   use liosubs, only: catch_error, safeio_rewind
+   implicit none
+   integer, intent(in)            :: file_unit
+   integer, intent(out), optional :: return_stat
+
+   integer                        :: mystat
+   character(len=*), parameter    :: myname="readnml_liokeys_fu"
+!
+!
+!  Rewind to make sure the namelist has not been already passed
+!------------------------------------------------------------------------------!
+   mystat = 0
+   call safeio_rewind( file_unit, mystat )
+   call catch_error( myname, mystat, 1, return_stat )
+   if ( mystat /= 0 ) return
+!
+!
+!  Read the namelist (if wasn't found, return error)
+!------------------------------------------------------------------------------!
+   mystat = 0
+   read( unit = file_unit, nml = liokeys, iostat = mystat )
+   if ( (mystat == 84) .or. (mystat == 85) ) then
+!     (case: namelist not found)
+      call catch_error( myname, mystat, 2, return_stat )
+      return
+   else
+!     (case: other errors)
+      call catch_error( myname, mystat, 3, return_stat )
+      if ( mystat /= 0 ) return
+   end if
+
+
+   if ( present(return_stat) ) return_stat = 0
+end subroutine readnml_liokeys_fu
+!
+!
+!
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine readnml_liokeys_fn( file_name, return_stat )
+
+   use liosubs, only: catch_error, safeio_open
+   implicit none
+   character(len=*), intent(in)   :: file_name
+   integer, intent(out), optional :: return_stat
+
+   integer                        :: file_unit
+   integer                        :: mystat
+   character(len=*), parameter    :: myname="readnml_liokeys_fn"
+!
+!
+!  Open the file in an available unit
+!------------------------------------------------------------------------------!
+   mystat = 0
+   call safeio_open( file_unit, file_name, 1, mystat )
+   if ( mystat == 5 ) then
+!     (case: file not found)
+      call catch_error( myname, mystat, 1, return_stat )
+      return
+   else
+!     (case: other errors)
+      call catch_error( myname, mystat, 2, return_stat )
+      if ( mystat /= 0 ) return
+   end if
+!
+!
+!  Read the namelist
+!------------------------------------------------------------------------------!
+   mystat = 0
+   call readnml_liokeys_fu( file_unit, mystat )
+   if (mystat == 2) then
+!     (case: namelist not found)
+      call catch_error( myname, mystat, 3, return_stat )
+      return
+   else
+!     (case: other errors)
+      call catch_error( myname, mystat, 4, return_stat )
+      if ( mystat /= 0 ) return
+   end if
+!
+!
+!  Close the open unit
+!------------------------------------------------------------------------------!
+   mystat = 0
+   close( unit = file_unit, iostat = mystat )
+   call catch_error( myname, mystat, 5, return_stat )
+   if ( mystat /= 0 ) return
+
+
+   if ( present(return_stat) ) return_stat = 0
+end subroutine readnml_liokeys_fn
+!
+!
+!
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine writenml_liokeys_fu( file_unit, return_stat )
+
+   use liosubs, only: catch_error
+   implicit none
+   integer, intent(in)            :: file_unit
+   integer, intent(out), optional :: return_stat
+
+   logical                        :: unit_opened
+   integer                        :: mystat
+   character(len=*), parameter    :: myname="writenml_liokeys_fu"
+!
+!
+!  Sanity Check: confirm that unit is opened
+!------------------------------------------------------------------------------!
+   mystat = 0
+   inquire( unit = file_unit, opened = unit_opened, iostat = mystat )
+   if (.not.unit_opened) then
+!     (case: unit was not opened)
+      call catch_error( myname, 1, 1, return_stat )
+      return
+   else
+!     (case: other errors)
+      call catch_error( myname, mystat, 2, return_stat )
+      if ( mystat /= 0 ) return
+   end if
+!
+!
+!  Write the namelist
+!------------------------------------------------------------------------------!
+   mystat = 0
+   write( unit = file_unit, nml = liokeys, iostat = mystat )
+   call catch_error( myname, mystat, 3, return_stat )
+   if ( mystat /= 0 ) return
+
+
+   if ( present(return_stat) ) return_stat = 0
+end subroutine writenml_liokeys_fu
+!
+!
+!
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine writenml_liokeys_fn( file_name, return_stat )
+
+   use liosubs, only: catch_error, safeio_open
+   implicit none
+   character(len=*), intent(in)   :: file_name
+   integer, intent(out), optional :: return_stat
+
+   integer                        :: file_unit
+   integer                        :: mystat
+   character(len=*), parameter    :: myname="writenml_liokeys_fu"
+!
+!
+!  Open, write, close, pretty clear which is which
+!------------------------------------------------------------------------------!
+   mystat = 0
+   call safeio_open( file_unit, file_name, 3, mystat )
+   call catch_error( myname, mystat, 1, return_stat )
+   if ( mystat /= 0 ) return
+
+   mystat = 0
+   call writenml_liokeys_fu( file_unit, mystat )
+   call catch_error( myname, mystat, 2, return_stat )
+   if ( mystat /= 0 ) return
+
+   mystat = 0
+   close( unit = file_unit, iostat = mystat )
+   call catch_error( myname, mystat, 3, return_stat )
+   if ( mystat /= 0 ) return
+
+   if ( present(return_stat) ) return_stat = 0
+end subroutine writenml_liokeys_fn
+!
+!
+!
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+end module
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!

--- a/lioamber/liokeys.f90
+++ b/lioamber/liokeys.f90
@@ -1,5 +1,5 @@
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
-module lio_keywords
+module liokeys
 !
 !    This module contains a set of keywords/options that the user can provide
 ! in order to customize the calculations. A description of each with posible

--- a/lioamber/liomods/liomods.mk
+++ b/lioamber/liomods/liomods.mk
@@ -1,5 +1,5 @@
 ######################################################################
 # INTERNAL DEPENDENCIES
 INCLUDES := param.f
-$(obj_path)/garcha_mod.o : $(INCLUDES) liomods.mk
+$(OBJPATH)/garcha_mod.o : $(INCLUDES) liomods.mk
 ######################################################################

--- a/lioamber/liosubs/catch_error.f90
+++ b/lioamber/liosubs/catch_error.f90
@@ -1,0 +1,88 @@
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine catch_error( caller_name, statid_chck, statid_pass, statid_comm )
+!------------------------------------------------------------------------------!
+!
+!     The following subroutine provides a simple, direct and automatic way
+!  to  check and deal with the status variable coming out of a procedure or
+!  set due to an error in part of a process/calculation.
+!
+!     It will check the statid_chck and will just return if it is equal to
+!  zero (no error). If it is different than zero, it will check if argument
+!  statid_comm is present so as to copy there information about the problem
+!  (statid_pass) and let another part of the program handle it. Please do
+!  notice that when returning to the calling procedure, you will still have
+!  to handle the problem there (check the example below for the simplest way
+!  to do this).
+!
+!     Finally, if a problem is detected and no statid_comm is provided, it
+!  will abort the program with an error message with information about the
+!  last place that couldn't deal with the error.
+!
+!------------------------------------------------------------------------------!
+!  ARGUMENTS DESCRIPTION:
+!
+!  caller_name: Should contain the name of the subroutine calling this check
+!               so as to help identify where the error is ocurring.
+!
+!  statid_chck: The status variable out of a procedure recently called or
+!               explicitly set during some calculations. This is the one
+!               to be checked against 0 to detect any problem.
+!               
+!  statid_pass: A numerical value that identifies the location inside the
+!               calling subroutine where the error is ocurring. This is the
+!               "status" that will be propagated upstream to statid_comm, so
+!               that the problem can be dealt with elsewhere (so it should
+!               serve to identify what the problem is about).
+!
+!  statid_comm: If this is present, the content of statid_pass will be then
+!               copied here so that another part of the program may deal
+!               with this issue. If not, then an error message with some
+!               information will be printed and the program will stop.
+!
+!------------------------------------------------------------------------------!
+!  USAGE EXAMPLE:
+!
+!    subroutine example( arg_A1, ... , arg_AN, extern_stat )
+!==>    use liosubs, only: catch_error, [...]
+!       implicit none
+!       [...]
+!       integer, intent(out), optional :: extern_stat
+!       integer                        :: intern_stat
+!       [...]
+!       call subtest( arg_B1, ... , arg_BN, intern_stat )
+!==>    catch_error( "example", intern_stat, 11, extern_stat )
+!==>    if ( intern_stat /= 0 ) return
+!       [...]
+!    end subroutine
+!
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+   implicit none
+   character(len=*), intent(in)            :: caller_name
+   integer,          intent(in)            :: statid_chck
+   integer,          intent(in)            :: statid_pass
+   integer,          intent(out), optional :: statid_comm
+
+   if ( statid_chck == 0) return !  ELSE...
+
+   if ( present(statid_comm) ) then
+      statid_comm = statid_pass
+
+   else
+      print "(A)",    ""
+      print "(A)",    "CRITICAL ERROR OCURRED"
+      print "(2A)",   " * Inside Procedure:  ", adjustl(caller_name)
+      print "(A,I8)", " * Error place ID:    ", statid_pass
+      print "(A,I8)", " * Error cause ID:    ", statid_chck
+      print "(A)",    ""
+      print "(A)",    "If you can't find out what caused this error, please"
+      print "(A)",    "report it back to us through our github page:"
+      print "(A)",    ""
+      print "(A)",    "   https://github.com/MALBECC/lio"
+      print "(A)",    ""
+      print "(A)",    "Aborting run..."
+      stop
+
+   end if
+
+end subroutine catch_error
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!

--- a/lioamber/liosubs/find_free_unit.f90
+++ b/lioamber/liosubs/find_free_unit.f90
@@ -1,35 +1,59 @@
-!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
-  subroutine find_free_unit(search_start,search_stop,file_unit)
-!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
-  implicit none
-  integer,intent(in)  :: search_start
-  integer,intent(in)  :: search_stop
-  integer,intent(out) :: file_unit
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine find_free_unit( free_unit, last_unit, return_stat )
+!
+!     This subroutine automatizes the process of finding a free available
+!  unit to open a file into. It receives three arguments:
+!
+!  free_unit (inout):
+!     On input, it contains the first unit that the subroutine will try.
+!     On output, it contains the last unit that the subroutine has tried
+!     (if no error occurrs, that last unit is one that is free and available
+!     to use). This subroutine will never use a unit lower that 10 (in which
+!     case, it ignores this argument).
+!
+!  last_unit (in):
+!     The last unit the subroutine will try out.
+!
+!  resturn_stat (optional out):
+!     Contains information about any error that might have occurred during
+!     this procedure. If nothing went wrongh, it returns 0. If it is not
+!     present, any error will halt the program.
+!
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+   implicit none
+   integer, intent(inout)          :: free_unit
+   integer, intent(in)             :: last_unit
+   integer, intent(out),  optional :: return_stat
 
-  logical :: is_open
-  integer :: iost
+   integer                      :: mystat
+   character(len=20), parameter :: myname="find_free_unit"
 
-  iost=0
-  is_open=.true.
-  file_unit=max(9,search_start-1)
+   integer :: first_try
+   integer :: final_try
+   integer :: test_unit
+   logical :: unit_is_open
 
-  do while ((is_open).and.(file_unit.lt.search_stop))
-    file_unit=file_unit+1
-    inquire(unit=file_unit,opened=is_open,iostat=iost)
-    call catch_iostat(iost,file_unit,'find_free_unit',1)
-  enddo
 
-  if (is_open) then
-    print '(A)', ''
-    print '(A)', &
-    'Error in find_free_unit: Either no free unit available in'
-    print '(A)', &
-    'range, or range selected is invalid.'
-    print '(A,I6)', '  From unit: ',search_start
-    print '(A,I6)', '  To unit:   ',search_stop
-    print '(A)',    ''
-    stop
-  endif
+   first_try = max( free_unit, 10 )
+   final_try = last_unit
+   if ( first_try > final_try ) mystat = 1
+   call catch_error( myname, mystat, 1, return_stat )
+   if ( mystat /= 0 ) return
 
-  return;end subroutine
-!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+   do test_unit = first_try, final_try
+      unit_is_open = .true.
+      inquire( unit = test_unit, opened = unit_is_open, iostat = mystat )
+      if (.not.unit_is_open) exit
+   end do
+
+   if (unit_is_open) then
+      mystat = 1
+      test_unit = -test_unit
+   end if
+   call catch_error( myname, mystat, test_unit, return_stat )
+   if ( mystat /= 0 ) return
+
+   free_unit = test_unit
+   if ( present(return_stat) ) return_stat = 0
+end subroutine find_free_unit
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!

--- a/lioamber/liosubs/liosubs.f90
+++ b/lioamber/liosubs/liosubs.f90
@@ -1,23 +1,32 @@
-!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
 module liosubs
-!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+!------------------------------------------------------------------------------!
 !
-! This is a place for general use subroutines that don't belong
-! in more specific modules. Procedures here should not depend on
-! other lio modules but be as independent as possible instead.
+!  This is a place for general use subroutines that don't belong in more 
+!  specific modules. It can also be used to temporarily store subroutines
+!  that would later will packed in another module which is not ready yet.
 !
-!--------------------------------------------------------------------!
-  implicit none
-  contains
+!  Whatever the case, procedures here should not depend on other lio modules
+!  but be as independent as possible instead.
+!
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+! INTERFACES GO HERE (EXPLICIT)
+   implicit none
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+! PROCEDURES GO HERE (INCLUDED)
+contains
 
-#   include "set_masses.f90"
-#   include "nuclear_verlet.f90"
+#  include "catch_error.f90"
+#  include "set_masses.f90"
+#  include "nuclear_verlet.f90"
 
-! The following procedures should be exported to a io-specific mod
-#   include "catch_iostat.f90"
-#   include "find_free_unit.f90"
-#   include "write_geom.f90"
-#   include "write_energy.f90"
+!  Possible IO-specific mode? 
+#  include "catch_iostat.f90"
+#  include "find_free_unit.f90"
+#  include "safeio_open.f90"
+#  include "safeio_rewind.f90"
+#  include "write_geom.f90"
+#  include "write_energy.f90"
 
 end module
-!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!

--- a/lioamber/liosubs/liosubs.mk
+++ b/lioamber/liosubs/liosubs.mk
@@ -1,20 +1,20 @@
-######################################################################
+###############################################################################
 # INTERNAL DEPENDENCIES
-######################################################################
+###############################################################################
 internal_files := liosubs.mk
 internal_files += liosubs.f90
-internal_files += find_free_unit.f90
+
+internal_files += catch_error.f90
 internal_files += catch_iostat.f90
-internal_files += set_masses.f90
-internal_files += nuclear_verlet.f90
+internal_files += find_free_unit.f90
+internal_files += safeio_open.f90
+internal_files += safeio_rewind.f90
 internal_files += write_energy.f90
 internal_files += write_geom.f90
-$(obj_path)/liosubs.o : $(internal_files)
 
-######################################################################
-# EXTERNAL DEPENDENCIES
-######################################################################
-external_users := SCF.o
-$(external_users:%.o=$(obj_path)/%.o) : $(obj_path)/liosubs.mod
+internal_files += set_masses.f90
+internal_files += nuclear_verlet.f90
 
-######################################################################
+$(OBJPATH)/liosubs.o : $(internal_files)
+
+###############################################################################

--- a/lioamber/liosubs/safeio_open.f90
+++ b/lioamber/liosubs/safeio_open.f90
@@ -1,0 +1,124 @@
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine safeio_open( file_unit, file_name, open_mode, return_stat )
+!
+!  open_mode = ... 
+!  >
+!  > = +-1   Opens existing file to read. 
+!  >
+!  > = +-2   Opens/creates file to write (overwritting existing).
+!  >
+!  > = +-3   Opens/creates file to write (appending existing).
+!  >
+!  > (positive numbers for formatted, negative for binary)
+!
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+   implicit none
+   integer,          intent(inout)          :: file_unit
+   character(len=*), intent(in)             :: file_name
+   integer,          intent(in)             :: open_mode
+   integer,          intent(out),  optional :: return_stat
+
+   logical           :: file_exists
+   logical           :: file_opened
+
+   character(len=20) :: file_action
+   character(len=20) :: file_format
+   character(len=20) :: file_status
+
+   logical                      :: can_exist, can_create, can_append
+   integer                      :: mystat
+   character(len=20), parameter :: myname="safeio_open"
+
+
+
+!  (1) Apply setup according to option selected
+!------------------------------------------------------------------------------!
+   mystat = 0
+   select case (open_mode)
+      case (1,-1)
+         file_action = "read"
+         can_append  = .false.
+         can_exist   = .true.
+         can_create  = .false.
+
+      case (2,-2)
+         file_action = "write"
+         can_append  = .false.
+         can_exist   = .true.
+         can_create  = .true.
+
+      case (3,-3)
+         file_action = "write"
+         can_append  = .true.
+         can_exist   = .true.
+         can_create  = .true.
+
+      case default
+         mystat = open_mode
+
+   end select
+   call catch_error( myname, mystat, 1, return_stat )
+   if ( mystat /= 0 ) return
+
+   if ( open_mode > 0 ) then
+      file_format = "formatted"
+   else
+      file_format = "unformatted"
+   end if
+
+
+!  (2) Inquire if file exists and if its opened and adapt to it
+!------------------------------------------------------------------------------!
+   mystat = 0
+   inquire( file = file_name,   exist = file_exists, opened = file_opened, &
+          & iostat = mystat )
+   call catch_error( myname, mystat, 2, return_stat )
+   if ( mystat /= 0 ) return
+
+
+   if (file_opened) then
+      call catch_error( myname, 1, 3, return_stat )
+      return
+   end if
+
+
+   if (file_exists) then
+      if (can_append) then
+         file_status = "old"
+      else
+         file_status = "replace"
+      end if
+      if (.not.can_exist) then
+        call catch_error( myname, mystat, 4, return_stat )
+        return
+      end if
+
+   else
+      file_status = "new"
+      if (.not.can_create) then
+        call catch_error( myname, mystat, 5, return_stat )
+        return
+      end if
+
+   end if
+
+
+
+!  (3) Find a free unit and open the file there
+!------------------------------------------------------------------------------!
+   mystat = 0
+   call find_free_unit( file_unit, 1000, mystat )
+   call catch_error( myname, mystat, 6, return_stat )
+   if ( mystat /= 0 ) return
+
+
+   mystat = 0
+   open( unit = file_unit,   file = file_name,     iostat = mystat,          &
+       & form = file_format, status = file_status, action = file_action )
+   call catch_error( myname, mystat, 7, return_stat )
+   if ( mystat /= 0 ) return
+
+
+   if ( present(return_stat) ) return_stat = 0
+end subroutine safeio_open
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!

--- a/lioamber/liosubs/safeio_rewind.f90
+++ b/lioamber/liosubs/safeio_rewind.f90
@@ -1,0 +1,34 @@
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine safeio_rewind( file_unit, return_stat )
+!
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+   implicit none
+   integer, intent(in)            :: file_unit
+   integer, intent(out), optional :: return_stat
+
+   logical                        :: unit_opened
+   integer                        :: mystat
+   character(len=20), parameter   :: myname="safeio_rewind"
+
+
+!  Sanity Check
+   mystat = 0
+   inquire( unit = file_unit, opened = unit_opened, iostat = mystat )
+   call catch_error( myname, mystat, 1, return_stat )
+   if ( mystat /= 0 ) return
+
+   if (.not.unit_opened) mystat=1
+   call catch_error( myname, 1, 2, return_stat )
+   if ( mystat /= 0 ) return
+
+
+!  Actual Rewind
+   mystat = 0
+   rewind( unit = file_unit, iostat = mystat )
+   call catch_error( myname, mystat, 3, return_stat )
+   if ( mystat /= 0 ) return
+
+
+   if ( present(return_stat) ) return_stat = 0
+end subroutine safeio_rewind
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!

--- a/lioamber/maskrmm/maskrmm.mk
+++ b/lioamber/maskrmm/maskrmm.mk
@@ -7,6 +7,5 @@ INCLUDES += rmmput_fock_all.f90  rmmput_fock_h.f90
 INCLUDES += rmmget_fock_all.f90  rmmget_fock_h.f90
 INCLUDES += rmmcalc_fockmao.f90  rmmcalc_overlap.f90
 
-
-$(obj_path)/maskrmm.o : $(INCLUDES) maskrmm.mk
+$(OBJPATH)/maskrmm.o : $(INCLUDES) maskrmm.mk
 ######################################################################

--- a/lioamber/mathsubs/mathsubs.mk
+++ b/lioamber/mathsubs/mathsubs.mk
@@ -6,5 +6,5 @@ INCLUDES += commutator.f commutator_h.f
 INCLUDES += basechange.f basechange_h.f
 INCLUDES += basechange_gemm.f basechange_gemm_h.f
 
-$(obj_path)/mathsubs.o : $(INCLUDES) mathsubs.mk
+$(OBJPATH)/mathsubs.o : $(INCLUDES) mathsubs.mk
 ######################################################################


### PR DESCRIPTION
(1) Fixed a bug in the makefiles that was causing to not recompile modified files inside modules:

 *  cublasmath/cublasmath.mk
 *  general_module/general_module.mk
 *  linear_algebra/linear_algebra.mk
 *  liomods/liomods.mk
 *  maskrmm/maskrmm.mk
 *  mathsubs/mathsubs.mk

(2) Added a few subroutines for later use:

 *  Makefile.depends (to compile with new modules)
 *  errlog.f90
 *  lio_keywords.f90
 *  liosubs/catch_error.f90
 *  liosubs/find_free_unit.f90 (modified slightly)
 *  liosubs/liosubs.f90 (to include new subs)
 *  liosubs/liosubs.mk (to include new subs + previous fix)
 *  liosubs/safeio_open.f90
 *  liosubs/safeio_rewind.f90

DISCLAIMER: It is not ideal to do both in the same commit/pull request, but I found the bug after adding the new stuff and didn't want to pull a broken commit. The fix is small, and since I'm not actually using in the running code any of the added subroutines/modules, this should not be that bad.