### PR TITLE
Atoms rising from the Grave

### DIFF
--- a/g2g/analytic_integral/aint_init.cpp
+++ b/g2g/analytic_integral/aint_init.cpp
@@ -45,7 +45,7 @@ extern "C" void aint_parameter_init_(const unsigned int& Md,
                                      double* ad, unsigned int* Nucd, double* af,
                                      double* RMM, const unsigned int& M9,
                                      const unsigned int& M11, double* str,
-                                     double* fac, double& rmax) {
+                                     double* fac, double& rmax, uint* atomZ_i) {
   /* DENSITY BASIS SET */
   integral_vars.s_funcs_dens = nshelld[0];
   integral_vars.p_funcs_dens = nshelld[1] / 3;
@@ -115,6 +115,11 @@ extern "C" void aint_parameter_init_(const unsigned int& Md,
   // Maximum Gaussian argument used as basis function overlap cut-off (Coulomb
   // and QM/MM)
   integral_vars.rmax = rmax;
+  // Atomic number for each atom. It is NOT the atom type, since Ghost Atoms
+  // (basis placed but Z=0) may be used.
+
+  integral_vars.atom_Z =
+      G2G::FortranMatrix<uint>(atomZ_i, G2G::fortran_vars.atoms, 1, 1);
 
 #if GPU_KERNELS
   os_integral.load_params();

--- a/g2g/analytic_integral/aint_init.h
+++ b/g2g/analytic_integral/aint_init.h
@@ -11,6 +11,7 @@ struct FortranVars {
   /* ---DENSITY BASIS--- */
   uint gaussians_dens, s_gaussians_dens, p_gaussians_dens;
   uint s_funcs_dens, p_funcs_dens, d_funcs_dens, spd_funcs_dens, m_dens;
+  G2G::FortranMatrix<uint> atom_Z;
   G2G::FortranMatrix<uint> nucleii_dens, contractions_dens;
   G2G::FortranMatrix<double> a_values_dens, c_values_dens;
   G2G::FortranMatrix<double> af_input_ndens1;

--- a/g2g/analytic_integral/cuda/gpu_vars/os_gpu_variables.h
+++ b/g2g/analytic_integral/cuda/gpu_vars/os_gpu_variables.h
@@ -20,5 +20,6 @@ extern __device__ __constant__ uint TERM_TYPE_GAUSSIANS[6];  // How many
                                                              // (s-s,etc) is
                                                              // calculating
 extern __device__ __constant__ uint gpu_atom_types[MAX_ATOMS];
+extern __device__ __constant__ uint gpu_atom_Z[MAX_ATOMS];
 
 #endif

--- a/g2g/analytic_integral/cuda/kernels/qmmm_energy.h
+++ b/g2g/analytic_integral/cuda/kernels/qmmm_energy.h
@@ -149,7 +149,7 @@ __global__ void gpu_qmmm_fock(
           clatom_position_sh[tid].x = G2G::gpu_atom_positions[i + tid].x;
           clatom_position_sh[tid].y = G2G::gpu_atom_positions[i + tid].y;
           clatom_position_sh[tid].z = G2G::gpu_atom_positions[i + tid].z;
-          clatom_charge_sh[tid] = (scalar_type)(gpu_atom_types[i + tid] + 1);
+          clatom_charge_sh[tid] = (scalar_type)(gpu_atom_Z[i + tid]);
         }
         __syncthreads();
         //

--- a/g2g/analytic_integral/cuda/kernels/qmmm_forces.h
+++ b/g2g/analytic_integral/cuda/kernels/qmmm_forces.h
@@ -218,7 +218,7 @@ __global__ void gpu_qmmm_forces(
           clatom_position_sh[tid].x = G2G::gpu_atom_positions[i + tid].x;
           clatom_position_sh[tid].y = G2G::gpu_atom_positions[i + tid].y;
           clatom_position_sh[tid].z = G2G::gpu_atom_positions[i + tid].z;
-          clatom_charge_sh[tid] = (scalar_type)(gpu_atom_types[i + tid] + 1);
+          clatom_charge_sh[tid] = (scalar_type)(gpu_atom_types[i + tid]);
         }
         __syncthreads();
         //

--- a/g2g/analytic_integral/cuda/os_common.cu
+++ b/g2g/analytic_integral/cuda/os_common.cu
@@ -41,6 +41,7 @@ __device__ __constant__ float gpu_fac[17];
 
 __device__ __constant__ uint TERM_TYPE_GAUSSIANS[6] = { 1, 3, 9, 6, 18, 36 };
 __device__ __constant__ uint gpu_atom_types[MAX_ATOMS];
+__device__ __constant__ uint gpu_atom_Z[MAX_ATOMS];
 
 template<class scalar_type>
 void OSIntegral<scalar_type>::load_params(void)
@@ -65,7 +66,7 @@ void OSIntegral<scalar_type>::load_params(void)
 
     cudaMemcpyToSymbol(gpu_m, &G2G::fortran_vars.m, sizeof(G2G::fortran_vars.m), 0, cudaMemcpyHostToDevice);
     cudaMemcpyToSymbol(gpu_atom_types, G2G::fortran_vars.atom_types.data, G2G::fortran_vars.atom_types.bytes(), 0, cudaMemcpyHostToDevice);
-
+    cudaMemcpyToSymbol(gpu_atom_Z, integral_vars.atom_Z.data, integral_vars.atom_Z.bytes(), 0, cudaMemcpyHostToDevice);
     //
     // Set up arrays needed for F(m,U) calculation in QM/MM kernels (STR and FAC) and send them to device
     // FAC is small so it's put into constant memory

--- a/g2g/analytic_integral/qmmm_nuc.cpp
+++ b/g2g/analytic_integral/qmmm_nuc.cpp
@@ -29,7 +29,7 @@ void QMMMIntegral<scalar_type>::calc_nuc_gradient(double* qm_forces,
       dist = sqrt(dist);
 
       double prefactor = -integral_vars.clatom_charges(j) *
-                         (G2G::fortran_vars.atom_types(i) + 1) / pow(dist, 3.0);
+                          integral_vars.atom_Z(i) / pow(dist, 3.0);
       qm_forces[i + 0 * G2G::fortran_vars.atoms] += prefactor * diff.x;
       qm_forces[i + 1 * G2G::fortran_vars.atoms] += prefactor * diff.y;
       qm_forces[i + 2 * G2G::fortran_vars.atoms] += prefactor * diff.z;
@@ -52,7 +52,7 @@ void QMMMIntegral<scalar_type>::calc_nuc_energy(double& Ens) {
       dist = sqrt(dist);
 
       double E = integral_vars.clatom_charges(j) *
-                 (G2G::fortran_vars.atom_types(i) + 1) / dist;
+                 integral_vars.atom_Z(i) / dist;
       Ens += E;
     }
   }

--- a/lioamber/Makefile.depends
+++ b/lioamber/Makefile.depends
@@ -97,6 +97,12 @@ tmplist :=
 tmplist += liomain.o
 $(tmplist:%.o=$(OBJPATH)/%.o) : $(OBJPATH)/build_info.mod
 
+################################################################################
+SRCDIRS +=
+OBJECTS += ghost_atoms.o
+tmplist :=
+tmplist += drive.o
+$(tmplist:%.o=$(OBJPATH)/%.o) : $(OBJPATH)/ghost_atoms.mod
 
 ################################################################################
 OBJECTS += dftb_subs.o

--- a/lioamber/Makefile.depends
+++ b/lioamber/Makefile.depends
@@ -101,7 +101,7 @@ $(tmplist:%.o=$(OBJPATH)/%.o) : $(OBJPATH)/build_info.mod
 SRCDIRS +=
 OBJECTS += ghost_atoms.o
 tmplist :=
-tmplist += drive.o
+tmplist += drive.o lionml_data.o
 $(tmplist:%.o=$(OBJPATH)/%.o) : $(OBJPATH)/ghost_atoms.mod
 
 ################################################################################

--- a/lioamber/drive.f90
+++ b/lioamber/drive.f90
@@ -1086,7 +1086,7 @@
       call aint_query_gpu_level(igpu)
       if (igpu.gt.1) then
       call aint_parameter_init(Md, ncontd, nshelld, cd, ad, Nucd, &
-      af, RMM, M9, M11, STR, FAC, rmax)
+      af, RMM, M9, M11, STR, FAC, rmax, Iz)
       endif
       allocate(X(M,4*M),XX(Md,Md))
 

--- a/lioamber/drive.f90
+++ b/lioamber/drive.f90
@@ -1083,7 +1083,7 @@
                              NCO,OPEN,Nunp,nopt,Iexch, &
                              e_, e_2, e3, wang, wang2, wang3, &
 			                    use_libxc, ex_functional_id, ec_functional_id)
-              call summon_ghosts(Iz, natom)
+              call summon_ghosts(Iz, natom, verbose)
 
       call aint_query_gpu_level(igpu)
       if (igpu.gt.1) then

--- a/lioamber/drive.f90
+++ b/lioamber/drive.f90
@@ -26,6 +26,7 @@
       USE fileio , ONLY : read_coef_restart, read_rho_restart
       use td_data    , only: td_do_pop
       use fileio_data, only: verbose, rst_dens
+      use ghost_atoms_subs, only: summon_ghosts
 
       IMPLICIT NONE
       LOGICAL :: basis_check
@@ -1081,7 +1082,8 @@
                              RMM,M5,M3,rhoalpha,rhobeta, &
                              NCO,OPEN,Nunp,nopt,Iexch, &
                              e_, e_2, e3, wang, wang2, wang3, &
-			     use_libxc, ex_functional_id, ec_functional_id)
+			                    use_libxc, ex_functional_id, ec_functional_id)
+              call summon_ghosts(Iz, natom)
 
       call aint_query_gpu_level(igpu)
       if (igpu.gt.1) then

--- a/lioamber/ghost_atoms.f90
+++ b/lioamber/ghost_atoms.f90
@@ -22,12 +22,28 @@ end module ghost_atoms_data
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
 module ghost_atoms_subs
 contains
-   subroutine summon_ghosts(Iz, natom, verbose)
+   subroutine adjust_ghost_charge(atom_Z, n_atoms, nuc_charge)
+      use ghost_atoms_data, only: ghost_atoms, n_ghosts
+      implicit none
+      integer, intent(in)    :: n_atoms, atom_Z(n_atoms)
+      integer, intent(inout) :: nuc_charge
+      integer :: icount
+
+      if (n_ghosts .lt. 1) return;
+
+      do icount = 1, n_ghosts
+         nuc_charge = nuc_charge - atom_Z(ghost_atoms(icount))
+      enddo
+
+      return
+   end subroutine adjust_ghost_charge
+
+   subroutine summon_ghosts(atom_Z, n_atoms, verbose)
       use ghost_atoms_data, only: ghost_atoms, n_ghosts
 
       implicit none
-      integer, intent(in)    :: natom, verbose
-      integer, intent(inout) :: Iz(natom)
+      integer, intent(in)    :: n_atoms, verbose
+      integer, intent(inout) :: atom_Z(n_atoms)
       integer :: icount
 
       if (n_ghosts .lt. 1) return;
@@ -41,7 +57,7 @@ contains
             write(*,'(A)') " ERROR - SUMMON_GHOSTS: Ghost_atoms(x) cannot be"&
                  &" less than 1."
          endif
-         Iz(ghost_atoms(icount)) = 0
+         atom_Z(ghost_atoms(icount)) = 0
       enddo
 
       return

--- a/lioamber/ghost_atoms.f90
+++ b/lioamber/ghost_atoms.f90
@@ -1,0 +1,39 @@
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+!%% GHOST_ATOMS.F90 %%%%$%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+! This files contains variables ghost_atoms and n_ghosts, as well as subroutine!
+! summon_ghosts which sets the desired atomic nuclei (atom_Z) to 0.            !
+! n_ghost is the number of ghost_atoms in the system, while ghost_atoms()      !
+! contains the index of each ghost.                                            !
+! WARNING: The following module assumes the maximum amount of QM atoms is 300. !
+!          While this is not optimal, a similar cap is set in module G2G.      !
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+module ghost_atoms_data
+   implicit none
+   integer      :: ghost_atoms(300)
+   integer      :: n_ghosts = 0
+contains
+end module ghost_atoms_data
+
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+module ghost_atoms_subs
+contains
+   subroutine summon_ghosts(Iz, natom)
+      use ghost_atoms_data, only: ghost_atoms, n_ghosts
+
+      implicit none
+      integer, intent(in)    :: natom
+      integer, intent(inout) :: Iz(natom)
+      integer :: icount
+
+      if (n_ghosts .lt. 1) return;
+      do icount=1, n_ghosts
+         if (ghost_atoms(icount) .lt. 1) then
+            write(*,'(A)') " ERROR - SUMMON_GHOSTS: Ghost_atoms(x) cannot be"&
+                 &" less than 1."
+         endif
+         Iz(ghost_atoms(icount)) = 0
+      enddo
+
+      return
+   end subroutine summon_ghosts
+end module ghost_atoms_subs

--- a/lioamber/ghost_atoms.f90
+++ b/lioamber/ghost_atoms.f90
@@ -17,15 +17,20 @@ end module ghost_atoms_data
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
 module ghost_atoms_subs
 contains
-   subroutine summon_ghosts(Iz, natom)
+   subroutine summon_ghosts(Iz, natom, verbose)
       use ghost_atoms_data, only: ghost_atoms, n_ghosts
 
       implicit none
-      integer, intent(in)    :: natom
+      integer, intent(in)    :: natom, verbose
       integer, intent(inout) :: Iz(natom)
       integer :: icount
 
       if (n_ghosts .lt. 1) return;
+      if (verbose.gt.3) then
+         write(*,'(A)', advance = 'no') "  Ghost atom indexes = "
+         write(*,*) ghost_atoms
+      endif
+
       do icount=1, n_ghosts
          if (ghost_atoms(icount) .lt. 1) then
             write(*,'(A)') " ERROR - SUMMON_GHOSTS: Ghost_atoms(x) cannot be"&

--- a/lioamber/ghost_atoms.f90
+++ b/lioamber/ghost_atoms.f90
@@ -4,8 +4,13 @@
 ! summon_ghosts which sets the desired atomic nuclei (atom_Z) to 0.            !
 ! n_ghost is the number of ghost_atoms in the system, while ghost_atoms()      !
 ! contains the index of each ghost.                                            !
+! To use this module, set n_ghosts > 1 and ghost_atoms=x,y,z,..,n where x,y,z  !
+! and n indicate the index for each ghost atom (in the order that are placed in!
+! the coordinates file).                                                       !
+!                                                                              !
 ! WARNING: The following module assumes the maximum amount of QM atoms is 300. !
 !          While this is not optimal, a similar cap is set in module G2G.      !
+! F. Pedron - July 2018                                                        !
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
 module ghost_atoms_data
    implicit none

--- a/lioamber/init_lio.f90
+++ b/lioamber/init_lio.f90
@@ -125,7 +125,7 @@ subroutine init_lio_common(natomin, Izin, nclatom, callfrom)
     use garcha_mod, only : idip, nunp, RMM, d, c, a, Nuc, ncont, cx,           &
                            ax, Nucx, ncontx, cd, ad, Nucd, ncontd, indexii,    &
                            indexiid, r, v, rqm, Em, Rm, pc, nnat, af, B, Iz,   &
-                           natom, nco, ng0, ngd0, ngrid, nl, norbit, ntatom,   &
+                           natom, ng0, ngd0, ngrid, nl, norbit, ntatom,        &
                            free_global_memory, little_cube_size,&
                            assign_all_functions, energy_all_iterations,        &
                            remove_zero_weights, min_points_per_cube,           &
@@ -139,18 +139,17 @@ subroutine init_lio_common(natomin, Izin, nclatom, callfrom)
 
     implicit none
     integer , intent(in) :: nclatom, natomin, Izin(natomin), callfrom
-    integer              :: i, ng2, ngdDyn, ngDyn, nqnuc, ierr, ios, MM,      &
-                            electrons
-    call g2g_set_options(free_global_memory, little_cube_size, sphere_radius, &
-                         assign_all_functions, energy_all_iterations,         &
-                         remove_zero_weights, min_points_per_cube,            &
-                         max_function_exponent, timers, verbose)
+    integer              :: ng2, ngdDyn, ngDyn, ierr, ios, MM
 
     if (verbose .gt. 2) then
       write(*,*)
       write(*,'(A)') "LIO initialisation."
     endif
     call g2g_timer_start('lio_init')
+    call g2g_set_options(free_global_memory, little_cube_size, sphere_radius, &
+                         assign_all_functions, energy_all_iterations,         &
+                         remove_zero_weights, min_points_per_cube,            &
+                         max_function_exponent, timers, verbose)
 
     chrg_sq = charge**2
     if (callfrom.eq.1) then
@@ -187,21 +186,6 @@ subroutine init_lio_common(natomin, Izin, nclatom, callfrom)
     if (ecpmode) allocate (Cnorm(ngDyn,nl))
 
     call g2g_init()
-
-    nqnuc = 0
-    do i = 1, natom
-       nqnuc = nqnuc + Iz(i)
-    enddo
-
-    electrons=nqnuc - charge
-    if (.not. OPEN .and. (mod(electrons,2) .ne. 0)) then
-	    write(*,*) "odd number of electrons in a close-shell calculation"
-	    write(*,*) "check system charge"
-	    stop
-    endif
-
-    NCO = ((nqnuc - charge) - NUNP)/2
-
     allocate(MO_coef_at(ngDyn*ngDyn))
     if (OPEN) allocate(MO_coef_at_b(ngDyn*ngDyn))
 
@@ -211,7 +195,6 @@ subroutine init_lio_common(natomin, Izin, nclatom, callfrom)
     ! reemplazos de RMM
     MM=M*(M+1)/2
     allocate(Fock_Hcore(MM), Fock_Overlap(MM), P_density(MM))
-
     call g2g_timer_stop('lio_init')
 
     return

--- a/lioamber/lionml_data.f90
+++ b/lioamber/lionml_data.f90
@@ -49,6 +49,7 @@ module lionml_data
    use trans_Data        , only: gaussian_convert
    use transport_data    , only: transport_calc, generate_rho0, gate_field,    &
                                  save_charge_freq, driving_rate, Pop_Drive
+   use ghost_atoms_data  , only: n_ghosts, ghost_atoms
    implicit none
 
 !  Namelist definition
@@ -100,7 +101,9 @@ module lionml_data
                   dftb_calc, MTB, alfaTB, betaTB, gammaTB, Vbias_TB, end_bTB,  &
                   start_tdtb, end_tdtb, TBsave, TBload,                        &
                    ! Libxc variables
-                  use_libxc, ex_functional_id, ec_functional_id
+                  use_libxc, ex_functional_id, ec_functional_id,               &
+                  ! Variables for Ghost atoms:
+                  n_ghosts, ghost_atoms
 
    type lio_input_data
       ! COMMON
@@ -162,7 +165,8 @@ module lionml_data
       ! Libxc configuration
       integer          :: ex_functional_id, ec_functional_id
       logical          :: use_libxc
-
+      ! Ghost atoms
+      integer          :: n_ghosts, ghost_atoms(300)
    end type lio_input_data
 contains
 
@@ -243,6 +247,8 @@ subroutine get_namelist(lio_in)
    lio_in%save_charge_freq = save_charge_freq; lio_in%MTB       = MTB
    lio_in%start_tdtb       = start_tdtb      ; lio_in%TBload    = TBload
    lio_in%TBsave           = TBsave
+   ! Ghost atoms
+   lio_in%n_ghosts = n_ghosts ; lio_in%ghost_atoms = ghost_atoms
 
    ! Ehrenfest
    lio_in%rsti_fname = rsti_fname; lio_in%eefld_timeamp  = eefld_timeamp

--- a/lioamber/lionml_subs.f90
+++ b/lioamber/lionml_subs.f90
@@ -119,6 +119,7 @@ subroutine lionml_write_dull()
    write(*,8004) inputs%Etold, inputs%good_cut, inputs%Rmax
    write(*,8005) inputs%RmaxS, inputs%Iexch, inputs%Igrid, inputs%Igrid2
    write(*,8006) inputs%PredCoef, inputs%initial_guess, inputs%dbug
+   write(*,8007) inputs%n_ghosts
    write(*,9000) " ! -- Input and output options: -- !"
    write(*,8020) inputs%verbose, inputs%style, inputs%timers, inputs%writexyz, &
                  inputs%WriteForces
@@ -192,7 +193,9 @@ subroutine lionml_write_dull()
             ",")
 8005 FORMAT(2x,"RmaxS = ", F14.8, ", IExch = ", I5, ", IGrid = ", I3, &
             ", IGrid2 = ", I3, ",")
-8006 FORMAT(2x, "PredCoef = ", L2, ", initial_guess = ", I3, ", DBug = ", L2)
+8006 FORMAT(2x, "PredCoef = ", L2, ", initial_guess = ", I3, ", DBug = ", L2, &
+            ",")
+8007 FORMAT(2x, "n_ghosts = ", I5)
 ! I/O Control
 8020 FORMAT(2x, "verbose = ", I3, ", style = ", L2, ", timers = ", I3, &
             ", writeXYZ = ", L2, ", writeForces = ", L2, ",")
@@ -296,6 +299,7 @@ subroutine lionml_write_style()
    write(*,8218) inputs%Iexch         ; write(*,8219) inputs%Igrid
    write(*,8220) inputs%Igrid2        ; write(*,8221) inputs%PredCoef
    write(*,8222) inputs%initial_guess ; write(*,8223) inputs%dbug
+   write(*,8224) inputs%n_ghosts
    write(*,8003)
 
    ! File IO and Property calculations
@@ -449,6 +453,7 @@ subroutine lionml_write_style()
 8221 FORMAT(4x,"║  PredCoef            ║  ",21x,L2,2x,"║")
 8222 FORMAT(4x,"║  Initial_guess       ║  ",18x,I5,2x,"║")
 8223 FORMAT(4x,"║  Dbug                ║  ",21x,L2,2x,"║")
+8224 FORMAT(4x,"║  n_ghosts            ║  ",18x,I5,2x,"║")
 !IO Control
 8250 FORMAT(4x,"║  Verbose             ║  ",20x,I3,2x,"║")
 8251 FORMAT(4x,"║  Style               ║  ",21x,L2,2x,"║")


### PR DESCRIPTION
Added ghost atom functionality to LIO, in order to perform BSSE calculations and charge transfer calculations.

To use, simply set n_ghosts to the desired quantity, and ghots_atoms=x,y,z where x, y,z are the ghost atom indexes (max. 300).