### PR TITLE
Hotfix - Makefile in liosolo

### DIFF
--- a/liosolo/Makefile
+++ b/liosolo/Makefile
@@ -9,7 +9,11 @@ FLAGS = -fopenmp
 ifeq ($(intel),1)
   FC    = ifort
   FLAGS+= -fpp
-  LIBS += -module ../lioamber/obj -I../lioamber/obj 
+  LIBS += -module ../lioamber/obj -I../lioamber/obj
+else ifeq ($(intel),2)
+  FC    = ifort
+  FLAGS+= -fpp
+  LIBS += -module ../lioamber/obj -I../lioamber/obj
 else
   FC    = gfortran
   FLAGS+= -cpp


### PR DESCRIPTION
Please notice that now to use mkl you need to set intel=2, as intel=1 only enables the compilers. See issue #75.