### PR TITLE
Refactoring Int1

### DIFF
--- a/lioamber/SCF.f90
+++ b/lioamber/SCF.f90
@@ -329,7 +329,7 @@ subroutine SCF(E)
 !
       call g2g_timer_sum_start('1-e Fock')
       call g2g_timer_sum_start('Nuclear attraction')
-      call int1(En, RMM, Smat, Nuc, a, c, d, r, Iz, ncont, NORM, natom, M, Md, nshell)
+      call int1(En, RMM, Smat, Nuc, a, c, d, r, Iz, ncont, NORM, natom, M, Md, nshell,ntatom)
 
       call ECP_fock( MM, RMM(M11) )
 
@@ -968,7 +968,7 @@ subroutine SCF(E)
         Es=Ens
 
 !       One electron Kinetic (with aint >3) or Kinetic + Nuc-elec (aint >=3)
-        call int1(En, RMM, Smat, Nuc, a, c, d, r, Iz, ncont, NORM, natom, M, Md, nshell)
+        call int1(En, RMM, Smat, Nuc, a, c, d, r, Iz, ncont, NORM, natom, M, Md, nshell,ntatom)
 
 !       Computing the E1-fock without the MM atoms
         if (nsol.gt.0.and.igpu.ge.1) then

--- a/lioamber/SCF.f90
+++ b/lioamber/SCF.f90
@@ -36,7 +36,7 @@ subroutine SCF(E)
                           nuc, doing_ehrenfest, first_step, RealRho,           &
                           total_time, MO_coef_at, MO_coef_at_b, Smat, good_cut,&
                           ndiis, ncont, nshell, rhoalpha, rhobeta, OPEN, nshell, &
-                          Nuc, a, c, d, NORM
+                          Nuc, a, c, d, NORM, ntatom
    use ECP_mod, only : ecpmode, term1e, VAAA, VAAB, VBAC, &
                        FOCK_ECP_read,FOCK_ECP_write,IzECP
    use field_data, only: field, fx, fy, fz

--- a/lioamber/SCF.f90
+++ b/lioamber/SCF.f90
@@ -329,7 +329,7 @@ subroutine SCF(E)
 !
       call g2g_timer_sum_start('1-e Fock')
       call g2g_timer_sum_start('Nuclear attraction')
-      call int1(En, RMM, Smat, Nuc, a, c, d, r, Iz, ncont, NORM, natom, M, Md)
+      call int1(En, RMM, Smat, Nuc, a, c, d, r, Iz, ncont, NORM, natom, M, Md, nshell)
 
       call ECP_fock( MM, RMM(M11) )
 
@@ -968,7 +968,7 @@ subroutine SCF(E)
         Es=Ens
 
 !       One electron Kinetic (with aint >3) or Kinetic + Nuc-elec (aint >=3)
-        call int1(En, RMM, Smat, Nuc, a, c, d, r, Iz, ncont, NORM, natom, M, Md)
+        call int1(En, RMM, Smat, Nuc, a, c, d, r, Iz, ncont, NORM, natom, M, Md, nshell)
 
 !       Computing the E1-fock without the MM atoms
         if (nsol.gt.0.and.igpu.ge.1) then

--- a/lioamber/TD.f90
+++ b/lioamber/TD.f90
@@ -640,7 +640,7 @@ subroutine td_integral_1e(E1, En, E1s, Ens, MM, igpu, nsol, RMM, RMM11, r, pc, &
    E1 = 0.0D0 ; En = 0.0D0
    call g2g_timer_sum_start('TD - 1-e Fock')
    call g2g_timer_sum_start('TD - Nuclear attraction')
-   call int1(En, RMM, Smat, Nuc, a, c, d, r, Iz, ncont, NORM, natom, M, Md, nshell)
+   call int1(En, RMM, Smat, Nuc, a, c, d, r, Iz, ncont, NORM, natom, M, Md, nshell,ntatom)
 
    call ECP_fock(MM, RMM11)
    call g2g_timer_sum_stop('TD - Nuclear attraction')

--- a/lioamber/TD.f90
+++ b/lioamber/TD.f90
@@ -226,7 +226,7 @@ subroutine TD(fock_aop, rho_aop, fock_bop, rho_bop)
    if (field) call field_setup_old(pert_time, 1, fx, fy, fz)
    call td_integration_setup(igrid2, igpu)
    call td_integral_1e(E1, En, E1s, Ens, MM, igpu, nsol, RMM, RMM(M11), r, pc, &
-                       ntatom,natom,Smat,Nuc,a,c,d,Iz,ncont,NORM,M,Md)
+                       ntatom,natom,Smat,Nuc,a,c,d,Iz,ncont,NORM,M,Md,nshell)
    ! Initialises transport if required.
    if (transport_calc) call transport_init(M, dim3, natom, Nuc, RMM(M5),       &
                                            overlap, rho,OPEN)
@@ -618,7 +618,7 @@ end subroutine td_integration_setup
 
 subroutine td_integral_1e(E1, En, E1s, Ens, MM, igpu, nsol, RMM, RMM11, r, pc, &
                           ntatom, natom, Smat, Nuc, a, c, d, Iz, ncont, NORM,  &
-                          M, Md)
+                          M, Md, nshell)
     use faint_cpu77, only: intsol
     use faint_cpu  , only: int1
     use mask_ecp   , only: ECP_fock
@@ -626,7 +626,7 @@ subroutine td_integral_1e(E1, En, E1s, Ens, MM, igpu, nsol, RMM, RMM11, r, pc, &
 
     double precision, intent(in) :: pc(ntatom), r(ntatom,3)
     integer         , intent(in) :: M, Md, MM, igpu, nsol, ntatom, &
-                                    Nuc(M), Iz(natom)
+                                    Nuc(M), Iz(natom),nshell(0:4)
     logical         , intent(in) :: NORM
     integer         , intent(inout) :: natom
     double precision, intent(inout) :: RMM11(MM), E1, En, E1s, Ens
@@ -640,7 +640,7 @@ subroutine td_integral_1e(E1, En, E1s, Ens, MM, igpu, nsol, RMM, RMM11, r, pc, &
    E1 = 0.0D0 ; En = 0.0D0
    call g2g_timer_sum_start('TD - 1-e Fock')
    call g2g_timer_sum_start('TD - Nuclear attraction')
-   call int1(En, RMM, Smat, Nuc, a, c, d, r, Iz, ncont, NORM, natom, M, Md)
+   call int1(En, RMM, Smat, Nuc, a, c, d, r, Iz, ncont, NORM, natom, M, Md, nshell)
 
    call ECP_fock(MM, RMM11)
    call g2g_timer_sum_stop('TD - Nuclear attraction')

--- a/lioamber/basis_subs.f90
+++ b/lioamber/basis_subs.f90
@@ -126,7 +126,7 @@ subroutine basis_data_norm( Isize, Icont, gcoefs )
    use maskrmm,     only: rmmget_fock
    use faint_cpu,   only: int1
    use basis_data,  only: gauss_coef
-   use garcha_mod,  only: RMM,Nuc,a,c,d,r,Iz,NORM,natom,M,Md,ncont
+   use garcha_mod,  only: RMM,Nuc,a,c,d,r,Iz,NORM,natom,M,Md,ncont,nshell
 
    implicit none
    integer, intent(in)              :: Isize
@@ -139,7 +139,7 @@ subroutine basis_data_norm( Isize, Icont, gcoefs )
 
 !   call g2g_timer_start('RMMcalc1')
    allocate( Smat(isize, isize) )
-   call int1(scratch_energy,RMM,Smat,Nuc,a,c,d,r,Iz,ncont,NORM,natom,M,Md)
+   call int1(scratch_energy,RMM,Smat,Nuc,a,c,d,r,Iz,ncont,NORM,natom,M,Md,nshell)
    do kk = 1, isize
       gcoefs(kk,:) = gcoefs(kk,:) / sqrt( Smat(kk,kk) )
       gauss_coef(:,kk) = gauss_coef(:,kk) / sqrt( Smat(kk,kk) )

--- a/lioamber/basis_subs.f90
+++ b/lioamber/basis_subs.f90
@@ -126,7 +126,7 @@ subroutine basis_data_norm( Isize, Icont, gcoefs )
    use maskrmm,     only: rmmget_fock
    use faint_cpu,   only: int1
    use basis_data,  only: gauss_coef
-   use garcha_mod,  only: RMM,Nuc,a,c,d,r,Iz,NORM,natom,M,Md,ncont,nshell
+   use garcha_mod,  only: RMM,Nuc,a,c,d,r,Iz,NORM,natom,M,Md,ncont,nshell,ntatom
 
    implicit none
    integer, intent(in)              :: Isize

--- a/lioamber/basis_subs.f90
+++ b/lioamber/basis_subs.f90
@@ -139,7 +139,7 @@ subroutine basis_data_norm( Isize, Icont, gcoefs )
 
 !   call g2g_timer_start('RMMcalc1')
    allocate( Smat(isize, isize) )
-   call int1(scratch_energy,RMM,Smat,Nuc,a,c,d,r,Iz,ncont,NORM,natom,M,Md,nshell)
+   call int1(scratch_energy,RMM,Smat,Nuc,a,c,d,r,Iz,ncont,NORM,natom,M,Md,nshell,ntatom)
    do kk = 1, isize
       gcoefs(kk,:) = gcoefs(kk,:) / sqrt( Smat(kk,kk) )
       gauss_coef(:,kk) = gauss_coef(:,kk) / sqrt( Smat(kk,kk) )

--- a/lioamber/ehrensubs/RMMcalc1_Overlap.f90
+++ b/lioamber/ehrensubs/RMMcalc1_Overlap.f90
@@ -5,7 +5,7 @@ subroutine RMMcalc1_Overlap(Ovlap,Energy)
 !
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
   use maskrmm     , only: rmmget_fock
-  use garcha_mod  , only: RMM, Smat, Nuc, a, c, d, r, Iz, ncont, NORM, natom, M, Md
+  use garcha_mod  , only: RMM, Smat, Nuc, a, c, d, r, Iz, ncont, NORM, natom, M, Md, nshell
   use faint_cpu   , only: int1
   implicit none
   real*8,intent(out) :: Ovlap(M,M)
@@ -15,8 +15,7 @@ subroutine RMMcalc1_Overlap(Ovlap,Energy)
   call g2g_timer_start('RMMcalc1')
   call aint_query_gpu_level(igpu)
   if (igpu.gt.1) call aint_new_step()
-!  call int1(Energy)
-  call int1(Energy,RMM,Smat,Nuc,a,c,d,r,Iz,ncont,NORM,natom,M,Md)
+  call int1(Energy,RMM,Smat,Nuc,a,c,d,r,Iz,ncont,NORM,natom,M,Md,nshell)
   call rmmget_fock(Ovlap)
   call g2g_timer_stop('RMMcalc1')
 

--- a/lioamber/ehrensubs/RMMcalc1_Overlap.f90
+++ b/lioamber/ehrensubs/RMMcalc1_Overlap.f90
@@ -15,7 +15,7 @@ subroutine RMMcalc1_Overlap(Ovlap,Energy)
   call g2g_timer_start('RMMcalc1')
   call aint_query_gpu_level(igpu)
   if (igpu.gt.1) call aint_new_step()
-  call int1(Energy,RMM,Smat,Nuc,a,c,d,r,Iz,ncont,NORM,natom,M,Md,nshell)
+  call int1(Energy,RMM,Smat,Nuc,a,c,d,r,Iz,ncont,NORM,natom,M,Md,nshell,ntatom)
   call rmmget_fock(Ovlap)
   call g2g_timer_stop('RMMcalc1')
 

--- a/lioamber/ehrensubs/RMMcalc1_Overlap.f90
+++ b/lioamber/ehrensubs/RMMcalc1_Overlap.f90
@@ -5,7 +5,7 @@ subroutine RMMcalc1_Overlap(Ovlap,Energy)
 !
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
   use maskrmm     , only: rmmget_fock
-  use garcha_mod  , only: RMM, Smat, Nuc, a, c, d, r, Iz, ncont, NORM, natom, M, Md, nshell
+  use garcha_mod  , only: RMM, Smat, Nuc, a, c, d, r, Iz, ncont, NORM, natom, M, Md, nshell, ntatom
   use faint_cpu   , only: int1
   implicit none
   real*8,intent(out) :: Ovlap(M,M)

--- a/lioamber/ehrensubs/ehrentest_SCF.f90
+++ b/lioamber/ehrensubs/ehrentest_SCF.f90
@@ -272,7 +272,7 @@ c in intsol)
 c
       call g2g_timer_sum_start('1-e Fock')
       call g2g_timer_sum_start('Nuclear attraction')
-      call int1(En, RMM, Smat, Nuc, a, c, d, r, Iz, ncont, NORM, natom, M, Md, nshell)
+      call int1(En, RMM, Smat, Nuc, a, c, d, r, Iz, ncont, NORM, natom, M, Md, nshell,ntatom)
       call g2g_timer_sum_stop('Nuclear attraction')
       if(nsol.gt.0.or.igpu.ge.4) then
           call g2g_timer_sum_start('QM/MM')
@@ -1354,7 +1354,7 @@ c
        call g2g_timer_sum_start('Mulliken')
 ! MULLIKEN POPULATION ANALYSIS (FFR - Simplified)
 !--------------------------------------------------------------------!
-       call int1(En, RMM, Smat, Nuc, a, c, d, r, Iz, ncont, NORM, natom, M, Md, nshell)
+       call int1(En, RMM, Smat, Nuc, a, c, d, r, Iz, ncont, NORM, natom, M, Md, nshell,ntatom)
        call spunpack('L',M,RMM(M5),Smat)
        call spunpack('L',M,RMM(M1),RealRho)
        call fixrho(M,RealRho)

--- a/lioamber/ehrensubs/ehrentest_SCF.f90
+++ b/lioamber/ehrensubs/ehrentest_SCF.f90
@@ -272,7 +272,7 @@ c in intsol)
 c
       call g2g_timer_sum_start('1-e Fock')
       call g2g_timer_sum_start('Nuclear attraction')
-      call int1(En, RMM, Smat, Nuc, a, c, d, r, Iz, ncont, NORM, natom, M, Md)
+      call int1(En, RMM, Smat, Nuc, a, c, d, r, Iz, ncont, NORM, natom, M, Md, nshell)
       call g2g_timer_sum_stop('Nuclear attraction')
       if(nsol.gt.0.or.igpu.ge.4) then
           call g2g_timer_sum_start('QM/MM')
@@ -1354,7 +1354,7 @@ c
        call g2g_timer_sum_start('Mulliken')
 ! MULLIKEN POPULATION ANALYSIS (FFR - Simplified)
 !--------------------------------------------------------------------!
-       call int1(En, RMM, Smat, Nuc, a, c, d, r, Iz, ncont, NORM, natom, M, Md)
+       call int1(En, RMM, Smat, Nuc, a, c, d, r, Iz, ncont, NORM, natom, M, Md, nshell)
        call spunpack('L',M,RMM(M5),Smat)
        call spunpack('L',M,RMM(M1),RealRho)
        call fixrho(M,RealRho)

--- a/lioamber/ehrensubs/ehrentest_SCF.f90
+++ b/lioamber/ehrensubs/ehrentest_SCF.f90
@@ -12,7 +12,8 @@ c Dario Estrin, 1992
       use garcha_mod
       use mathsubs
       use general_module
-      use faint_cpu77, only: int1, int2, intsol, int3mem, int3lu
+      use faint_cpu77, only: int2, intsol, int3mem, int3lu
+      use faint_cpu, only: int1
 #ifdef CUBLAS
       use cublasmath
 #endif
@@ -22,9 +23,9 @@ c
       integer:: l
        dimension q(natom),work(1000),IWORK(1000)
        REAL*8 , intent(inout)  :: dipxyz(3)
-       real*8, dimension (:,:), ALLOCATABLE::xnano,znano,scratch
-       real*8, dimension (:,:), ALLOCATABLE::scratch1
-       real*8, dimension (:), ALLOCATABLE :: rmm5,rmm15,rmm13,
+       real*8, dimension (:,:), allocatable::xnano,znano,scratch
+       real*8, dimension (:,:), allocatable::scratch1
+       real*8, dimension (:), allocatable :: rmm5,rmm15,rmm13,
      >   bcoef, suma
       real*8, dimension (:,:), allocatable :: fock,fockm,rho,!,FP_PF,
      >   FP_PFm,EMAT,Y,Ytrans,Xtrans,rho1,EMAT2,Xcpy
@@ -264,14 +265,14 @@ c            RMM(i)=(3*old1(i))-(3*old2(i))+(old3(i))
 c          enddo
 c         endif
        endif
-        
+
 c
 c Calculate 1e part of F here (kinetic/nuc in int1, MM point charges
 c in intsol)
 c
       call g2g_timer_sum_start('1-e Fock')
       call g2g_timer_sum_start('Nuclear attraction')
-      call int1(En)
+      call int1(En, RMM, Smat, Nuc, a, c, d, r, Iz, ncont, NORM, natom, M, Md)
       call g2g_timer_sum_stop('Nuclear attraction')
       if(nsol.gt.0.or.igpu.ge.4) then
           call g2g_timer_sum_start('QM/MM')
@@ -540,7 +541,7 @@ c
         call g2g_timer_sum_stop('TD')
         return
       endif
-c 
+c
 c Precalculate two-index (density basis) "G" matrix used in density fitting
 c here (S_ij in Dunlap, et al JCP 71(8) 1979) into RMM(M7)
 c Also, pre-calculate G^-1 if G is not ill-conditioned into RMM(M9)
@@ -567,7 +568,7 @@ c
 c Large elements of t_i put into double-precision cool here
 c Size criteria based on size of pre-factor in Gaussian Product Theorem
 c (applied to MO basis indices)
-         call int3mem() 
+         call int3mem()
 c Small elements of t_i put into single-precision cools here
          call g2g_timer_stop('int3mem')
          call g2g_timer_sum_stop('Coulomb precalc')
@@ -771,7 +772,7 @@ c-------------------------------------------------------------------------------
 c If we are not doing diis this iteration, apply damping to F, save this
 c F in RMM(M3) for next iteration's damping and put F' = X^T * F * X in RMM(M5)
 c-----------------------------------------------------------------------------------------
-        if(.not.hagodiis) then 
+        if(.not.hagodiis) then
           call g2g_timer_start('Fock damping')
           if(niter.ge.2) then
             do k=1,MM
@@ -858,7 +859,7 @@ c
             call cumfx(fock,DevPtrX,fock,M)
 #else
             fock=basechange_gemm(M,fock,x)
-#endif     
+#endif
           do j=1,M
              do k=1,j
                 RMM(M5+j+(M2-k)*(k-1)/2-1)=fock(j,k)
@@ -1275,7 +1276,7 @@ c       write(*,*) 'g2g-Exc',Exc
 #endif
         call g2g_timer_sum_stop('Exchange-correlation energy')
         ! -------------------------------------------------
-        ! Total SCF energy = 
+        ! Total SCF energy =
         ! E1 - kinetic+nuclear attraction+QM/MM interaction
         ! E2 - Coulomb
         ! En - nuclear-nuclear repulsion
@@ -1353,7 +1354,7 @@ c
        call g2g_timer_sum_start('Mulliken')
 ! MULLIKEN POPULATION ANALYSIS (FFR - Simplified)
 !--------------------------------------------------------------------!
-       call int1(En)
+       call int1(En, RMM, Smat, Nuc, a, c, d, r, Iz, ncont, NORM, natom, M, Md)
        call spunpack('L',M,RMM(M5),Smat)
        call spunpack('L',M,RMM(M1),RealRho)
        call fixrho(M,RealRho)

--- a/lioamber/faint_cpu/subm_int1.f90
+++ b/lioamber/faint_cpu/subm_int1.f90
@@ -23,7 +23,30 @@
 !      Input : basis function information
 !      Output: F matrix, and S matrix
 !
-!------------------------------------------------------------------------------!
+!-------------------------------------------------------------------------------
+!      INPUT AND OUTPUT VARIABLES
+!-------------------------------------------------------------------------------
+!
+!        Smat ............. Overlap matrix
+!        RMM .............. Vector containing many matrices. Only Fock and
+!                           overlap are used here.
+!        En ............... Electron-nucleus interaction.
+!        natom ............ Number of atoms
+!        d ................ Interatomic distances.
+!        r ................ Nuclear positions.
+!        a ................ Basis exponents.
+!        c ................ Basis coefficients.
+!        nshell ........... Number of basis functions per shell.
+!        Nuc(i) ........... Nucleus corresponding to basis function i.
+!        Iz(i) ............ Atomic number Z of nucleus i.
+!        ncount(i) ........ Number of contractions of bais function i.
+!        M ................ Number of basis functions.
+!        Md ............... Number of basis functions + auxiliary basis
+!                           functions.
+!        NORM ............. Deprecated. Boolean indicating normalization.
+!
+!-------------------------------------------------------------------------------
+
        use liotemp      , only: FUNCT
        use constants_mod, only: pi, pi32
        implicit none

--- a/lioamber/faint_cpu/subm_int1.f90
+++ b/lioamber/faint_cpu/subm_int1.f90
@@ -48,9 +48,9 @@
 
 
        integer :: natomold, igpu
-       integer :: n, i, j, k, ii, jj, ni, nj, iin
+       integer :: n, i, j, k, jj, ni, nj, iin
        integer :: l1, l2, l3, l4, l12, l34
-       integer :: MM, MMd, ns, np, nd
+       integer :: MM, MMd, ns, np
        integer :: M1, M2, M3, M5, M7, M9, M11
 
        double precision  :: E1, ovlap
@@ -64,7 +64,6 @@
        double precision  :: d0s, d0p, d1p, d1s, d2s
        double precision  :: t0, t1, t2
 
-       integer, allocatable, dimension(:) :: Iaux
        double precision , allocatable, dimension(:) :: s0s, s1s, s2s, s3s, s4s
 !
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
@@ -72,7 +71,6 @@
        allocate(s0s(natom),s1s(natom),s2s(natom))
        allocate(s3s(natom))
        allocate(s4s(natom))
-!       allocate(Iaux(natom))
        if (.not.allocated(Smat)) allocate(Smat(M,M))
 
 
@@ -84,7 +82,6 @@
 
       ns=nshell(0)
       np=nshell(1)
-      nd=nshell(2)
       MM=M*(M+1)/2
       MMd=Md*(Md+1)/2
       M2=2*M
@@ -218,7 +215,6 @@
               ovlap=t1*ss
               tn=t1*sks+alf2*ovlap
               iin=i+l2-1
-!            ii index , taking into account different components of the shell
 !
               k=iin+((M2-j)*(j-1))/2
               RMM(M5+k-1)=RMM(M5+k-1)+ovlap*ccoef
@@ -834,7 +830,6 @@
       enddo
 
       deallocate(s0s,s1s,s2s,s3s,s4s)
-!      deallocate(Iaux)
 
       if (igpu.gt.3) natom = natomold
       return;end subroutine

--- a/lioamber/faint_cpu/subm_int1.f90
+++ b/lioamber/faint_cpu/subm_int1.f90
@@ -24,27 +24,28 @@
 !      Output: F matrix, and S matrix
 !
 !------------------------------------------------------------------------------!
-       use liotemp   , only: FUNCT
-       use garcha_mod, only: nshell
+       use liotemp      , only: FUNCT
+       use garcha_mod   , only: nshell
        use constants_mod, only: pi, pi32
        implicit none
 
 !      Input quantities (ex-garchamod variables)
-        double precision, allocatable, intent(inout) :: RMM(:)
         double precision, allocatable, intent(inout) :: Smat(:,:)
-        double precision,              intent(inout) :: En
-        integer,                       intent(inout) :: natom
 
-        double precision, allocatable, intent(in) :: d(:,:)
-        double precision, intent(in) :: r(natom,3)
-        double precision, allocatable, intent(in) :: a(:,:)
-        double precision, allocatable, intent(in) :: c(:,:)
-        integer, intent(in) :: Nuc(M)
-        integer, intent(in) :: Iz(natom)
-        integer, allocatable, intent(in) :: ncont(:)
-        integer, intent(in) :: M
-        integer, intent(in) :: Md
-        logical, intent(in) :: NORM
+        double precision, intent(inout)              :: RMM(:)
+        double precision, intent(inout)              :: En
+        integer,          intent(inout)              :: natom
+
+        double precision, intent(in)                 :: d(:,:)
+        double precision, intent(in)                 :: r(natom,3)
+        double precision, intent(in)                 :: a(:,:)
+        double precision, intent(in)                 :: c(:,:)
+        integer,          intent(in)                 :: Nuc(M)
+        integer,          intent(in)                 :: Iz(natom)
+        integer,          intent(in)                 :: ncont(:)
+        integer,          intent(in)                 :: M
+        integer,          intent(in)                 :: Md
+        logical,          intent(in)                 :: NORM
 
 
        integer :: natomold, igpu
@@ -70,26 +71,11 @@
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
 !
        allocate(s0s(natom),s1s(natom),s2s(natom))
-!       allocate(s3s(natom),s4s(natom),Iaux(natom))
        allocate(s3s(natom))
        allocate(s4s(natom))
 !       allocate(Iaux(natom))
        if (.not.allocated(Smat)) allocate(Smat(M,M))
 
-!-------------------------------------------------------------------------------
-!      Distance between pairs of centers
-!      BSSE
-!-------------------------------------------------------------------------------
-!      Sets to 0 atomic charges, but since they are used to
-!      construct the grids, they are stored in an auxiliary array
-!
-!      if (BSSE) then
-!      do i=1,natom
-!       Iaux(i)=Iz(i)
-!       Iz(i)=Iz(i)*ighost(i)
-!      enddo
-!      endif
-!-------------------------------------------------------------------------------
 
       if (NORM) then
         sq3=sqrt(3.D0)
@@ -132,13 +118,7 @@
          RMM(M5+i-1)=0.D0
          RMM(M11+i-1)=0.D0
        enddo
-!
-!     do 50 i=1,natom
-!       do 50 j=1,natom
-!         d(i,j)=(r(i,1)-r(j,1))**2+(r(i,2)-r(j,2))**2+(r(i,3)-r(j,3))**2
-!       end do
-!     end do
-!
+
 ! Nuclear Repulsion part ------------------------------------------
       En=0.D0
       do i=1,natom
@@ -841,13 +821,6 @@
       end do ! ni
 
 !*******************************************************************************
-!--- Debugging and tests -----------------------------------------------
-!
-!     do 1 k=1,M*(M+1)/2
-!      write(*,*) k,RMM(M5+k-1),RMM(M11+k-1)
-! gradient debuggings
-!
-!*******************************************************************************
 
       E1=0.D0
       do k=1,MM
@@ -855,37 +828,12 @@
       end do
 
 !*******************************************************************************
-!
-!      write(*,*) 'E1+En =',E1+En
-!
-! BSSE ------------
-!      if (BSSE) then
-!        do i=1,natom
-!         Iz(i)=Iaux(i)
-!        enddo
-!      endif
-!
-!-- prueba ----------------
-!      En=En+0.0D0*(d(1,2)-2.89D0)**2
-!--------------------------
-!
-!     write(*,*) 'matriz overlap'
-!     do i=1,MM
-!      write(*,*) i,RMM(M5+i-1)
-!     enddo
-!     do i=1,natom
-!      write(*,*) i,r(i,1),r(i,2),r(i,3)
-!     enddo
-!     pause
-!*******************************************************************************
-
 !     Avoid double-counting diagonal elements.
       do i=1,M
         Smat(i,i)=Smat(i,i)/2
       enddo
 
       deallocate(s0s,s1s,s2s,s3s,s4s)
-!      deallocate(Iaux)
 
       if (igpu.gt.3) natom = natomold
       return;end subroutine

--- a/lioamber/faint_cpu/subm_int1.f90
+++ b/lioamber/faint_cpu/subm_int1.f90
@@ -1,7 +1,7 @@
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
       module subm_int1; contains
        subroutine int1(En, RMM, Smat, Nuc, a, c, d, r, Iz, ncont, NORM,&
-                       & natom, M, Md )
+                       & natom, M, Md, nshell )
 !------------------------------------------------------------------------------!
 !
 !      Integrals subroutine
@@ -25,13 +25,11 @@
 !
 !------------------------------------------------------------------------------!
        use liotemp      , only: FUNCT
-       use garcha_mod   , only: nshell
        use constants_mod, only: pi, pi32
        implicit none
 
 !      Input quantities (ex-garchamod variables)
         double precision, allocatable, intent(inout) :: Smat(:,:)
-
         double precision, intent(inout)              :: RMM(:)
         double precision, intent(inout)              :: En
         integer,          intent(inout)              :: natom
@@ -40,6 +38,7 @@
         double precision, intent(in)                 :: r(natom,3)
         double precision, intent(in)                 :: a(:,:)
         double precision, intent(in)                 :: c(:,:)
+        integer,          intent(in)                 :: nshell(0:4)
         integer,          intent(in)                 :: Nuc(M)
         integer,          intent(in)                 :: Iz(natom)
         integer,          intent(in)                 :: ncont(:)
@@ -828,12 +827,14 @@
       end do
 
 !*******************************************************************************
+
 !     Avoid double-counting diagonal elements.
       do i=1,M
         Smat(i,i)=Smat(i,i)/2
       enddo
 
       deallocate(s0s,s1s,s2s,s3s,s4s)
+!      deallocate(Iaux)
 
       if (igpu.gt.3) natom = natomold
       return;end subroutine

--- a/lioamber/faint_cpu/subm_int1.f90
+++ b/lioamber/faint_cpu/subm_int1.f90
@@ -1,7 +1,7 @@
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
       module subm_int1; contains
        subroutine int1(En, RMM, Smat, Nuc, a, c, d, r, Iz, ncont, NORM,&
-                       & natom, M, Md, nshell )
+                       & natom, M, Md, nshell,ntatom )
 !------------------------------------------------------------------------------!
 !
 !      Integrals subroutine
@@ -58,9 +58,10 @@
         integer,          intent(inout)              :: natom
 
         double precision, intent(in)                 :: d(:,:)
-        double precision, intent(in)                 :: r(natom,3)
+        double precision, intent(in)                 :: r(ntatom,3)
         double precision, intent(in)                 :: a(:,:)
         double precision, intent(in)                 :: c(:,:)
+        integer,          intent(in)                 :: ntatom
         integer,          intent(in)                 :: nshell(0:4)
         integer,          intent(in)                 :: Nuc(M)
         integer,          intent(in)                 :: Iz(natom)

--- a/lioamber/liomain.f90
+++ b/lioamber/liomain.f90
@@ -145,7 +145,7 @@ end subroutine do_dipole
 subroutine do_population_analysis()
    use garcha_mod, only : RMM, Smat, RealRho, M, Enucl, Nuc, Iz, natom, &
                           mulliken, lowdin, sqsm, a, c, d, r, Iz, ncont, NORM,&
-                          M, Md
+                          M, Md, nshell
    use ECP_mod   , only : ecpmode, IzECP
    use faint_cpu, only: int1
 
@@ -162,7 +162,7 @@ subroutine do_population_analysis()
 
    ! Decompresses and fixes S and RealRho matrixes, which are needed for
    ! population analysis.
-   call int1(Enucl,RMM,Smat,Nuc,a,c,d,r,Iz,ncont,NORM,natom,M,Md)
+   call int1(Enucl,RMM,Smat,Nuc,a,c,d,r,Iz,ncont,NORM,natom,M,Md,nshell)
    call spunpack('L',M,RMM(M5),Smat)
    call spunpack('L',M,RMM(M1),RealRho)
    call fixrho(M,RealRho)

--- a/lioamber/liomain.f90
+++ b/lioamber/liomain.f90
@@ -162,7 +162,7 @@ subroutine do_population_analysis()
 
    ! Decompresses and fixes S and RealRho matrixes, which are needed for
    ! population analysis.
-   call int1(Enucl,RMM,Smat,Nuc,a,c,d,r,Iz,ncont,NORM,natom,M,Md,nshell)
+   call int1(Enucl,RMM,Smat,Nuc,a,c,d,r,Iz,ncont,NORM,natom,M,Md,nshell,ntatom)
    call spunpack('L',M,RMM(M5),Smat)
    call spunpack('L',M,RMM(M1),RealRho)
    call fixrho(M,RealRho)

--- a/lioamber/liomain.f90
+++ b/lioamber/liomain.f90
@@ -145,7 +145,7 @@ end subroutine do_dipole
 subroutine do_population_analysis()
    use garcha_mod, only : RMM, Smat, RealRho, M, Enucl, Nuc, Iz, natom, &
                           mulliken, lowdin, sqsm, a, c, d, r, Iz, ncont, NORM,&
-                          M, Md, nshell
+                          M, Md, nshell,ntatom
    use ECP_mod   , only : ecpmode, IzECP
    use faint_cpu, only: int1
 


### PR DESCRIPTION
Solved the following issues:
    Variable nshell was still called from garcha_mod.
    Variables a, r, c, d, RMM, Smat and ncont had their size set already, they should not be declared as allocatable. They are now properly declared.
    Commented out code should was removed.
    Heavy variable cleanup done.
    Improved documentation, providing a short explanation for inputs and outputs.
