### PR TITLE
Fixed bugs from the encapsulation of the fortran analitic integrals.

### DIFF
--- a/lioamber/SCF.f90
+++ b/lioamber/SCF.f90
@@ -21,7 +21,7 @@
       use ECP_mod, only : ecpmode, term1e, VAAA, VAAB, VBAC, &
        FOCK_ECP_read,FOCK_ECP_write,IzECP
       use transport, only : generate_rho0
-      use faint_cpu77, only: int1, int2, intsol, int3mem, int3lu
+      use faint_cpu77, only: int1, int2, intsol, int3mem, int3lu, intfld
 !      use general_module 
 !#ifdef  CUBLAS
 !      use cublasmath 

--- a/lioamber/SCFop.f
+++ b/lioamber/SCFop.f
@@ -15,7 +15,7 @@ c---------------------------------------------------
      >     FOCK_ECP_read,FOCK_ECP_write,IzECP
       use faint_cpu77, only: int1, int2, intsol, int3mem, int3lu
 
-      REAL*8:: E2,En,E,Es,Ex,Exc
+      REAL*8:: E2,En,E,Es,Ex,Exc,E1s,Ens
       dimension work(1000)
       real*8, dimension (:,:), ALLOCATABLE ::xnano,znano
       real*8, dimension (:), ALLOCATABLE :: rmm5,rmm15,rmm13,


### PR DESCRIPTION
 * SCFop had two implicit real*4 definitions of E1s and Ens that were being used
   in some subroutine that needed real*8 variables.
 * SCF was calling intfld without explicitly asking to use it from the module.