### PR TITLE
It's timers' time!

### DIFF
--- a/g2g/Makefile
+++ b/g2g/Makefile
@@ -46,14 +46,6 @@ ifeq ($(print), 1)
         CXXFLAGS += -DPRINT_MATRICES
 endif
 
-ifeq ($(time), 1)
-  CXXFLAGS += -DTIMINGS
-endif
-ifeq ($(time), 2)
-  CXXFLAGS += -DTIMINGS
-  CXXFLAGS += -DTIMER_SUMMARY
-endif
-
 ifeq ($(profile),1)
   CXXFLAGS += -pg -g
   LDFLAGS += -pg -g

--- a/g2g/Makefile.translate
+++ b/g2g/Makefile.translate
@@ -62,7 +62,6 @@ endif
 ifeq ($(analytics),0)
 
 else ifeq ($(analytics),1)
-   time=2
    profile=1
 
 else ifeq ($(analytics),2)

--- a/g2g/init.cpp
+++ b/g2g/init.cpp
@@ -250,13 +250,8 @@ extern "C" void g2g_new_grid_(const unsigned int& grid_type) {
 
 template<bool compute_rmm, bool lda, bool compute_forces> void g2g_iteration(bool compute_energy, double* fort_energy_ptr, double* fort_forces_ptr)
 {
-  Timer timer; Timers timers;
-
-  timer.start();
+  Timers timers;
   partition.solve(timers, compute_rmm, lda, compute_forces, compute_energy, fort_energy_ptr, fort_forces_ptr, fortran_vars.OPEN);
-  timer.stop();
-
-  cout << "iteracion total: " << timer << endl;
 }
 
 //===============================================================================================================

--- a/g2g/init.cpp
+++ b/g2g/init.cpp
@@ -314,18 +314,33 @@ namespace G2G
     bool   remove_zero_weights   = true ;
     bool   energy_all_iterations = false;
     double free_global_memory    = 0.0  ;
+    bool   timer_single          = false;
+    bool   timer_sum             = false;
 }
 
 //=================================================================================================================
 extern "C" void g2g_set_options_(double * fort_fgm , double * fort_lcs, 
                                  double * fort_sr  , bool   * fort_aaf, 
                                  bool   * fort_eai , bool   * fort_rzw, 
-                                 uint   & fort_mppc, uint   & fort_mfe)
+                                 uint   & fort_mppc, uint   & fort_mfe,
+                                 uint   & fort_time)
 {
+    uint timer_level = 0;
+
     free_global_memory    = *fort_fgm ; little_cube_size      = *fort_lcs  ;
     sphere_radius         = *fort_sr  ; assign_all_functions  = *fort_aaf  ;
     energy_all_iterations = *fort_eai ; remove_zero_weights   = *fort_rzw  ;
     min_points_per_cube   = fort_mppc ; max_function_exponent = fort_mfe   ;
+    timer_level           = fort_time ;
+
+    if (timer_level > 1)
+    {
+       timer_sum = true;
+    }
+    if (timer_level % 2 == 1)
+    {
+       timer_single = true;
+    }
 }
 
 

--- a/g2g/init.h
+++ b/g2g/init.h
@@ -56,6 +56,9 @@ namespace G2G {
   extern bool energy_all_iterations;
   extern double big_function_cutoff;
   extern double free_global_memory;
+
+  extern bool timer_sum;
+  extern bool timer_single;
 }
 
 #endif

--- a/g2g/partition.cpp
+++ b/g2g/partition.cpp
@@ -18,14 +18,13 @@ namespace G2G {
 int MINCOST, THRESHOLD, SPLITPOINTS;
 Partition partition;
 
-ostream& operator<<(ostream& io, const Timers& t) {
-#ifdef TIMINGS
-    ostringstream ss;
-    ss << "density = " << t.density << " rmm = " << t.rmm << " forces = " << t.forces
+ostream& operator<<(ostream& io, const Timers& t) 
+{
+   ostringstream ss;
+   ss << "density = " << t.density << " rmm = " << t.rmm << " forces = " << t.forces
       << " functions = " << t.functions;
-    io << ss.str() << endl;
-#endif
-  return io;
+   io << ss.str() << endl;
+   return io;
 }
 
 /********************

--- a/g2g/timer.cpp
+++ b/g2g/timer.cpp
@@ -35,255 +35,273 @@ using namespace std;
   } while (0)
 
 
-Timer::Timer(void) : started(false) {
-  timerspecclear(&res);
+Timer::Timer(void) : started(false)
+{
+   timerspecclear(&res);
 }
 
-Timer::Timer(const timespec& t) : started(false) {
-  res = t;
+Timer::Timer(const timespec& t) : started(false) 
+{
+   res = t;
 }
 
-void Timer::start(void) {
-#ifdef TIMINGS
-  started = true;
-  clock_gettime(CLOCK_MONOTONIC, &t0);
+void Timer::start(void) 
+{
+   started = true;
+   clock_gettime(CLOCK_MONOTONIC, &t0);
+}
+
+void Timer::pause(void)
+{
+   clock_gettime(CLOCK_MONOTONIC, &t1);
+   timespec partial_res;
+   timerspecsub(&t1, &t0, &partial_res);
+   timerspecadd(&res, &partial_res, &res);
+   timerspecclear(&t0);
+}
+
+void Timer::stop(void)
+{
+   clock_gettime(CLOCK_MONOTONIC, &t1);
+   timerspecsub(&t1, &t0, &res);
+   timerspecclear(&t0);
+   started = false;
+}
+
+void Timer::start_and_sync(void)
+{
+   sync();
+   start();
+}
+
+void Timer::stop_and_sync(void)
+{
+   sync();
+   stop();
+}
+
+void Timer::pause_and_sync(void) 
+{
+   sync();
+   pause();
+}
+
+bool Timer::isStarted(void) const
+{
+   return started;
+}
+
+unsigned long Timer::getMicrosec(void) const 
+{
+   return res.tv_nsec / 1000;
+}
+
+unsigned long Timer::getSec(void) const
+{
+   return res.tv_sec;
+}
+
+double Timer::getTotal(void) const
+{
+   return res.tv_nsec + res.tv_sec * 1000.0 * 1000.0 * 1000.0;
+}
+
+bool Timer::operator<(const Timer& other) const 
+{
+   return (res.tv_sec < other.res.tv_sec || (res.tv_sec == other.res.tv_sec && res.tv_nsec < other.res.tv_nsec));
+}
+
+void Timer::sync(void) 
+{
+#if GPU_KERNELS
+   cudaThreadSynchronize();
 #endif
 }
 
-void Timer::pause(void) {
-#ifdef TIMINGS
-  clock_gettime(CLOCK_MONOTONIC, &t1);
-  timespec partial_res;
-  timerspecsub(&t1, &t0, &partial_res);
-  timerspecadd(&res, &partial_res, &res);
-  timerspecclear(&t0);
-#endif
+std::ostream& G2G::operator<<(std::ostream& o, const Timer& t) 
+{
+   if (t.getSec() != 0)
+   {
+      o << t.getSec() << "s. " << t.getMicrosec() << "us.";
+   } else {
+      o << t.getMicrosec() << "us.";
+   }
+   return o;
 }
 
-void Timer::stop(void) {
-#ifdef TIMINGS
-  clock_gettime(CLOCK_MONOTONIC, &t1);
-	timerspecsub(&t1, &t0, &res);
-  timerspecclear(&t0);
-	started = false;
-#endif
-}
-
-void Timer::start_and_sync(void) {
-  sync();
-  start();
-}
-
-void Timer::stop_and_sync(void) {
-  sync();
-  stop();
-}
-
-void Timer::pause_and_sync(void) {
-  sync();
-  pause();
-}
-
-bool Timer::isStarted(void) const {
-	return started;
-}
-
-unsigned long Timer::getMicrosec(void) const {
-  return res.tv_nsec / 1000;
-}
-
-unsigned long Timer::getSec(void) const {
-	return res.tv_sec;
-}
-
-double Timer::getTotal(void) const {
-    return res.tv_nsec + res.tv_sec * 1000.0 * 1000.0 * 1000.0;
-}
-
-bool Timer::operator<(const Timer& other) const {
-  return (res.tv_sec < other.res.tv_sec ||
-					(res.tv_sec == other.res.tv_sec && res.tv_nsec < other.res.tv_nsec));
-}
-
-void Timer::sync(void) {
-#ifdef TIMINGS
-  #if GPU_KERNELS
-	cudaThreadSynchronize();
-  #endif
-#endif
-}
-
-std::ostream& G2G::operator<<(std::ostream& o, const Timer& t) {
-#ifdef TIMINGS
-	if (t.getSec() != 0)
-		o << t.getSec() << "s. " << t.getMicrosec() << "us.";
-	else
-		o << t.getMicrosec() << "us.";
-
-#else
-	o << "[TIMINGS NOT ENABLED]";
-#endif
-	return o;
-}
-
-void Timer::print(void) {
-#ifdef TIMINGS
-	if (getSec() != 0)
-		printf("%lus. %luus.", getSec(), getMicrosec());
-	else
-		printf("%luus.", getMicrosec());
-#else
-	printf("%s","[TIMINGS NOT ENABLED]");
-#endif
+void Timer::print(void)
+{
+   if (getSec() != 0)
+   {
+      printf("%lus. %luus.", getSec(), getMicrosec());
+   } else {
+      printf("%luus.", getMicrosec());
+   }
 }
 
 /**** to be used by fortran ****/
 Timer global_timer;
-#ifdef TIMER_SUMMARY
 string current_timer;
 map<string, set<string> > timer_children;
 map<string, string> timer_parents;
 map<string, Timer*> all_timers;
 map<string, Timer*> top_timers;
-#else
 map<string, Timer> fortran_timers;
-#endif
 
-//
 // One-time Fortran timer calls - these time sections and report timings immediately
-//
-extern "C" void g2g_timer_start_(const char* timer_name, unsigned int length_arg) {
-#ifdef TIMINGS
-#ifndef TIMER_SUMMARY
-  string tname(timer_name,length_arg);
-  tname.append("\0");
-  if (fortran_timers.find(tname) == fortran_timers.end()) fortran_timers[tname] = Timer();
-  Timer::sync();
-  fortran_timers[tname].start();
-#endif
-#endif
+extern "C" void g2g_timer_start_(const char* timer_name, unsigned int length_arg)
+{
+   string tname(timer_name,length_arg);
+   tname.append("\0");
+
+   if (fortran_timers.find(tname) == fortran_timers.end())
+   {
+      fortran_timers[tname] = Timer();
+   }
+   Timer::sync();
+   fortran_timers[tname].start();
 }
 
-extern "C" void g2g_timer_stop_(const char* timer_name, unsigned int length_arg) {
-#ifdef TIMINGS
-#ifndef TIMER_SUMMARY
-  string tname(timer_name, length_arg);
-  tname.append("\0");
-  Timer::sync();
-  if (fortran_timers.find(tname) == fortran_timers.end()) cout << "no existe timer! (" << tname << ")" << endl;
-  fortran_timers[tname].stop();
-  cout << "TIMER [" << tname << "]: " << fortran_timers[tname] << endl;
-#endif
-#endif
+extern "C" void g2g_timer_stop_(const char* timer_name, unsigned int length_arg)
+{
+   string tname(timer_name, length_arg);
+   tname.append("\0");
+
+   Timer::sync();
+   if (fortran_timers.find(tname) == fortran_timers.end())
+   {
+      cout << "no existe timer! (" << tname << ")" << endl;
+   }
+   fortran_timers[tname].stop();
+
+   cout << "TIMER [" << tname << "]: " << fortran_timers[tname] << endl;
 }
 
-extern "C" void g2g_timer_pause_(const char* timer_name, unsigned int length_arg) {
-#ifdef TIMINGS
-#ifndef TIMER_SUMMARY
-  string tname(timer_name, length_arg);
-  tname.append("\0");
-  Timer::sync();
-  if (fortran_timers.find(tname) == fortran_timers.end()) cout << "no existe timer! (" << tname << ")" << endl;
-  fortran_timers[tname].pause();
-  cout << "TIMER [" << tname << "]: " << fortran_timers[tname] << "(so far)" << endl;
-#endif
-#endif
+extern "C" void g2g_timer_pause_(const char* timer_name, unsigned int length_arg)
+{
+   string tname(timer_name, length_arg);
+   tname.append("\0");
+
+   Timer::sync();
+   if (fortran_timers.find(tname) == fortran_timers.end()) 
+   {
+      cout << "no existe timer! (" << tname << ")" << endl;
+   }
+   fortran_timers[tname].pause();
+
+   cout << "TIMER [" << tname << "]: " << fortran_timers[tname] << "(so far)" << endl;
 }
 
-//
 // Summary timer calls - these store timings until g2g_timer_summary is called, when a summary
 // of all timings up to that point is given in a tree-sorted display
-//
-extern "C" void g2g_timer_sum_start_(const char* timer_name, unsigned int length_arg) {
-#ifdef TIMER_SUMMARY
-  string tname(timer_name,length_arg);
-  tname.append("\0");
-  if (timer_children.find(tname) == timer_children.end()) timer_children[tname] = set<string>();
-  if (current_timer.length() == 0) {
-    if (top_timers.find(tname) == top_timers.end()) top_timers[tname] = new Timer();
-    Timer::sync();
-    top_timers[tname]->start();
-    if (all_timers.find(tname) == all_timers.end()) all_timers[tname] = top_timers[tname];
-    current_timer = tname;
-  } else {
-    if ((timer_children[current_timer]).find(tname) == (timer_children[current_timer]).end()) {
-       timer_children[current_timer].insert(tname);
-       all_timers[tname] = new Timer();
-       timer_parents[tname] = current_timer;
-    }
-    Timer::sync();
-    all_timers[tname]->start();
-    current_timer = tname;
-  }
-#endif
+extern "C" void g2g_timer_sum_start_(const char* timer_name, unsigned int length_arg)
+{
+   string tname(timer_name,length_arg);
+   tname.append("\0");
+   if (timer_children.find(tname) == timer_children.end()) 
+   {
+      timer_children[tname] = set<string>();
+   }
+   if (current_timer.length() == 0)
+   {
+      if (top_timers.find(tname) == top_timers.end()) 
+      {
+         top_timers[tname] = new Timer();
+      }
+      Timer::sync();
+      top_timers[tname]->start();
+      if (all_timers.find(tname) == all_timers.end())
+      {
+         all_timers[tname] = top_timers[tname];
+      }
+      current_timer = tname;
+   } else {
+      if ((timer_children[current_timer]).find(tname) == (timer_children[current_timer]).end()) {
+         timer_children[current_timer].insert(tname);
+         all_timers[tname] = new Timer();
+         timer_parents[tname] = current_timer;
+      }
+      Timer::sync();
+      all_timers[tname]->start();
+      current_timer = tname;
+   }
 }
 
-extern "C" void g2g_timer_sum_stop_(const char* timer_name, unsigned int length_arg) {
-#ifdef TIMER_SUMMARY
-  string tname(timer_name, length_arg);
-  tname.append("\0");
-  Timer::sync();
-  if (current_timer.compare(tname) != 0) { cout << "Error: not the current timer: (" << tname << "," << current_timer << ")" << endl; }
-  else {
-    all_timers[current_timer]->stop();
-    if (timer_parents.find(current_timer) == timer_parents.end()) { current_timer = ""; }
-    else { current_timer = timer_parents[current_timer]; }
-  }
-#endif
+extern "C" void g2g_timer_sum_stop_(const char* timer_name, unsigned int length_arg)
+{
+   string tname(timer_name, length_arg);
+   tname.append("\0");
+   Timer::sync();
+   if (current_timer.compare(tname) != 0) 
+   { 
+      cout << "Error: not the current timer: (" << tname << "," << current_timer << ")" << endl; 
+   } else {
+      all_timers[current_timer]->stop();
+      if (timer_parents.find(current_timer) == timer_parents.end()) 
+      {
+         current_timer = ""; 
+      } else { 
+         current_timer = timer_parents[current_timer];
+      }
+   }
 }
 
-extern "C" void g2g_timer_sum_pause_(const char* timer_name, unsigned int length_arg) {
-#ifdef TIMER_SUMMARY
-  string tname(timer_name, length_arg);
-  tname.append("\0");
-  Timer::sync();
-  if (current_timer.compare(tname) != 0) { cout << "Error: not the current timer: (" << tname << ")" << endl; }
-  else {
-    all_timers[current_timer]->pause();
-    if (timer_parents.find(current_timer) == timer_parents.end()) { current_timer = ""; }
-    else { current_timer = timer_parents[current_timer]; }
-  }
-#endif
-}
-
-
-extern "C" void g2g_timer_clear_( void ) {
-#ifdef TIMER_SUMMARY
-  for (map<string,Timer*>::iterator it = all_timers.begin(); it != all_timers.end(); ++it) {
-    delete it->second;
-  }
-  top_timers.clear();
-  all_timers.clear();
-  timer_parents.clear();
-  timer_children.clear();
-#endif
-}
-
-#ifdef TIMER_SUMMARY
-void print_timer(string indent, string timer_name, Timer& timer, float total, string parent) {
-  float time = timer.getSec() + (float)(timer.getMicrosec()) / 1000000.0f;
-  printf("%s%-35s%12.6fs (%6.2f%% of %s)\n",indent.c_str(),timer_name.c_str(),time,(100.0f * time / total),parent.c_str());
-  indent.append("  ");
-  for (set<string>::iterator it = timer_children[timer_name].begin(); it != timer_children[timer_name].end(); ++it) {
-    print_timer(indent, *it, *all_timers[(*it)], time, timer_name);
+extern "C" void g2g_timer_sum_pause_(const char* timer_name, unsigned int length_arg)
+{
+   string tname(timer_name, length_arg);
+   tname.append("\0");
+   Timer::sync();
+   if (current_timer.compare(tname) != 0) 
+   { 
+      cout << "Error: not the current timer: (" << tname << ")" << endl;
+   } else {
+      all_timers[current_timer]->pause();
+      if (timer_parents.find(current_timer) == timer_parents.end())
+      { 
+         current_timer = "";
+      } else { 
+         current_timer = timer_parents[current_timer];
+      }
   }
 }
-#endif
 
-extern "C" void g2g_timer_summary_( void ) {
-#ifdef TIMER_SUMMARY
-  Timer total_timer = *all_timers["Total"];
-  float total_time = 0.0f;
-  total_time = total_timer.getSec() + (float)(total_timer.getMicrosec()) / 1000000.0f;
 
-  string indent = "";
-  cout << "-------------------------------------------------------------------------------------------" << endl;
-  cout << "                   LIO TIMING INFORMATION:" << endl;
-  cout << "-------------------------------------------------------------------------------------------" << endl << endl;
-  cout << "Total time: " << total_time << "s" << endl;
-  for (map<string,Timer*>::iterator it = top_timers.begin(); it != top_timers.end(); ++it) {
-    print_timer(indent, it->first, *(it->second), total_time, "Total");
-  }
-  cout << "-------------------------------------------------------------------------------------------" << endl;
-#endif
+extern "C" void g2g_timer_clear_( void )
+{
+   for (map<string,Timer*>::iterator it = all_timers.begin(); it != all_timers.end(); ++it)
+   {
+     delete it->second;
+   }
+   top_timers.clear();
+   all_timers.clear();
+   timer_parents.clear();
+   timer_children.clear();
+}
+
+void print_timer(string indent, string timer_name, Timer& timer, float total, string parent) 
+{
+   float time = timer.getSec() + (float)(timer.getMicrosec()) / 1000000.0f;
+   printf("%s%-35s%12.6fs (%6.2f%% of %s)\n",indent.c_str(),timer_name.c_str(),time,(100.0f * time / total),parent.c_str());
+   indent.append("  ");
+   for (set<string>::iterator it = timer_children[timer_name].begin(); it != timer_children[timer_name].end(); ++it)
+   {
+      print_timer(indent, *it, *all_timers[(*it)], time, timer_name);
+   }
+}
+
+extern "C" void g2g_timer_summary_( void )
+{
+   Timer total_timer = *all_timers["Total"];
+   float total_time = 0.0f;
+   total_time = total_timer.getSec() + (float)(total_timer.getMicrosec()) / 1000000.0f;
+
+   string indent = "";
+   cout << "-------------------------------------------------------------------------------------------" << endl;
+   cout << "                   LIO TIMING INFORMATION:" << endl;
+   cout << "-------------------------------------------------------------------------------------------" << endl << endl;
+   cout << "Total time: " << total_time << "s" << endl;
+   for (map<string,Timer*>::iterator it = top_timers.begin(); it != top_timers.end(); ++it) {
+      print_timer(indent, it->first, *(it->second), total_time, "Total");
+   }
+   cout << "-------------------------------------------------------------------------------------------" << endl;
 }

--- a/g2g/timer.h
+++ b/g2g/timer.h
@@ -3,43 +3,40 @@
 
 #include <iostream>
 
-namespace G2G {
-	class Timer {
-		public:
-			Timer(void);
+namespace G2G 
+{
+
+class Timer 
+{
+   public:
+      Timer(void);
       Timer(const timespec& t);
 
-			void start(void);
-			void stop(void);
+      void start(void);
+      void stop(void);
       void pause(void);
-
       void start_and_sync(void);
-			void stop_and_sync(void);
+      void stop_and_sync(void);
       void pause_and_sync(void);
 
-			unsigned long getMicrosec(void) const;
-			unsigned long getSec(void) const;
-			double getTotal(void) const;
+      unsigned long getMicrosec(void) const;
+      unsigned long getSec(void) const;
+      double getTotal(void) const;
 
-			bool isStarted(void) const;
+      bool isStarted(void) const;
 
-			friend std::ostream& operator<<(std::ostream& o, const Timer& t);
+      friend std::ostream& operator<<(std::ostream& o, const Timer& t);
+      // to compare stopped timers
+      bool operator<(const Timer& other) const;
+      void print(void);
+      static void sync(void);
 
-			/* to compare stopped timers */
-			bool operator<(const Timer& other) const;
+   private:
+      timespec t0, t1, res;
+      bool started;
+};
 
-			void print(void);
-
-			static void sync(void);
-
-		private:
-			timespec t0, t1, res;
-			bool started;
-	};
-
-	std::ostream& operator<<(std::ostream& o, const Timer& t);
+std::ostream& operator<<(std::ostream& o, const Timer& t);
 }
-
-
 
 #endif

--- a/lioamber/SCF_exter.f90
+++ b/lioamber/SCF_exter.f90
@@ -23,8 +23,6 @@
 
           nsol = nsolin ; ntatom = nsol + natom ;
 
-          call g2g_timer_sum_start("Total")
-
           if (allocated(r))  deallocate(r)
           if (allocated(v))  deallocate(v)
           if (allocated(Em)) deallocate(Em)

--- a/lioamber/dft_get_mm_forces.f
+++ b/lioamber/dft_get_mm_forces.f
@@ -90,10 +90,6 @@ c       real*8 ftot(3)
 
        call g2g_timer_sum_stop('QM/MM gradients')
        call g2g_timer_sum_stop('Forces')
-       call g2g_timer_sum_stop("Total")
-       call g2g_timer_summary()
-       call g2g_timer_clear()
-
 
 !
 !

--- a/lioamber/dft_get_mm_forces.f
+++ b/lioamber/dft_get_mm_forces.f
@@ -90,6 +90,9 @@ c       real*8 ftot(3)
 
        call g2g_timer_sum_stop('QM/MM gradients')
        call g2g_timer_sum_stop('Forces')
+       call g2g_timer_sum_stop("Total")
+       call g2g_timer_summary()
+       call g2g_timer_clear()
 
 !
 !

--- a/lioamber/dft_get_qm_forces.f
+++ b/lioamber/dft_get_qm_forces.f
@@ -131,6 +131,9 @@ c       factor=627.509391D0/0.5291772108D0
 
        if (nsol.le.0) then
          call g2g_timer_sum_stop('Forces')
+         call g2g_timer_sum_stop("Total")
+         call g2g_timer_summary()
+         call g2g_timer_clear()
        endif
 
 ! FFR: No other place for this to go right now.

--- a/lioamber/dft_get_qm_forces.f
+++ b/lioamber/dft_get_qm_forces.f
@@ -131,9 +131,6 @@ c       factor=627.509391D0/0.5291772108D0
 
        if (nsol.le.0) then
          call g2g_timer_sum_stop('Forces')
-         call g2g_timer_sum_stop("Total")
-         call g2g_timer_summary()
-         call g2g_timer_clear()
        endif
 
 ! FFR: No other place for this to go right now.

--- a/lioamber/init_lio.f90
+++ b/lioamber/init_lio.f90
@@ -36,7 +36,7 @@ subroutine lio_defaults()
                            energy_all_iterations, free_global_memory, dipole,  &
                            lowdin, mulliken, print_coeffs, number_restr, Dbug, &
                            steep, Force_cut, Energy_cut, minimzation_steep,    &
-                           n_min_steeps, lineal_search, n_points
+                           n_min_steeps, lineal_search, n_points, timers
 
 
 
@@ -78,7 +78,7 @@ subroutine lio_defaults()
     NBCH           = 10            ; exter              = .false.       ;
     field          = .false.       ;
 
-! TD-DFT transport options
+!   TD-DFT transport options
     Pop_Drive = 1;
 
 !   Distance restrain options
@@ -126,6 +126,7 @@ subroutine lio_defaults()
     SHFT           = .false.       ; GRAD               = .true.        ;
     BSSE           = .false.       ; sol                = .false.       ;
     primera        = .true.        ; watermod           = 0             ;
+    timers         = 0             ;
 
     return
 end subroutine lio_defaults
@@ -145,13 +146,19 @@ subroutine init_lio_common(natomin, Izin, nclatom, charge, callfrom)
                            assign_all_functions, energy_all_iterations,        &
                            remove_zero_weights, min_points_per_cube,           &
                            max_function_exponent, sphere_radius, M,Fock_Hcore, &
-                           Fock_Overlap, P_density, OPEN
+                           Fock_Overlap, P_density, OPEN, timers
                          
     use ECP_mod,    only : Cnorm, ecpmode
 
     implicit none
     integer , intent(in) :: charge, nclatom, natomin, Izin(natomin), callfrom
-    integer              :: i, ng2, ng3, ngdDyn, ngDyn, nqnuc, ierr, ios, MM, electrons
+    integer              :: i, ng2, ng3, ngdDyn, ngDyn, nqnuc, ierr, ios, MM,  &
+                            electrons
+
+    call g2g_set_options(free_global_memory, little_cube_size, sphere_radius, &
+                         assign_all_functions, energy_all_iterations,         &
+                         remove_zero_weights, min_points_per_cube,            &
+                         max_function_exponent, timers)
 
 !    call g2g_timer_start('lio_init')
 
@@ -188,10 +195,6 @@ subroutine init_lio_common(natomin, Izin, nclatom, charge, callfrom)
     ! Differentiate C for x^2,y^2,z^2 and  xy,xz,yx (3^0.5 factor)
     if (ecpmode) allocate (Cnorm(ngDyn,nl)) 
 
-    call g2g_set_options(free_global_memory, little_cube_size, sphere_radius, &
-                         assign_all_functions, energy_all_iterations,         &
-                         remove_zero_weights, min_points_per_cube,            &
-                         max_function_exponent)
     call g2g_init()
 
     nqnuc = 0

--- a/lioamber/input_read.f90
+++ b/lioamber/input_read.f90
@@ -26,7 +26,7 @@ subroutine read_options(inputFile, charge)
                            sphere_radius, dipole, lowdin, mulliken,            &
                            print_coeffs, number_restr, Dbug, steep, Force_cut, &
                            Energy_cut, minimzation_steep, n_min_steeps,        &
-                           lineal_search, n_points
+                           lineal_search, n_points, timers
 
 
     use ECP_mod   , only : ecpmode, ecptypes, tipeECP, ZlistECP, verbose_ECP,  &
@@ -63,7 +63,7 @@ subroutine read_options(inputFile, charge)
                    ! Distance Restrain
                    number_restr,                                               &
                    ! Debug variables
-                   Dbug,                                                       &
+                   Dbug, timers,                                               &
                    ! Geometry optimizations
                    steep, Force_cut, Energy_cut, minimzation_steep,            &
                    n_min_steeps,lineal_search,n_points,                        &

--- a/lioamber/liomain.f90
+++ b/lioamber/liomain.f90
@@ -24,6 +24,8 @@ subroutine liomain(E, dipxyz)
     REAL*8, intent(inout) :: dipxyz(3), E
     integer :: idip_scrach
 
+    call g2g_timer_sum_start("Total")
+
     if (.not.allocated(Smat))    allocate(Smat(M,M))
     if (.not.allocated(RealRho)) allocate(RealRho(M,M))
     if (.not.allocated(sqsm))    allocate(sqsm(M,M))
@@ -70,6 +72,10 @@ subroutine liomain(E, dipxyz)
     endif
 
     if ((restart_freq.gt.0).and.(MOD(npas, restart_freq).eq.0)) call write_restart(88)
+
+    call g2g_timer_sum_stop("Total")
+    call g2g_timer_summary()
+    call g2g_timer_clear()
 
     return
 end subroutine liomain

--- a/lioamber/liomain.f90
+++ b/lioamber/liomain.f90
@@ -73,10 +73,6 @@ subroutine liomain(E, dipxyz)
 
     if ((restart_freq.gt.0).and.(MOD(npas, restart_freq).eq.0)) call write_restart(88)
 
-    call g2g_timer_sum_stop("Total")
-    call g2g_timer_summary()
-    call g2g_timer_clear()
-
     return
 end subroutine liomain
 

--- a/lioamber/liomods/garcha_mod.f
+++ b/lioamber/liomods/garcha_mod.f
@@ -159,6 +159,7 @@ c      parameter rmintsol=16.0D0
      > restr_r0
 !-Debug. Activates check of NaN in Fock and Rho
       Logical :: Dbug
+      integer :: timers
 
 !-Temporal variable for the transition of change RMM array int smaller arrays
 	logical :: break_rmm

--- a/liosolo/liomd.f90
+++ b/liosolo/liomd.f90
@@ -50,9 +50,6 @@ program liomd
         endselect
     enddo
 
-    ! Checks input files' existence.
-    call g2g_timer_sum_start("Total")
-
     ! Reads runtime options and input coordinates.
     call read_options(inpfile, charge)
     call read_coords(inpcoords)

--- a/liosolo/liosolo.f90
+++ b/liosolo/liosolo.f90
@@ -42,8 +42,6 @@ program liosolo
         endselect
     enddo
 
-    call g2g_timer_sum_start("Total")
-
     ! Reads options and coordinates files.
     call read_options(inpfile, charge)
     call read_coords(inpcoords)


### PR DESCRIPTION
Timers are now usable as a runtime option, rendering the "time" compilation flag obsolete. The current scheme adds the "timers" integer variable to lio namelist, which can get the following values:

timers = 0  => No timers at all.
timers = 1  => Only single start/pause/stop timers are used.
timers = 2  => Only timer summary is used.
timers = 3  => Both single timers and timer summary are used.

Please test at will.