### PR TITLE
Bugfixes - Mainly OpenShell

### DIFF
--- a/dat/basis/Stuttgart RLC
+++ b/dat/basis/Stuttgart RLC
@@ -1293,3 +1293,4 @@ gaussian
 # ELEMENTS                      REFERENCES
 # ---------                       ----------
 #
+endbasis

--- a/dat/basis/Stuttgart RSC 1997
+++ b/dat/basis/Stuttgart RSC 1997
@@ -3137,4 +3137,4 @@ gaussian
 # ELEMENTS                      REFERENCES
 # ---------                       ----------
 # 
-
+endbasis

--- a/g2g/cuda/kernels/accumulate_point.h
+++ b/g2g/cuda/kernels/accumulate_point.h
@@ -45,12 +45,6 @@ __global__ void gpu_accumulate_point_open(scalar_type* const energy, scalar_type
     energy_c[point] = ((_partial_density_a + _partial_density_b) * point_weight) * corr;
     energy_c1[point] = ((_partial_density_a + _partial_density_b) * point_weight) * corr1;
     energy_c2[point] = ((_partial_density_a + _partial_density_b) * point_weight) * corr2;
-  } else {
-    energy[point] = 0.0f;
-    energy_i[point] = 0.0f;
-    energy_c[point] = 0.0f;
-    energy_c1[point] = 0.0f;
-    energy_c2[point] = 0.0f;
   }
 
   if (compute_factor && valid_thread){


### PR DESCRIPTION
Fixed a bug which allowed Open Shell GPU calculations only when energy_all_iterations was set to _true_.
@charlyqchm, I also addressed #129 thus fixing basis sets.