### PR TITLE
Operators time

### DIFF
--- a/lioamber/Makefile.depends
+++ b/lioamber/Makefile.depends
@@ -231,7 +231,7 @@ include liosubs_dens/liosubs_dens.mk
 SRCDIRS += liosubs_dens
 OBJECTS += liosubs_dens.o
 #
-modusrs := tmpaux_SCF.o
+modusrs := tmpaux_SCF.o typedef_operator.o
 $(modusrs:%.o=$(OBJPATH)/%.o) : ${OBJPATH}/liosubs_dens.mod
 
 
@@ -253,8 +253,14 @@ OBJECTS += typedef_sop.o
 modusrs :=
 modusrs += SCF.o
 $(modusrs:%.o=$(OBJPATH)/%.o) : ${OBJPATH}/typedef_sop.mod
-
-
+################################################################################
+include typedef_operator/typedef_operator.mk
+SRCDIRS += typedef_operator
+OBJECTS += typedef_operator.o
+#
+modusrs :=
+modusrs += SCF.o converger_subs.o
+$(modusrs:%.o=$(OBJPATH)/%.o) : ${OBJPATH}/typedef_operator.mod
 ################################################################################
 OBJECTS += mask_ecp.o
 #
@@ -289,14 +295,14 @@ include linear_algebra/linear_algebra.mk
 SRCDIRS += linear_algebra
 OBJECTS += linear_algebra.o
 tmplist :=
-tmplist += SCF.o tmpaux_SCF.o
+tmplist += SCF.o tmpaux_SCF.o typedef_operator.o
 $(tmplist:%.o=$(OBJPATH)/%.o) : $(OBJPATH)/linear_algebra.mod
 
 include mathsubs/mathsubs.mk
 SRCDIRS += mathsubs
 OBJECTS += mathsubs.o
 tmplist :=
-tmplist += SCF.o SCFop.o predictor.o converger_subs.o
+tmplist += SCF.o SCFop.o predictor.o typedef_operator.o
 tmplist += tmpaux_SCF.o
 $(tmplist:%.o=$(OBJPATH)/%.o) : $(OBJPATH)/mathsubs.mod
 
@@ -320,7 +326,7 @@ ifeq ($(use_cublas),1)
   $(tmplist:%.o=$(OBJPATH)/%.o) : $(OBJPATH)/fortran.o
 
   tmplist :=
-  tmplist += SCF.o SCFop.o TD.o converger_subs.o transport.o
+  tmplist += SCF.o SCFop.o TD.o typedef_operator.o transport.o
   tmplist += tmpaux_SCF.o
   $(tmplist:%.o=$(OBJPATH)/%.o) : $(OBJPATH)/cublasmath.mod
 

--- a/lioamber/typedef_operator/BChange_data.f90
+++ b/lioamber/typedef_operator/BChange_data.f90
@@ -1,0 +1,32 @@
+
+#ifdef CUBLAS
+   subroutine BChange_AOtoON(this,devPtrX,Nsize)
+   use cublasmath, only : cumfx, cumxtf
+#else
+   subroutine BChange_AOtoON(this,Xmat,Nsize)
+   use mathsubs, only : basechange_gemm
+#endif
+
+   implicit none
+   class(operator), intent(inout) :: this
+   integer, intent(in)           :: Nsize
+#  ifdef  CUBLAS
+   integer*8, intent(in) :: devPtrX
+#  else
+   real*8,  intent(in) :: Xmat(Nsize,Nsize)
+#  endif
+
+   real*8 :: Dmat(Nsize,Nsize)
+
+   Dmat = this%data_AO
+
+#  ifdef  CUBLAS
+     call cumxtf(Dmat,devPtrX,Dmat,Nsize)
+     call cumfx(Dmat,DevPtrX,Dmat,Nsize)
+#  else
+      Dmat = basechange_gemm(Nsize,Dmat,Xmat)
+#  endif
+
+   call this%Sets_data_ON(Dmat)
+
+ end subroutine BChange_AOtoON

--- a/lioamber/typedef_operator/Commut_data.f90
+++ b/lioamber/typedef_operator/Commut_data.f90
@@ -1,0 +1,38 @@
+#ifdef CUBLAS
+subroutine Commut_data(this, Bmat,devPtrX,devPtrY,AB_BAmat, Nsize)
+   use cublasmath, only : cu_calc_fock_commuts
+#else
+subroutine Commut_data(this, Bmat,Xmat,Ymat,AB_BAmat, Nsize )
+#endif
+
+   implicit none
+   class(operator), intent(inout) :: this
+   integer, intent(in)            :: Nsize
+   real*8, intent(in)             :: Bmat(Nsize,Nsize)
+
+#ifdef  CUBLAS
+!  ver intent pointers...
+   integer*8, intent(in)         :: devPtrX
+   integer*8, intent(in)         :: devPtrY
+#else
+   real*8,  intent(in)           :: Xmat(Nsize,Nsize)
+   real*8,  intent(in)           :: Ymat(Nsize,Nsize)
+#endif
+
+   real*8, intent(out)           :: AB_BAmat(Nsize,Nsize)
+   real*8   :: ABmat(Nsize,Nsize)
+   real*8   :: BAmat(Nsize,Nsize)
+   real*8   :: Amat(Nsize,Nsize)
+
+   Amat=this%data_AO
+
+#  ifdef  CUBLAS
+      call cu_calc_fock_commuts(Amat,Bmat,devPtrX,devPtrY,AB_BAmat,Nsize)
+#  else
+      call calc_fock_commuts(Amat,Bmat,Xmat,Ymat,ABmat,BAmat,Nsize)
+      AB_BAmat = ABmat - BAmat
+#  endif
+
+   call this%Sets_data_ON(Amat)
+
+end subroutine Commut_data

--- a/lioamber/typedef_operator/Dens_build.f90
+++ b/lioamber/typedef_operator/Dens_build.f90
@@ -1,0 +1,13 @@
+subroutine Dens_build(this,Msize, Nocup,Focup,coef_mat)
+   use liosubs_dens  , only: builds_densmat
+
+   implicit none
+   class(operator), intent(inout) :: this
+   integer, intent(in)            :: Msize
+   integer, intent(in)            :: Nocup
+   real*8 , intent(in)            :: Focup
+   real*8 , intent(in)            :: coef_mat(Msize, Msize)
+
+   call builds_densmat( Msize, Nocup, Focup, coef_mat, this%data_AO)
+
+end subroutine Dens_build

--- a/lioamber/typedef_operator/Diagon_datamat.f90
+++ b/lioamber/typedef_operator/Diagon_datamat.f90
@@ -1,0 +1,11 @@
+subroutine Diagon_datamat (this, eigen_vecs, eigen_vals)
+   use linear_algebra, only: matrix_diagon
+
+   implicit none
+   class(operator), intent(in) :: this
+   real*8, intent(out) :: eigen_vecs(:,:)
+   real*8, intent(out) :: eigen_vals(:)
+
+   call matrix_diagon( this%data_ON, eigen_vecs, eigen_vals )
+
+end subroutine Diagon_datamat

--- a/lioamber/typedef_operator/Gets_datamat.f90
+++ b/lioamber/typedef_operator/Gets_datamat.f90
@@ -1,0 +1,19 @@
+subroutine Gets_data_AO (this, Dmat)
+
+   implicit none
+   class(operator), intent(in) :: this
+   real*8, intent(out)         :: Dmat(:,:)
+
+   Dmat=this%data_AO
+
+end subroutine Gets_data_AO
+
+subroutine Gets_data_ON (this, Dmat)
+
+   implicit none
+   class(operator), intent(in) :: this
+   real*8, intent(out)         :: Dmat(:,:)
+
+   Dmat=this%data_ON
+
+end subroutine Gets_data_ON

--- a/lioamber/typedef_operator/Sets_datamat.f90
+++ b/lioamber/typedef_operator/Sets_datamat.f90
@@ -1,0 +1,43 @@
+subroutine Sets_data_AO (this, Dmat)
+
+   implicit none
+   class(operator), intent(inout) :: this
+   real*8, intent(in)             :: Dmat(:,:)
+   integer    :: Nbasis
+
+   Nbasis = size( Dmat, 1 )
+
+   if (allocated(this%data_AO)) then
+      if (size(this%data_AO,1)/=Nbasis) then
+        deallocate(this%data_AO)
+        allocate(this%data_AO(Nbasis,Nbasis))
+      endif
+    else
+      allocate(this%data_AO(Nbasis,Nbasis))
+   endif
+
+   this%data_AO = Dmat
+
+end subroutine Sets_data_AO
+
+subroutine Sets_data_ON (this, Dmat)
+
+   implicit none
+   class(operator), intent(inout) :: this
+   real*8, intent(in)             :: Dmat(:,:)
+   integer    :: Nbasis
+
+   Nbasis = size( Dmat, 1 )
+
+   if (allocated(this%data_ON)) then
+      if (size(this%data_ON,1)/=Nbasis) then
+        deallocate(this%data_ON)
+        allocate(this%data_ON(Nbasis,Nbasis))
+      endif
+    else
+      allocate(this%data_ON(Nbasis,Nbasis))
+   endif
+
+   this%data_ON = Dmat
+
+end subroutine Sets_data_ON

--- a/lioamber/typedef_operator/typedef_operator.f90
+++ b/lioamber/typedef_operator/typedef_operator.f90
@@ -1,0 +1,26 @@
+module typedef_operator
+
+   type operator
+     real*8, allocatable :: data_AO(:,:)
+     real*8, allocatable :: data_ON(:,:)
+
+   contains
+     procedure, pass :: Sets_data_AO
+     procedure, pass :: Gets_data_AO
+     procedure, pass :: Sets_data_ON
+     procedure, pass :: Gets_data_ON
+     procedure, pass :: Diagon_datamat
+     procedure, pass :: Dens_build
+     procedure, pass :: Commut_data
+     procedure, pass :: BChange_AOtoON
+   end type operator
+
+contains
+#include  "Sets_datamat.f90"
+#include  "Gets_datamat.f90"
+#include  "Diagon_datamat.f90"
+#include  "Dens_build.f90"
+#include  "Commut_data.f90"
+#include  "BChange_data.f90"
+
+end module typedef_operator

--- a/lioamber/typedef_operator/typedef_operator.mk
+++ b/lioamber/typedef_operator/typedef_operator.mk
@@ -1,0 +1,12 @@
+################################################################################
+# INTERNAL DEPENDENCIES
+INCLUDES :=
+INCLUDES += Sets_datamat.f90
+INCLUDES += Gets_datamat.f90
+INCLUDES += Diagon_datamat.f90
+INCLUDES += Dens_build.f90
+INCLUDES += Commut_data.f90
+INCLUDES += BChange_data.f90
+
+$(OBJPATH)/typedef_operator.o : $(INCLUDES) typedef_operator.mk
+################################################################################


### PR DESCRIPTION
Added operator type
This object includes:
- Two matrices representing AO and ON basis, of what is store here.
- Extraction and Storing subroutines for the corresponding matrix.
- Diagonalization subroutine.
- Density building subroutine.
- Conmutation subroutine.
- Base change subroutine from AO to ON.

The most important changes were made in SCF and converger_sub.
This is the first step to include Open Shell in SCF.