### PR TITLE
Makefix

### DIFF
--- a/g2g/Makefile
+++ b/g2g/Makefile
@@ -1,8 +1,8 @@
 .DEFAULT_GOAL := all
 
 # -*- mode: make -*-
-include Makefile.common
 include Makefile.translate
+include Makefile.common
 
 ## Define sources and objects
 SRCS:=$(wildcard *.cpp)
@@ -71,7 +71,7 @@ endif
 
 ## Define libraries
 LIBRARIES := $(CUDA_LDFLAGS) $(CUDA_LIBS) -lrt
-ifneq ($(intel),1)
+ifeq ($(intel),0)
   LIBRARIES += -L$(PACK_LIB_DIR) -lcblas
 endif
 

--- a/g2g/Makefile.common
+++ b/g2g/Makefile.common
@@ -3,7 +3,7 @@
 CXXFLAGS+= -fopenmp -fPIC -Wall -Wextra -Wshadow -I. -I$(CUDAHOME)/include
 OPTIMIZECPU :=
 
-ifneq ($(intel),1)
+ifeq ($(intel),0)
   CXX          := g++
   OPTIMIZECPU  := -O3
   CXXFLAGS     := $(CXXFLAGS) -Wno-unused-variable -Wno-unused-parameter -Wno-sign-compare


### PR DESCRIPTION
Bug in makefile when intel = 2 (apparently) fixed. Problem: it was not recognizing intel=2 when compiling g2g.