### PR TITLE
Atompot PR-0

### DIFF
--- a/lioamber/Makefile.depends
+++ b/lioamber/Makefile.depends
@@ -112,6 +112,16 @@ tmplist :=
 tmplist += TD.o SCF.o input_read.o
 $(tmplist:%.o=$(OBJPATH)/%.o) : $(OBJPATH)/transport.mod
 
+
+################################################################################
+OBJECTS += atompot_data.o
+OBJECTS += atompot_subs.o
+$(OBJPATH)/atompot_subs.o: $(OBJPATH)/atompot_data.mod
+
+tmplist :=
+tmplist += 
+$(tmplist:%.o=$(OBJPATH)/%.o) : $(OBJPATH)/atompot_subs.mod
+
 ###############################################################################
 TD.o : properties.o
 

--- a/lioamber/SCFop.f
+++ b/lioamber/SCFop.f
@@ -15,7 +15,7 @@ c---------------------------------------------------
      >     FOCK_ECP_read,FOCK_ECP_write,IzECP
       use faint_cpu77, only: int1, int2, intsol, int3mem, int3lu
 
-      REAL*8:: E2,En,E,Es,Ex,Exc
+      REAL*8:: E2,En,E,Es,Ex,Exc,E1s,Ens
       dimension work(1000)
       real*8, dimension (:,:), ALLOCATABLE ::xnano,znano
       real*8, dimension (:), ALLOCATABLE :: rmm5,rmm15,rmm13,

--- a/lioamber/atompot_data.f90
+++ b/lioamber/atompot_data.f90
@@ -1,0 +1,20 @@
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+module atompot_data
+!------------------------------------------------------------------------------!
+!
+! DESCRIPTION PENDING
+!
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+  implicit none
+  logical             :: atompot_apply = .false.
+  logical             :: atompot_ready = .false.
+  integer             :: atompot_msize = 0
+  real*8, allocatable :: qweight_of_orb(:)
+
+  logical             :: atompot_timegrow = .false.
+  logical             :: atompot_timefall = .false.
+  real*8              :: atompot_timepos0 = 0.0d0
+  real*8              :: atompot_timeamp1 = 0.0d0
+
+end module atompot_data
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!

--- a/lioamber/atompot_subs.f90
+++ b/lioamber/atompot_subs.f90
@@ -1,0 +1,158 @@
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+module atompot_subs
+!------------------------------------------------------------------------------!
+!
+!    This module controls the aplication of charge biases that are directly
+! applied through the fock matrix.
+!
+! REFERENCE: Physical Review B 74, 155112 ͑2006͒
+!
+! atompot_check_ready: internal subroutine to check if setup was performed.
+! atompot_check_msize: internal subroutine to check if size is consistent.
+! atompot_setup_basics: setups the size and the application of the potential.
+! atompot_setup_shaper: setups the parameters of the shaper.
+! atompot_reads_charges: reads the charges to apply from given file.
+! atompot_fockadd: adds the potential to a fiven fock matrix, provided the
+!                  shape 
+!
+!------------------------------------------------------------------------------!
+   implicit none
+   contains
+!
+!
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine atompot_check_ready()
+   use atompot_data, only: atompot_apply, atompot_ready
+   implicit none
+   if (.not.atompot_ready) then
+      print*,'FATAL ERROR:'
+      print*,'  A module subroutine is being used without proper setup.'
+      stop
+   endif
+end subroutine atompot_check_ready
+!
+!
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine atompot_check_msize( msize_inp )
+   use atompot_data, only: atompot_apply, atompot_msize
+   implicit none
+   integer, intent(in) :: msize_inp
+   if (msize_inp.ne.atompot_msize) then
+      print*,'FATAL ERROR:'
+      print*,'  Wrong setup of atompot, inconsistent sizes.'
+      print*,'  * msize_inp (input):   ', msize_inp
+      print*,'  * atompot_msize (mod): ', atompot_msize
+      stop
+   endif
+end subroutine atompot_check_msize
+!
+!
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine atompot_setup_basics( activate, msize )
+
+   use atompot_data, &
+   &   only: atompot_apply, atompot_ready, atompot_msize, qweight_of_orb
+
+   implicit none
+   logical, intent(in) :: activate
+   integer, intent(in) :: msize
+   integer             :: ii, jj
+
+   atompot_apply = activate
+   atompot_msize = msize
+   atompot_ready = .true.
+   if ( allocated(qweight_of_orb) ) deallocate(qweight_of_orb)
+   allocate( qweight_of_orb(msize) )
+   qweight_of_orb(:) = 0.0d0
+
+end subroutine atompot_setup_basics
+!
+!
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine atompot_setup_shaper( timegrow, timefall, timepos0, timeamp1 )
+   
+   use atompot_data, only: atompot_timegrow, atompot_timefall &
+                        &, atompot_timepos0, atompot_timeamp1
+
+   implicit none
+   logical, intent(in) :: timegrow
+   logical, intent(in) :: timefall
+   real*8 , intent(in) :: timepos0
+   real*8 , intent(in) :: timeamp1
+
+   atompot_timegrow = timegrow
+   atompot_timefall = timefall
+   atompot_timepos0 = timepos0
+   atompot_timeamp1 = timeamp1
+
+end subroutine atompot_setup_shaper
+!
+!
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine atompot_reads_charges( nsize, msize, atom_of_orb, source_fname )
+
+   use liosubs       , only: read_list, atmvec_to_orbvec
+   use atompot_data  , only: atompot_apply, qweight_of_orb
+
+   implicit none
+   integer          , intent(in) :: nsize
+   integer          , intent(in) :: msize
+   integer          , intent(in) :: atom_of_orb(msize)
+   character(len=80), intent(in) :: source_fname
+
+   real*8, allocatable :: qweight_of_atom(:)
+
+   if (.not.atompot_apply) return
+   call atompot_check_ready()
+   call atompot_check_msize( msize )
+
+   allocate( qweight_of_atom(nsize) )
+   call read_list( source_fname, qweight_of_atom )
+   call atmvec_to_orbvec( qweight_of_atom, atom_of_orb, qweight_of_orb )
+   deallocate( qweight_of_atom )
+   
+end subroutine atompot_reads_charges
+!
+!
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine atompot_fockadd( msize, timepos, sqsmat, fockao )
+
+   use liosubs     , only: gaussian_shaper
+   use atompot_data, only: atompot_apply,    qweight_of_orb   &
+                        &, atompot_timegrow, atompot_timefall &
+                        &, atompot_timepos0, atompot_timeamp1
+
+   implicit none
+   integer, intent(in)    :: msize
+   real*8 , intent(in)    :: timepos
+   real*8 , intent(in)    :: sqsmat( msize, msize )
+   real*8 , intent(inout) :: fockao( msize, msize )
+
+   real*8  :: newterm
+   real*8  :: shape_factor
+   integer :: ii, jj, kk
+
+   if (.not.atompot_apply) return
+   call atompot_check_ready()
+   call atompot_check_msize( msize )
+
+   shape_factor = 1.0d0
+   call gaussian_shaper( atompot_timegrow, atompot_timefall, timepos &
+                      &, atompot_timepos0, atompot_timeamp1, shape_factor )
+
+   do ii = 1, msize
+   do jj = 1, msize
+      do kk = 1, msize
+         newterm       = shape_factor * qweight_of_orb(kk)
+         newterm       = newterm * sqsmat(ii,kk) * sqsmat(kk,jj)
+         fockao(ii,jj) = fockao(ii,jj) + newterm
+      enddo
+   enddo
+   enddo
+
+end subroutine atompot_fockadd
+!
+!
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+end module atompot_subs
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!

--- a/lioamber/liosubs/atmvec_to_orbvec.header.f90
+++ b/lioamber/liosubs/atmvec_to_orbvec.header.f90
@@ -1,0 +1,41 @@
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine atmvec_to_orbvec_n( atmvec, atm_of_orb, orbvec )
+   implicit none
+   integer   , intent(in)  :: atmvec(:)
+   integer   , intent(in)  :: atm_of_orb(:)
+   integer   , intent(out) :: orbvec(:)
+#  include "atmvec_to_orbvec.proced.f90"
+end subroutine atmvec_to_orbvec_n
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine atmvec_to_orbvec_r( atmvec, atm_of_orb, orbvec )
+   implicit none
+   real*4    , intent(in)  :: atmvec(:)
+   integer   , intent(in)  :: atm_of_orb(:)
+   real*4    , intent(out) :: orbvec(:)
+#  include "atmvec_to_orbvec.proced.f90"
+end subroutine atmvec_to_orbvec_r
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine atmvec_to_orbvec_d( atmvec, atm_of_orb, orbvec )
+   implicit none
+   real*8    , intent(in)  :: atmvec(:)
+   integer   , intent(in)  :: atm_of_orb(:)
+   real*8    , intent(out) :: orbvec(:)
+#  include "atmvec_to_orbvec.proced.f90"
+end subroutine atmvec_to_orbvec_d
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine atmvec_to_orbvec_c( atmvec, atm_of_orb, orbvec )
+   implicit none
+   complex*8 , intent(in)  :: atmvec(:)
+   integer   , intent(in)  :: atm_of_orb(:)
+   complex*8 , intent(out) :: orbvec(:)
+#  include "atmvec_to_orbvec.proced.f90"
+end subroutine atmvec_to_orbvec_c
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine atmvec_to_orbvec_z( atmvec, atm_of_orb, orbvec )
+   implicit none
+   complex*16, intent(in)  :: atmvec(:)
+   integer   , intent(in)  :: atm_of_orb(:)
+   complex*16, intent(out) :: orbvec(:)
+#  include "atmvec_to_orbvec.proced.f90"
+end subroutine atmvec_to_orbvec_z
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!

--- a/lioamber/liosubs/atmvec_to_orbvec.proced.f90
+++ b/lioamber/liosubs/atmvec_to_orbvec.proced.f90
@@ -1,0 +1,22 @@
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+!subroutine atmvec_to_orbvec_X( atmvec, atm_of_orb, orbvec )
+!   implicit none
+!   XXXXXXX,intent(in)  :: atmvec(:)
+!   integer,intent(in)  :: atm_of_orb(:)
+!   XXXXXXX,intent(out) :: orbvec(:)
+!------------------------------------------------------------------------------!
+   integer :: nn
+
+   nn = size(atm_of_orb)
+   call check_vecsize( nn, orbvec, "orbvec", "atmvec_to_orbvec" )
+
+   nn = max( size(atmvec), maxval(atm_of_orb) )
+   call check_vecsize( nn, atmvec, "atmvec", "atmvec_to_orbvec" )
+
+   do nn = 1, size(orbvec)
+      orbvec(nn) = atmvec( atm_of_orb(nn) )
+   enddo
+
+!------------------------------------------------------------------------------!
+!end subroutine atmvec_to_orbvec_X
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!

--- a/lioamber/liosubs/check_matsize.header.f90
+++ b/lioamber/liosubs/check_matsize.header.f90
@@ -1,0 +1,51 @@
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine check_matsize_n( nsize1, nsize2, matrix, matname, subname )
+   implicit none
+   integer         , intent(in) :: nsize1
+   integer         , intent(in) :: nsize2
+   integer         , intent(in) :: matrix(:,:)
+   character(len=*), intent(in) :: matname
+   character(len=*), intent(in) :: subname
+#  include "check_matsize.proced.f90"
+end subroutine check_matsize_n
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine check_matsize_r( nsize1, nsize2, matrix, matname, subname )
+   implicit none
+   integer         , intent(in) :: nsize1
+   integer         , intent(in) :: nsize2
+   real*4          , intent(in) :: matrix(:,:)
+   character(len=*), intent(in) :: matname
+   character(len=*), intent(in) :: subname
+#  include "check_matsize.proced.f90"
+end subroutine check_matsize_r
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine check_matsize_d( nsize1, nsize2, matrix, matname, subname )
+   implicit none
+   integer         , intent(in) :: nsize1
+   integer         , intent(in) :: nsize2
+   real*8          , intent(in) :: matrix(:,:)
+   character(len=*), intent(in) :: matname
+   character(len=*), intent(in) :: subname
+#  include "check_matsize.proced.f90"
+end subroutine check_matsize_d
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine check_matsize_c( nsize1, nsize2, matrix, matname, subname )
+   implicit none
+   integer         , intent(in) :: nsize1
+   integer         , intent(in) :: nsize2
+   complex*8       , intent(in) :: matrix(:,:)
+   character(len=*), intent(in) :: matname
+   character(len=*), intent(in) :: subname
+#  include "check_matsize.proced.f90"
+end subroutine check_matsize_c
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine check_matsize_z( nsize1, nsize2, matrix, matname, subname )
+   implicit none
+   integer         , intent(in) :: nsize1
+   integer         , intent(in) :: nsize2
+   complex*16      , intent(in) :: matrix(:,:)
+   character(len=*), intent(in) :: matname
+   character(len=*), intent(in) :: subname
+#  include "check_matsize.proced.f90"
+end subroutine check_matsize_z
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!

--- a/lioamber/liosubs/check_matsize.proced.f90
+++ b/lioamber/liosubs/check_matsize.proced.f90
@@ -1,0 +1,20 @@
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+!subroutine check_matsize_X( nsize1, nsize2, matrix, matname, subname )
+!   implicit none
+!   integer          , intent(in) :: nsize1
+!   integer          , intent(in) :: nsize2
+!   XXXXXXXXXXXXXXXXX, intent(in) :: matrix(:)
+!   character(len=80), intent(in) :: matname
+!   character(len=80), intent(in) :: subname
+!------------------------------------------------------------------------------!
+   if (( size(matrix,1) /= nsize1 ).or.( size(matrix,2) /= nsize2 )) then
+      print*,'FATAL ERROR: Size problem incompativility!'
+      print*,'  Inside Procedure: ', subname
+      print*,'  Matrix Name:      ', matname
+      print*,'  Expected sizes:   ', nsize1, nsize2
+      print*,'  Actual sizes:     ', size(matrix,1), size(matrix,2)
+      print*; stop
+   end if
+!------------------------------------------------------------------------------!
+!end subroutine check_matsize_X
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!

--- a/lioamber/liosubs/check_vecsize.header.f90
+++ b/lioamber/liosubs/check_vecsize.header.f90
@@ -1,0 +1,46 @@
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine check_vecsize_n( nsize, vector, vecname, subname )
+   implicit none
+   integer         , intent(in) :: nsize
+   integer         , intent(in) :: vector(:)
+   character(len=*), intent(in) :: vecname
+   character(len=*), intent(in) :: subname
+#  include "check_vecsize.proced.f90"
+end subroutine check_vecsize_n
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine check_vecsize_r( nsize, vector, vecname, subname )
+   implicit none
+   integer         , intent(in) :: nsize
+   real*4          , intent(in) :: vector(:)
+   character(len=*), intent(in) :: vecname
+   character(len=*), intent(in) :: subname
+#  include "check_vecsize.proced.f90"
+end subroutine check_vecsize_r
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine check_vecsize_d( nsize, vector, vecname, subname )
+   implicit none
+   integer         , intent(in) :: nsize
+   real*8          , intent(in) :: vector(:)
+   character(len=*), intent(in) :: vecname
+   character(len=*), intent(in) :: subname
+#  include "check_vecsize.proced.f90"
+end subroutine check_vecsize_d
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine check_vecsize_c( nsize, vector, vecname, subname )
+   implicit none
+   integer         , intent(in) :: nsize
+   complex*8       , intent(in) :: vector(:)
+   character(len=*), intent(in) :: vecname
+   character(len=*), intent(in) :: subname
+#  include "check_vecsize.proced.f90"
+end subroutine check_vecsize_c
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine check_vecsize_z( nsize, vector, vecname, subname )
+   implicit none
+   integer         , intent(in) :: nsize
+   complex*16      , intent(in) :: vector(:)
+   character(len=*), intent(in) :: vecname
+   character(len=*), intent(in) :: subname
+#  include "check_vecsize.proced.f90"
+end subroutine check_vecsize_z
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!

--- a/lioamber/liosubs/check_vecsize.proced.f90
+++ b/lioamber/liosubs/check_vecsize.proced.f90
@@ -1,0 +1,19 @@
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+!subroutine check_vecsize_n( nsize, vector, vecname, subname )
+!   implicit none
+!   integer         , intent(in) :: nsize
+!   XXXXXXXXXXXXXXXX, intent(in) :: vector(:)
+!   character(len=*), intent(in) :: vecname
+!   character(len=*), intent(in) :: subname
+!------------------------------------------------------------------------------!
+   if ( size(vector) /= nsize ) then
+      print*,'FATAL ERROR: Size problem incompativility!'
+      print*,'  Inside Procedure: ', subname
+      print*,'  Vector Name:      ', vecname
+      print*,'  Expected size:    ', nsize
+      print*,'  Actual size:      ', size(vector)
+      print*; stop
+   end if
+!------------------------------------------------------------------------------!
+!end subroutine check_vecsize_X
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!

--- a/lioamber/liosubs/gaussian_shaper.f90
+++ b/lioamber/liosubs/gaussian_shaper.f90
@@ -1,0 +1,24 @@
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine gaussian_shaper( do_grow, do_fall, xpos, center, sigma1, yval )
+   implicit none
+   logical, intent(in)    :: do_grow, do_fall
+   real*8 , intent(in)    :: xpos
+   real*8 , intent(in)    :: center
+   real*8 , intent(in)    :: sigma1
+   real*8 , intent(inout) :: yval
+
+   logical :: is_growing, is_falling
+   real*8  :: gauss_exp
+
+   is_growing = (do_grow) .and. ( xpos < center )
+   is_falling = (do_fall) .and. ( xpos > center )
+
+   if ( (is_growing) .or. (is_falling) ) then
+      gauss_exp = ( xpos - center ) / (sigma1)
+      gauss_exp = (-1.0d0) * (gauss_exp)**2
+      yval = yval * exp( gauss_exp )
+   endif
+
+end subroutine gaussian_shaper
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+

--- a/lioamber/liosubs/liosubs.f90
+++ b/lioamber/liosubs/liosubs.f90
@@ -11,11 +11,52 @@ module liosubs
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
 ! INTERFACES GO HERE (EXPLICIT)
    implicit none
+
+   interface check_vecsize
+      module procedure check_vecsize_n
+      module procedure check_vecsize_r
+      module procedure check_vecsize_d
+      module procedure check_vecsize_c
+      module procedure check_vecsize_z
+   end interface check_vecsize
+
+   interface check_matsize
+      module procedure check_matsize_n
+      module procedure check_matsize_r
+      module procedure check_matsize_d
+      module procedure check_matsize_c
+      module procedure check_matsize_z
+   end interface check_matsize
+
+   interface atmvec_to_orbvec
+      module procedure atmvec_to_orbvec_n
+      module procedure atmvec_to_orbvec_r
+      module procedure atmvec_to_orbvec_d
+      module procedure atmvec_to_orbvec_c
+      module procedure atmvec_to_orbvec_z
+   end interface atmvec_to_orbvec
+
+   interface read_list
+      module procedure read_list_n
+      module procedure read_list_r
+      module procedure read_list_d
+      module procedure read_list_c
+      module procedure read_list_z
+   end interface read_list
+
+!
+!
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
 ! PROCEDURES GO HERE (INCLUDED)
 contains
 
 #  include "catch_error.f90"
+#  include "check_vecsize.header.f90"
+#  include "check_matsize.header.f90"
+#  include "atmvec_to_orbvec.header.f90"
+#  include "read_list.header.f90"
+
+#  include "gaussian_shaper.f90"
 #  include "set_masses.f90"
 #  include "nuclear_verlet.f90"
 

--- a/lioamber/liosubs/liosubs.mk
+++ b/lioamber/liosubs/liosubs.mk
@@ -5,15 +5,21 @@ internal_files := liosubs.mk
 internal_files += liosubs.f90
 
 internal_files += catch_error.f90
+internal_files += check_vecsize.header.f90 check_vecsize.proced.f90
+internal_files += check_matsize.header.f90 check_matsize.proced.f90
+internal_files += atmvec_to_orbvec.header.f90 atmvec_to_orbvec.proced.f90
+internal_files += read_list.header.f90 read_list.proced.f90
+
+internal_files += gaussian_shaper.f90
+internal_files += set_masses.f90
+internal_files += nuclear_verlet.f90
+
 internal_files += catch_iostat.f90
 internal_files += find_free_unit.f90
 internal_files += safeio_open.f90
 internal_files += safeio_rewind.f90
 internal_files += write_energy.f90
 internal_files += write_geom.f90
-
-internal_files += set_masses.f90
-internal_files += nuclear_verlet.f90
 
 $(OBJPATH)/liosubs.o : $(internal_files)
 

--- a/lioamber/liosubs/read_list.header.f90
+++ b/lioamber/liosubs/read_list.header.f90
@@ -1,0 +1,36 @@
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine read_list_n( file_name, list )
+   implicit none
+   character(len=*), intent(in)  :: file_name
+   integer         , intent(out) :: list(:)
+#  include "read_list.proced.f90"
+end subroutine read_list_n
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine read_list_r( file_name, list )
+   implicit none
+   character(len=*), intent(in)  :: file_name
+   real*4          , intent(out) :: list(:)
+#  include "read_list.proced.f90"
+end subroutine read_list_r
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine read_list_d( file_name, list )
+   implicit none
+   character(len=*), intent(in)  :: file_name
+   real*8          , intent(out) :: list(:)
+#  include "read_list.proced.f90"
+end subroutine read_list_d
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine read_list_c( file_name, list )
+   implicit none
+   character(len=*), intent(in)  :: file_name
+   complex*8       , intent(out) :: list(:)
+#  include "read_list.proced.f90"
+end subroutine read_list_c
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine read_list_z( file_name, list )
+   implicit none
+   character(len=*), intent(in)  :: file_name
+   complex*16      , intent(out) :: list(:)
+#  include "read_list.proced.f90"
+end subroutine read_list_z
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!

--- a/lioamber/liosubs/read_list.proced.f90
+++ b/lioamber/liosubs/read_list.proced.f90
@@ -1,0 +1,33 @@
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+!subroutine read_list_X( file_name, list )
+!   implicit none
+!   character(len=*), intent(in)  :: file_name
+!   XXXXXXXXXXXXXXXX, intent(out) :: list(:)
+!------------------------------------------------------------------------------!
+   integer :: kk
+   integer :: mystat
+
+   open( unit=1001, file=file_name, iostat=mystat )
+   if ( mystat /= 0 ) then
+      print*,'CRITICAL ERROR: inside read_list'
+      print*,'  Problem when opening unit 1001 to read: ', file_name
+      print*,'  IOSTAT = ', mystat
+      print*; stop
+   endif
+
+
+   do kk = 1, size(list)
+
+      read( unit=1001, fmt=*, iostat=mystat ) list(kk)
+      if ( mystat /= 0 ) then
+         print*,'CRITICAL ERROR: inside read_list'
+         print*,'  Problem when reading unit 1001, file: ', file_name
+         print*,'  List item number ',kk
+         print*,'  IOSTAT = ', mystat
+         print*; stop
+      endif
+
+   enddo
+   
+!end subroutine read_list_X
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!


### PR DESCRIPTION
Reordering of some subroutines and procedures, getting ready for a cleaner (and working) implementation of the Atomic Charge Potentials.
* Little fix in SCFop, I'm not sure why it appeared just now. A little unrelated, so I added it in a different commit, but couldn't compile without this fix.
* New subroutines added to liosubs. Actually, some of them are "remakes" of ones in general_module, but are a bit updated and plus is a step in the way of unifying both modules.
* Modules atompot_subs and atompot_data to take care of the specified feature.

Most likely I will be the one merging, but just in case: please do a merge commit instead of a squash so as to keep the different commits.