### PR TITLE
Overlap PR3.5 - Cleanups by hiding CUBLAS

### DIFF
--- a/lioamber/Makefile.depends
+++ b/lioamber/Makefile.depends
@@ -204,8 +204,7 @@ include liosubs_dens/liosubs_dens.mk
 SRCDIRS += liosubs_dens
 OBJECTS += liosubs_dens.o
 #
-#modusrs :=
-modusrs += tmpaux_SCF.o
+modusrs := tmpaux_SCF.o
 $(modusrs:%.o=$(OBJPATH)/%.o) : ${OBJPATH}/liosubs_dens.mod
 
 
@@ -232,9 +231,15 @@ $(modusrs:%.o=$(OBJPATH)/%.o) : ${OBJPATH}/typedef_sop.mod
 ################################################################################
 OBJECTS += mask_ecp.o
 #
-#modusrs :=
-modusrs += SCF.o
+modusrs := SCF.o
 $(modusrs:%.o=$(OBJPATH)/%.o) : ${OBJPATH}/mask_ecp.mod
+
+
+################################################################################
+OBJECTS += mask_cublas.o
+#
+modusrs := SCF.o
+$(modusrs:%.o=$(OBJPATH)/%.o) : ${OBJPATH}/mask_cublas.mod
 
 
 ################################################################################

--- a/lioamber/mask_cublas.f90
+++ b/lioamber/mask_cublas.f90
@@ -1,0 +1,65 @@
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+module mask_cublas
+   implicit none
+   logical            :: cublas_not_init = .true.
+   integer, parameter :: SIZE_OF_REAL = 8
+#  ifdef CUBLAS
+      integer, external :: CUBLAS_ALLOC
+      integer, external :: CUBLAS_SET_MATRIX
+      external          :: CUBLAS_INIT
+      external          :: CUBLAS_SHUTDOWN
+      external          :: CUBLAS_FREE
+#  endif
+   contains
+!
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine cublas_setmat( Msize, matrix, dev_ptr )
+   implicit none
+   integer  , intent(in)    :: Msize
+   real*8   , intent(in)    :: matrix(Msize, Msize)
+   integer*8, intent(inout) :: dev_ptr
+   integer                  :: stat
+
+#  ifdef CUBLAS
+
+   if (cublas_not_init) call CUBLAS_INIT()
+
+   stat = CUBLAS_ALLOC( Msize*Msize, SIZE_OF_REAL, dev_ptr)
+   if ( stat /= 0 ) then
+      write(*,*) "CUBLAS MEMORY ALLOCATION FAILED"
+      call CUBLAS_SHUTDOWN
+      stop
+   endif
+
+   stat = CUBLAS_SET_MATRIX( Msize, Msize, SIZE_OF_REAL, matrix, Msize, &
+                           & dev_ptr, Msize )
+   if ( stat /= 0 ) then
+      write(*,*) "CUBLAS MATRIX SETTING FAILED"
+      call CUBLAS_SHUTDOWN
+      stop
+   endif
+
+#  endif
+end subroutine cublas_setmat
+
+
+!------------------------------------------------------------------------------!
+subroutine cublas_release( dev_ptr )
+   implicit none
+   integer*8, optional, intent(inout) :: dev_ptr
+
+#  ifdef CUBLAS
+   if (present(dev_ptr)) then
+      call CUBLAS_FREE(dev_ptr)
+   else
+      cublas_not_init = .true.
+      call CUBLAS_SHUTDOWN
+   end if
+#  endif
+
+end subroutine cublas_release
+
+
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+end module mask_cublas
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!


### PR DESCRIPTION
First steps towards hiding cublas switch properly: added mask_cublas
module and introduced subroutines there that take care of initialization
if cublas is enabled or do nothing if it is not. This is a first step,
not the final result: there are still some ifdefs in SCF that we need
to eliminate.

Left as a separated PR to make it stand out from the rest of the cleanup.