### PR TITLE
Fixing lowdin charges

### DIFF
--- a/lioamber/Makefile.depends
+++ b/lioamber/Makefile.depends
@@ -285,7 +285,7 @@ SRCDIRS += typedef_sop
 OBJECTS += typedef_sop.o
 #
 modusrs :=
-modusrs += SCF.o
+modusrs += SCF.o properties.o
 $(modusrs:%.o=$(OBJPATH)/%.o) : ${OBJPATH}/typedef_sop.mod
 ################################################################################
 include typedef_operator/typedef_operator.mk

--- a/lioamber/SCF.f90
+++ b/lioamber/SCF.f90
@@ -411,19 +411,18 @@ subroutine SCF(E)
            RMM(M13+kk-1) = Dvec(kk)
         end do
 
-!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%tmp!
 !
 !
 !  Fockbias setup
         if ( allocated(sqsmat) ) deallocate(sqsmat)
         if ( allocated(tmpmat) ) deallocate(tmpmat)
         allocate( sqsmat(M,M), tmpmat(M,M) )
-        !tmpmat and sqsmat should probably be equal on output
+        !tmpmat and sqsmat should probably be equal on output, 
+        !but for some reason they are not...?
         call overop%Gets_orthog_2m( 2, 0.0d0, tmpmat, sqsmat )
-        write(*,*) "tmpmat is", tmpmat
-        write(*,*) "sqsmat is", sqsmat
         call fockbias_loads( natom, nuc )
-        call fockbias_setmat( sqsmat )
+        call fockbias_setmat( sqsmat  )
         deallocate( sqsmat, tmpmat )
 
 

--- a/lioamber/SCF.f90
+++ b/lioamber/SCF.f90
@@ -418,9 +418,12 @@ subroutine SCF(E)
         if ( allocated(sqsmat) ) deallocate(sqsmat)
         if ( allocated(tmpmat) ) deallocate(tmpmat)
         allocate( sqsmat(M,M), tmpmat(M,M) )
-        call overop%Gets_orthog_2m( 3, 0.0d0, tmpmat, sqsmat )
+        !tmpmat and sqsmat should probably be equal on output
+        call overop%Gets_orthog_2m( 2, 0.0d0, tmpmat, sqsmat )
+        write(*,*) "tmpmat is", tmpmat
+        write(*,*) "sqsmat is", sqsmat
         call fockbias_loads( natom, nuc )
-        call fockbias_setmat( tmpmat )
+        call fockbias_setmat( sqsmat )
         deallocate( sqsmat, tmpmat )
 
 

--- a/lioamber/SCF.f90
+++ b/lioamber/SCF.f90
@@ -386,13 +386,7 @@ subroutine SCF(E)
         allocate(Xmat(M_in,M_in), Ymat(M_in,M_in))
 
         call overop%Sets_smat( Smat )
-        if (lowdin) then
-!          TODO: inputs insuficient; there is also the symetric orthog using
-!                3 instead of 2 or 1. Use integer for onbasis_id
-           call overop%Gets_orthog_4m( 2, 0.0d0, X_min, Y_min, X_min_trans, Y_min_trans)
-        else
-           call overop%Gets_orthog_4m( 1, 0.0d0, X_min, Y_min, X_min_trans, Y_min_trans)
-        end if
+        call overop%Gets_orthog_4m( 1, 0.0d0, X_min, Y_min, X_min_trans, Y_min_trans)
 
 ! TODO: replace X,Y,Xtrans,Ytrans with Xmat, Ymat, Xtrp, Ytrp
 !        do ii=1,M

--- a/lioamber/SCF.f90
+++ b/lioamber/SCF.f90
@@ -386,7 +386,13 @@ subroutine SCF(E)
         allocate(Xmat(M_in,M_in), Ymat(M_in,M_in))
 
         call overop%Sets_smat( Smat )
-        call overop%Gets_orthog_4m( 1, 0.0d0, X_min, Y_min, X_min_trans, Y_min_trans)
+        if (lowdin) then
+!          TODO: inputs insuficient; there is also the symetric orthog using
+!                3 instead of 2 or 1. Use integer for onbasis_id
+           call overop%Gets_orthog_4m( 2, 0.0d0, X_min, Y_min, X_min_trans, Y_min_trans)
+        else
+           call overop%Gets_orthog_4m( 1, 0.0d0, X_min, Y_min, X_min_trans, Y_min_trans)
+        end if
 
 ! TODO: replace X,Y,Xtrans,Ytrans with Xmat, Ymat, Xtrp, Ytrp
 !        do ii=1,M

--- a/lioamber/SCF.f90
+++ b/lioamber/SCF.f90
@@ -411,15 +411,13 @@ subroutine SCF(E)
            RMM(M13+kk-1) = Dvec(kk)
         end do
 
-!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%tmp!
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
 !
 !
 !  Fockbias setup
         if ( allocated(sqsmat) ) deallocate(sqsmat)
         if ( allocated(tmpmat) ) deallocate(tmpmat)
         allocate( sqsmat(M,M), tmpmat(M,M) )
-        !tmpmat and sqsmat should probably be equal on output, 
-        !but for some reason they are not...?
         call overop%Gets_orthog_2m( 2, 0.0d0, tmpmat, sqsmat )
         call fockbias_loads( natom, nuc )
         call fockbias_setmat( sqsmat  )

--- a/lioamber/drive.f90
+++ b/lioamber/drive.f90
@@ -14,12 +14,12 @@
       nuc, ncont, nlb, nshelld, cd, ad, Nucd, ncontd, nld, Nucx, indexii,      &
       ncontx, cx, ax, indexiid, X, XX, RMM, rhoalpha,rhobeta, af,              &
       basis_set, fitting_set, dens, e_, e_2, e3, exists, NORM, fcoord,   &
-      fmulliken, natom, frestart, M, FAC, Iexch, int_basis, max_func, integ,   &
+      natom, frestart, M, FAC, Iexch, int_basis, max_func, integ,   &
       frestartin, Md, NCO, nng, npas, Nr, used, STR, omit_bas, Nr2,   &
       wang, wang2, wang3, VCINP, OPEN, OPEN1, whatis, Num, Iz, pi,             &
       Rm2, rqm, rmax, Nunp, nl, nt, ng, ngd, restart_freq,             &
       writexyz, number_restr, restr_pairs,restr_index,restr_k,restr_w,restr_r0,&
-      mulliken, MO_coef_at, MO_coef_at_b
+      MO_coef_at, MO_coef_at_b
 
       USE ECP_mod, ONLY : ecpmode, asignacion
       USE fileio , ONLY : read_coef_restart
@@ -106,7 +106,6 @@
       endif
 
       if (writexyz) open(unit=18,file=fcoord)
-      if (mulliken) open(unit=85,file=fmulliken)
       if (restart_freq.gt.0) open(unit=88,file=frestart)
 
 !-------------------------------------------------------

--- a/lioamber/ehrensubs/ehrentest_SCF.f90
+++ b/lioamber/ehrensubs/ehrentest_SCF.f90
@@ -1442,6 +1442,9 @@ c
 !       do kk=1,natom
 !         q(kk)=real(Iz(kk))
 !       enddo
+!       smat is not in this subroutine, but if this ever gets
+!       commented out then smat should be fed to lowdin_calc
+!       instead of sqsm
 !       call lowdin_calc(natom,M,RealRho,sqsm,Nuc,q)
 !       call mulliken_write(85,natom,Iz,q)
        endif

--- a/lioamber/ehrensubs/ehrentest_SCF.f90
+++ b/lioamber/ehrensubs/ehrentest_SCF.f90
@@ -1442,7 +1442,7 @@ c
 !       do kk=1,natom
 !         q(kk)=real(Iz(kk))
 !       enddo
-!       call lowdinpop(M,natom,RealRho,sqsm,Nuc,q)
+!       call lowdin_calc(M,natom,RealRho,sqsm,Nuc,q)
 !       call mulliken_write(85,natom,Iz,q)
        endif
 

--- a/lioamber/ehrensubs/ehrentest_SCF.f90
+++ b/lioamber/ehrensubs/ehrentest_SCF.f90
@@ -1442,7 +1442,7 @@ c
 !       do kk=1,natom
 !         q(kk)=real(Iz(kk))
 !       enddo
-!       call lowdin_calc(M,natom,RealRho,sqsm,Nuc,q)
+!       call lowdin_calc(natom,M,RealRho,sqsm,Nuc,q)
 !       call mulliken_write(85,natom,Iz,q)
        endif
 

--- a/lioamber/fterm_biaspot.f90
+++ b/lioamber/fterm_biaspot.f90
@@ -1,6 +1,7 @@
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
 !%% FTERM_BIASPOT.F90 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
 ! TO-DO: EXPLANATION.
+! This subroutine is used by the ehrenfest module only
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
 subroutine fterm_biaspot(M,sqsmat,vector,weight,outmat)
     implicit none

--- a/lioamber/init_lio.f90
+++ b/lioamber/init_lio.f90
@@ -43,8 +43,8 @@ subroutine lio_defaults()
     implicit none
 
 !   Names of files used for input and output.
-    basis          = 'basis'       ; output             = 'output'      ;
-    fpopulation      = 'population_analysis'    ; fcoord             = 'qm.xyz'      ;
+    basis          = 'basis'                ; output        = 'output'      ;
+    fpopulation    = 'population_analysis'  ; fcoord        = 'qm.xyz'      ;
 
 !   Theory level options.
     OPEN           = .false.       ; told               = 1.0D-6        ;

--- a/lioamber/init_lio.f90
+++ b/lioamber/init_lio.f90
@@ -16,7 +16,7 @@
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
 subroutine lio_defaults()
 
-    use garcha_mod, only : basis, output, fmulliken, fcoord, OPEN, NMAX,       &
+    use garcha_mod, only : basis, output, fpopulation, fcoord, OPEN, NMAX,       &
                            basis_set, fitting_set, int_basis, DIIS, ndiis,     &
                            GOLD, told, Etold, hybrid_converg, good_cut, rmax,  &
                            rmaxs, omit_bas, propagator, NBCH, VCINP,           &
@@ -44,7 +44,7 @@ subroutine lio_defaults()
 
 !   Names of files used for input and output.
     basis          = 'basis'       ; output             = 'output'      ;
-    fmulliken      = 'mulliken'    ; fcoord             = 'qm.xyz'      ;
+    fpopulation      = 'population_analysis'    ; fcoord             = 'qm.xyz'      ;
 
 !   Theory level options.
     OPEN           = .false.       ; told               = 1.0D-6        ;
@@ -131,7 +131,8 @@ subroutine init_lio_common(natomin, Izin, nclatom, callfrom)
                            remove_zero_weights, min_points_per_cube,           &
                            max_function_exponent, sphere_radius, M,Fock_Hcore, &
                            Fock_Overlap, P_density, OPEN, timers, MO_coef_at,  &
-                           MO_coef_at_b, RMM_save, charge
+                           MO_coef_at_b, RMM_save, charge, mulliken, lowdin,   &
+                           fpopulation
     use ECP_mod,    only : Cnorm, ecpmode
     use field_data, only : chrg_sq
     use fileio    , only : lio_logo
@@ -207,6 +208,7 @@ subroutine init_lio_common(natomin, Izin, nclatom, callfrom)
 
     ! Prints chosen options to output.
     call drive(ng2, ngDyn, ngdDyn)
+    if (mulliken .or. lowdin) open(unit=85,file=fpopulation)
 
     ! reemplazos de RMM
     MM=M*(M+1)/2
@@ -257,7 +259,7 @@ end subroutine init_lio_gromacs
 ! officialy updated on the AMBER side, only some variables are received.       !
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
 subroutine init_lio_amber(natomin, Izin, nclatom, charge_i, basis_i            &
-           , output_i, fcoord_i, fmulliken_i, frestart_i, frestartin_i         &
+           , output_i, fcoord_i, fpopulation_i, frestart_i, frestartin_i         &
            , verbose_i, OPEN_i, NMAX_i, NUNP_i, VCINP_i, GOLD_i, told_i        &
            , rmax_i, rmaxs_i, predcoef_i, idip_i, writexyz_i                   &
            , intsoldouble_i, DIIS_i, ndiis_i, dgtrig_i, Iexch_i, integ_i       &
@@ -266,7 +268,7 @@ subroutine init_lio_amber(natomin, Izin, nclatom, charge_i, basis_i            &
            , Fz_i, NBCH_i, propagator_i, writedens_i, tdrestart_i              &
            )
 
-    use garcha_mod, only : basis, output, fmulliken, fcoord, OPEN, NMAX,     &
+    use garcha_mod, only : basis, output, fpopulation, fcoord, OPEN, NMAX,     &
                            basis_set, fitting_set, int_basis, DIIS, ndiis,   &
                            GOLD, told, Etold, hybrid_converg, good_cut,      &
                            rmax, rmaxs, omit_bas, propagator, NBCH,          &
@@ -287,7 +289,7 @@ subroutine init_lio_amber(natomin, Izin, nclatom, charge_i, basis_i            &
 
     implicit none
     integer , intent(in) :: charge_i, nclatom, natomin, Izin(natomin)
-    character(len=20) :: basis_i, output_i, fcoord_i, fmulliken_i, frestart_i, &
+    character(len=20) :: basis_i, output_i, fcoord_i, fpopulation_i, frestart_i, &
                          frestartin_i, inputFile
     logical           :: verbose_i, OPEN_i, VCINP_i, predcoef_i, writexyz_i,   &
                          intsoldouble_i, DIIS_i, integ_i, DENS_i, field_i,     &
@@ -306,7 +308,7 @@ subroutine init_lio_amber(natomin, Izin, nclatom, charge_i, basis_i            &
     call read_options(inputFile)
 
     basis          = basis_i        ; output        = output_i       ;
-    fcoord         = fcoord_i       ; fmulliken     = fmulliken_i    ;
+    fcoord         = fcoord_i       ; fpopulation     = fpopulation_i    ;
     frestart       = frestart_i     ; frestartin    = frestartin_i   ;
     OPEN           = OPEN_i         ;
     NMAX           = NMAX_i         ; NUNP          = NUNP_i         ;
@@ -343,7 +345,7 @@ end subroutine init_lio_amber
 ! Performs LIO variable initialization.                                        !
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
 subroutine init_lioamber_ehren(natomin, Izin, nclatom, charge_i, basis_i       &
-           , output_i, fcoord_i, fmulliken_i, frestart_i, frestartin_i         &
+           , output_i, fcoord_i, fpopulation_i, frestart_i, frestartin_i         &
            , verbose_i, OPEN_i, NMAX_i, NUNP_i, VCINP_i, GOLD_i, told_i        &
            , rmax_i, rmaxs_i, predcoef_i, idip_i, writexyz_i                   &
            , intsoldouble_i, DIIS_i, ndiis_i, dgtrig_i, Iexch_i, integ_i       &
@@ -366,7 +368,7 @@ subroutine init_lioamber_ehren(natomin, Izin, nclatom, charge_i, basis_i       &
    implicit none
    integer, intent(in) :: charge_i, nclatom, natomin, Izin(natomin)
 
-   character(len=20) :: basis_i, output_i, fcoord_i, fmulliken_i, frestart_i   &
+   character(len=20) :: basis_i, output_i, fcoord_i, fpopulation_i, frestart_i   &
                      &, frestartin_i, inputFile
 
    logical :: verbose_i, OPEN_i, VCINP_i, predcoef_i, writexyz_i, DIIS_i       &
@@ -381,7 +383,7 @@ subroutine init_lioamber_ehren(natomin, Izin, nclatom, charge_i, basis_i       &
 
 
    call init_lio_amber(natomin, Izin, nclatom, charge_i, basis_i               &
-           , output_i, fcoord_i, fmulliken_i, frestart_i, frestartin_i         &
+           , output_i, fcoord_i, fpopulation_i, frestart_i, frestartin_i         &
            , verbose_i, OPEN_i, NMAX_i, NUNP_i, VCINP_i, GOLD_i, told_i        &
            , rmax_i, rmaxs_i, predcoef_i, idip_i, writexyz_i                   &
            , intsoldouble_i, DIIS_i, ndiis_i, dgtrig_i, Iexch_i, integ_i       &

--- a/lioamber/liomain.f90
+++ b/lioamber/liomain.f90
@@ -180,8 +180,8 @@ subroutine do_population_analysis()
    ! Performs Löwdin Population Analysis if required.
    if (lowdin) then
        call g2g_timer_start('Lowdin')
-       call lowdin_calc(M, natom, RealRho, sqsm, Nuc, q)
        call write_population(natom, Iz, q, 1, 85)
+       call lowdin_calc(natom, M, RealRho, sqsm, Nuc, q)
        call g2g_timer_stop('Lowdin')
    endif
 

--- a/lioamber/liomain.f90
+++ b/lioamber/liomain.f90
@@ -188,6 +188,10 @@ subroutine do_population_analysis()
        call g2g_timer_start('Lowdin')
        call write_population(natom, Iz, q, 1, 85)
        call lowdin_calc(natom, M, RealRho, sqsm, Nuc, q)
+<<<<<<< HEAD
+=======
+       call write_population(85, natom, Iz, q, 1)
+>>>>>>> while trying to fix lowdin charges came across the routine Get_orthog_2m and commented some stuff on it to make somewhat clearer what it does at a glance
        call g2g_timer_stop('Lowdin')
        q=0.0
    endif

--- a/lioamber/liomain.f90
+++ b/lioamber/liomain.f90
@@ -187,11 +187,7 @@ subroutine do_population_analysis()
        enddo
        call g2g_timer_start('Lowdin')
        call write_population(natom, Iz, q, 1, 85)
-       call lowdin_calc(natom, M, RealRho, sqsm, Nuc, q)
-<<<<<<< HEAD
-=======
-       call write_population(85, natom, Iz, q, 1)
->>>>>>> while trying to fix lowdin charges came across the routine Get_orthog_2m and commented some stuff on it to make somewhat clearer what it does at a glance
+       call lowdin_calc(natom, M, RealRho, smat, Nuc, q)
        call g2g_timer_stop('Lowdin')
        q=0.0
    endif

--- a/lioamber/liomain.f90
+++ b/lioamber/liomain.f90
@@ -186,8 +186,8 @@ subroutine do_population_analysis()
            q(kk) = real(IzUsed(kk))
        enddo
        call g2g_timer_start('Lowdin')
-       call write_population(natom, Iz, q, 1, 85)
        call lowdin_calc(natom, M, RealRho, smat, Nuc, q)
+       call write_population(natom, Iz, q, 1, 85)
        call g2g_timer_stop('Lowdin')
        q=0.0
    endif

--- a/lioamber/liomain.f90
+++ b/lioamber/liomain.f90
@@ -150,6 +150,9 @@ subroutine do_population_analysis()
    implicit none
    integer :: M1, M5, IzUsed(natom), kk
    real*8  :: q(natom)
+   !initializes q to 0, after performing each analysis q is reset to 0
+   !to prevent side effects
+   q=0.0
 
    ! Needed until we dispose of RMM.
    M1=1 ; M5=1+M*(M+1)
@@ -165,24 +168,28 @@ subroutine do_population_analysis()
    call spunpack('L',M,RMM(M1),RealRho)
    call fixrho(M,RealRho)
 
-   do kk=1,natom
-       q(kk) = real(IzUsed(kk))
-   enddo
-
    ! Performs Mulliken Population Analysis if required.
    if (mulliken) then
+       do kk=1,natom
+           q(kk) = real(IzUsed(kk))
+       enddo
        call g2g_timer_start('Mulliken')
        call mulliken_calc(natom, M, RealRho, Smat, Nuc, q)
        call write_population(natom, Iz, q, 0, 85)
        call g2g_timer_stop('Mulliken')
+       q=0.0
    endif
 
    ! Performs Löwdin Population Analysis if required.
    if (lowdin) then
+       do kk=1,natom
+           q(kk) = real(IzUsed(kk))
+       enddo
        call g2g_timer_start('Lowdin')
        call write_population(natom, Iz, q, 1, 85)
        call lowdin_calc(natom, M, RealRho, sqsm, Nuc, q)
        call g2g_timer_stop('Lowdin')
+       q=0.0
    endif
 
    return

--- a/lioamber/liomods/garcha_mod.f
+++ b/lioamber/liomods/garcha_mod.f
@@ -14,7 +14,7 @@
       character*20 basis,whatis,stdbas
       character*40 basis_set, fitting_set
       logical int_basis
-      character*20 output,fcoord,fmulliken,frestart,frestartin,solv,
+      character*20 output,fcoord,fpopulation,frestart,frestartin,solv,
      > solv2
       character*4 ctype
       logical exists,MEMO,predcoef

--- a/lioamber/lionml_data.f90
+++ b/lioamber/lionml_data.f90
@@ -2,7 +2,7 @@
 !
 module lionml_data
 
-   use garcha_mod        , only: natom, nsol, basis, output, fmulliken, fcoord,&
+   use garcha_mod        , only: natom, nsol, basis, output, fpopulation, fcoord,&
                                  OPEN, NMAX, basis_set, fitting_set, int_basis,&
                                  DIIS, ndiis, GOLD, told, Etold, good_cut,     &
                                  hybrid_converg, rmax, rmaxs, omit_bas, NBCH,  &

--- a/lioamber/properties.f90
+++ b/lioamber/properties.f90
@@ -113,6 +113,8 @@ subroutine lowdin_calc(N, M, rhomat, sqsmat, atm_of_bfunc, partial_q)
     do k=1, M
         do i=1, M
             do j=1, M
+            write(*,*) "rhomat is", rhomat
+            write(*,*) "sqsmat is", sqsmat
                 bfunc_pop = sqsmat(k, i) * rhomat(i, j) * sqsmat(j, k)
                 partial_q(atm_of_bfunc(k)) = partial_q(atm_of_bfunc(k)) - bfunc_pop
             enddo

--- a/lioamber/properties.f90
+++ b/lioamber/properties.f90
@@ -87,6 +87,7 @@ subroutine mulliken_calc(N, M, rhomat, smat, atm_of_bfunc, partial_q)
 
     integer :: i, j, k
     real*8  :: bfunc_pop
+    bfunc_pop=0
     do i=1,M
         do j=1,M
              bfunc_pop = rhomat(i, j) * smat(i, j)
@@ -100,27 +101,34 @@ end subroutine mulliken_calc
 !%% LOWDIN_CALC %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
 ! Performs a Löwdin Population Analysis and outputs atomic charges.            !
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
-subroutine lowdin_calc(N, M, rhomat, sqsmat, atm_of_bfunc, partial_q)
- 
+subroutine lowdin_calc(N, M, rhomat, smat, atm_of_bfunc, partial_q)
+    !sqsmat is built directly inside lowdin_calc since sqsmat is not really built anywhere
+    !in the program. 
+    use typedef_sop, only: sop 
     implicit none
     integer,intent(in)   :: N, M, atm_of_bfunc(M)
-    real*8,intent(in)    :: rhomat(M,M), sqsmat(M,M)
+    real*8,intent(in)    :: rhomat(M,M), smat(M,M)
     real*8,intent(inout) :: partial_q(N)
-
+    
     real*8  :: bfunc_pop
     integer :: i, j, k
+    type(sop) :: overop
+    real*8 :: tmpmat(M,M), sqsmat(M,M)
+
+    bfunc_pop=0
+    tmpmat=0
+    sqsmat=0
+    call overop%Sets_smat(smat)
+    call overop%Gets_orthog_2m( 2, 0.0d0, tmpmat, sqsmat )
 
     do k=1, M
         do i=1, M
             do j=1, M
-            write(*,*) "rhomat is", rhomat
-            write(*,*) "sqsmat is", sqsmat
                 bfunc_pop = sqsmat(k, i) * rhomat(i, j) * sqsmat(j, k)
                 partial_q(atm_of_bfunc(k)) = partial_q(atm_of_bfunc(k)) - bfunc_pop
             enddo
         enddo
     enddo
-
     return
 end subroutine lowdin_calc
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!

--- a/lioamber/properties.f90
+++ b/lioamber/properties.f90
@@ -74,23 +74,23 @@ end subroutine get_degeneration
 !%% MULLIKEN_CALC %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
 ! Performs a Mulliken Population Analysis and outputs atomic charges.          !
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
-subroutine mulliken_calc(N, M, RealRho, Smat, NofM, q)
+subroutine mulliken_calc(N, M, rhomat, smat, atm_of_bfunc, partial_q)
 
     ! RealRho         : Rho written in atomic orbitals.                !
-    ! q               : Starting and final Mulliken charges.           !
-    ! M, N, NofM, Smat: N° of basis functions, atoms, Nuclei belonging !
+    ! partial_q       : Starting and final Mulliken charges.           !
+    ! M, N, atm_of_bfunc, Smat: N° of basis functions, atoms, Nuclei belonging !
     !                   to each function M, overlap matrix.            !
     implicit none
-    integer, intent(in)  :: N, M, NofM(M)
-    real*8 , intent(in)  :: RealRho(M,M), Smat(M,M)
-    real*8 , intent(inout) :: q(N)
+    integer, intent(in)  :: N, M, atm_of_bfunc(M)
+    real*8 , intent(in)  :: rhomat(M,M), smat(M,M)
+    real*8 , intent(inout) :: partial_q(N)
 
     integer :: i, j, k
-    real*8  :: qe
+    real*8  :: bfunc_pop
     do i=1,M
         do j=1,M
-             qe = RealRho(i, j) * Smat(i, j)
-             q(NofM(i)) = q(NofM(i)) - qe
+             bfunc_pop = rhomat(i, j) * smat(i, j)
+             partial_q(atm_of_bfunc(i)) = partial_q(atm_of_bfunc(i)) - bfunc_pop
         enddo
     enddo
     return
@@ -100,23 +100,21 @@ end subroutine mulliken_calc
 !%% LOWDIN_CALC %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
 ! Performs a Löwdin Population Analysis and outputs atomic charges.            !
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
-subroutine lowdin_calc(M, N, rhomat, sqsmat, atomorb, atomicq)
+subroutine lowdin_calc(N, M, rhomat, sqsmat, atm_of_bfunc, partial_q)
  
     implicit none
-    integer,intent(in)   :: M, N, atomorb(M)
+    integer,intent(in)   :: N, M, atm_of_bfunc(M)
     real*8,intent(in)    :: rhomat(M,M), sqsmat(M,M)
-    real*8,intent(inout) :: atomicq(N)
+    real*8,intent(inout) :: partial_q(N)
 
-    real*8  :: newterm
-    integer :: natom
+    real*8  :: bfunc_pop
     integer :: i, j, k
 
     do k=1, M
-        natom=atomorb(k)
         do i=1, M
             do j=1, M
-                newterm = sqsmat(k, i) * rhomat(i, j) * sqsmat(j, k)
-                atomicq(natom) = atomicq(natom) - newterm
+                bfunc_pop = sqsmat(k, i) * rhomat(i, j) * sqsmat(j, k)
+                partial_q(atm_of_bfunc(k)) = partial_q(atm_of_bfunc(k)) - bfunc_pop
             enddo
         enddo
     enddo

--- a/lioamber/transport.f90
+++ b/lioamber/transport.f90
@@ -447,8 +447,8 @@ subroutine drive_population(M, dim3, natom, Nuc, Iz, rho1, overlap, smat,      &
          if (OPEN) call mulliken_calc(natom, M, rho(:,:,2), overlap, Nuc,      &
                                       q)
       case (2)
-         call lowdin_calc(M, natom, rho(:,:,1), smat, Nuc, q)
-         if (OPEN) call lowdin_calc(M, natom, rho(:,:,2), smat, Nuc, q)
+         call lowdin_calc(natom, M, rho(:,:,1), smat, Nuc, q)
+         if (OPEN) call lowdin_calc(natom, M, rho(:,:,2), smat, Nuc, q)
       case default
          write(*,*) "ERROR - Transport: Wrong value for Pop (drive_population)."
          stop

--- a/lioamber/typedef_sop/Gets_orthog_2m.f90
+++ b/lioamber/typedef_sop/Gets_orthog_2m.f90
@@ -1,5 +1,8 @@
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
 subroutine Gets_orthog_2m( this, method_id, maxval_ld, Xmat, Ymat )
+!This subroutine decomposes a matrix into TWO matrices using three different 
+!possible methods given by method_id. Cholesky decomposition, 
+!symetric orthogonalization and canonical orthogonalization are supported.
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
 
    use liosubs_math, only: purge_zeros_m, matmul3

--- a/lioamber/utests/test-properties.f90
+++ b/lioamber/utests/test-properties.f90
@@ -97,6 +97,7 @@ subroutine test_mulliken()
 end subroutine test_mulliken
 
 subroutine test_lowdin()
+    !this test should be redone and smat should be fed to lowdin charges
     implicit none
     real*8       :: Rho(2,2),SQS(2,2), outVec(2), criteria
     character*20 :: testResult

--- a/lioamber/utests/test-properties.f90
+++ b/lioamber/utests/test-properties.f90
@@ -164,7 +164,7 @@ subroutine test_lowdin()
     outVec(:)  = 0.0d0
     testResult = "FAILED"
 
-    call lowdin_calc(1, 2, Rho, SQS, atomOrb, outVec)
+    call lowdin_calc(2, 1, Rho, SQS, atomOrb, outVec)
     testCond = (abs(outVec(1)+8) < criteria).and.(abs(outVec(2)) < criteria) 
     if (testCond) testResult = "PASSED"
     write(*,*) testResult, ' - Usage of a single orbital.'


### PR DESCRIPTION
This is an actual PR! =) I am not yet totally sure of how to rebase so I just made the PR directly, there are not that many changes so it will most likely not be a problem. 
This pull request fixes issue #224:

1) **The lowdin_calc subroutine was not working properly when one asked fot lowdin charges and/or mulliken charges on a SP calculation**. When you asked for both LIO would spit out mulliken charges for both. When you asked only for lowdin charges lio would spit out atomic numbers (dumb LIO). 

The reason for this was twofold: first, lowdin_calc was being fed the output partial charges q after a mulliken calculation had been made. Second, lowdin_calc eats sqsmat (the square root of the overlap matrix), but sqsmat was allocated and then subsequently deallocated in the SCF subroutine. Lowdin_calc was therefore being fed zeroes and did nothing with the charges it was input with. 

2) **The lowdin_calc subroutine inside transport was also not working properly.**

The reason for this was that transport subroutine called lowdin_calc but fed it with the overlap matrix instead of sqsmat, and as a consequence the lowdin charges obtained in a transport calculation were rubbish. 

In order to fix this I first reset the partial charges in between mulliken and lowdin calculations in liomain and I also edited lowdin_calc so that it is fed smat and it calculates sqsmat internally. I preferred to do this instead of feeding it with sqsmat directly because **sqsmat is not really calculated anywhere in the program** except when using it for the fockbias subroutines, and I was worried that smat could change dynamically at some point since as far as I could see it is global state. I am not terribly familiar with the TD and steepest descent subroutines, and I was kind of scared that the overlap matrix could change at runtime there and as a consecuence sqsmat should be updated. By feeding it with smat we are certain that we are always using the most up-to-date info. 

If this is not the case and we can ALWAYS think of the overlap matrix as a global constant then it would be more efficient to calculate sqsmat and leave it as a global constant too, then I can modify that quickly. In any case the current way to do it is probably not so bad since I am only building sqsmat everytime lowdin_calc is called, which is hopefully not that often (it perhaps is called often during transport?).

As a side effect of feeding lowdin_calc smat the utests for lowdin_calc are now not working. I don't really know how to fix this because I don't understand them properly, so I will leave that to somebody else =)

**At least Lowdin charges are working properly after these changes.**