### PR TITLE
Bugfix - the order of factors ALTERS the product.

### DIFF
--- a/g2g/pointxc/pbeOS_corr.h
+++ b/g2g/pointxc/pbeOS_corr.h
@@ -199,7 +199,7 @@ __host__ __device__ void pbeOS_corr(scalar_type rho, scalar_type rs,
   //      FACT1 = Q5*Q9+Q4*Q9*Q9
 
   scalar_type hB =
-      -EASYPBE_BETA * G3 * B * T6 * ((scalar_type)2.0f + B * T2) / Q8;
+      -EASYPBE_BETA * G3 * B * (T6 / Q8) * ((scalar_type)2.0f + B * T2);
   scalar_type hRS = -rsthrd * hB * BEC * ECRS;
   scalar_type FACT0 = (scalar_type)2.0f * EASYPBE_DELTA - (scalar_type)6.0f * B;
   scalar_type FACT1 = Q5 * Q9 + Q4 * Q9 * Q9;
@@ -228,12 +228,14 @@ __host__ __device__ void pbeOS_corr(scalar_type rho, scalar_type rs,
   scalar_type FACT2 = Q4 * Q5 + B * T2 * (Q4 * Q9 + Q5);
   scalar_type FACT3 = (scalar_type)2.0f * B * Q5 * Q9 + EASYPBE_DELTA * FACT2;
   scalar_type hTT = (scalar_type)4.0f * EASYPBE_BETA * G3 * t *
-                    (2.0f * B / Q8 - (Q9 * FACT3 / Q8) / Q8);
+                    (2.0f * B / Q8 - ((Q9 / Q8) * FACT3) / Q8);
   COMM = h + hRS + hRST + T2 * hT / (scalar_type)6.0f +
          (scalar_type)7.0f * T2 * t * hTT / (scalar_type)6.0f;
   scalar_type PREF = hz - GZ * T2 * hT / G;
   scalar_type FACT5 = GZ * ((scalar_type)2.0f * hT + t * hTT) / G;
   COMM = COMM - PREF * zet - uu * hTT - vv * hT - ww * (hZT - FACT5);
+//  if ( COMM != COMM ) { printf("NaN in COMM2 - hRS %E hRST %E T2 %E hT %E hTT %E \n",
+// hRS, hRST, T2, hT, hTT); };
   dvc_a = COMM + PREF;
   dvc_b = COMM - PREF;
   // PBE POTENTIAL DONE !!!!!

--- a/g2g/pointxc/pbeOS_main.h
+++ b/g2g/pointxc/pbeOS_main.h
@@ -51,6 +51,16 @@ __host__ __device__ void pbeOS_main(
   // v = Laplacian/(rho*(2*fk)**2) where (rho=2*up)
   //-----------------------------------------------------*/
    scalar_type expbe_a, expbe_b;
+   scalar_type rho13, fk1, fk, twofk, twofk2, twofk3, s, u, v;
+   bool small_dens = false;
+
+   // Output initialization
+   expbe = (scalar_type)0.0f;
+   ecpbe = (scalar_type)0.0f;
+   corr1 = (scalar_type)0.0f;
+   corr2 = (scalar_type)0.0f;
+   vcpbe_a = (scalar_type)0.0f;
+   vcpbe_b = (scalar_type)0.0f;
 
    // Density Up
    scalar_type twodens = (scalar_type)2.0f * dens_a;
@@ -61,45 +71,55 @@ __host__ __device__ void pbeOS_main(
    if (twodens5 < flt_minimum) {
      expbe_a = (scalar_type)0.0f;
      vxpbe_a = (scalar_type)0.0f;
-     expbe_b = (scalar_type)0.0f;
-     vxpbe_b = (scalar_type)0.0f;
-     ecpbe   = (scalar_type)0.0f;
-     vcpbe_a = (scalar_type)0.0f;
-     vcpbe_b = (scalar_type)0.0f;
-     return;
+     small_dens = true;
+   } else {
+     rho13 = cbrt(twodens);
+     fk1 = cbrt((scalar_type)EASYPBE_PI32);
+     fk = fk1 * rho13;
+
+     twofk = (scalar_type)2.0f * fk;
+     twofk2 = twofk * twofk;
+     twofk3 = twofk * twofk2;
+
+     s = ((scalar_type)2.0f * dgrad_a)   / (twodens * twofk);
+     v = ((scalar_type)2.0f * rlap_a)    / (twodens * twofk2);
+     u = ((scalar_type)4.0f * delgrad_a) / (twodens2 * twofk3);
+     pbeOS_exch(twodens, s, u, v, expbe_a, vxpbe_a);
    }
-
-   scalar_type rho13 = cbrt(twodens);
-   scalar_type fk1 = cbrt((scalar_type)EASYPBE_PI32);
-   scalar_type fk = fk1 * rho13;
-
-   scalar_type twofk = (scalar_type)2.0f * fk;
-   scalar_type twofk2 = twofk * twofk;
-   scalar_type twofk3 = twofk * twofk2;
-
-   scalar_type s = ((scalar_type)2.0f * dgrad_a)   / (twodens * twofk);
-   scalar_type v = ((scalar_type)2.0f * rlap_a)    / (twodens * twofk2);
-   scalar_type u = ((scalar_type)4.0f * delgrad_a) / (twodens2 * twofk3);
-
-   pbeOS_exch(twodens, s, u, v, expbe_a, vxpbe_a);
 
    // Density Down
    twodens = (scalar_type)2.0f * dens_b;
    twodens2 = twodens * twodens;
+   twodens5 = twodens2 * twodens2 * twodens;
 
-   rho13 = cbrt((scalar_type)twodens);
-   fk1 = cbrt((scalar_type)EASYPBE_PI32);
-   fk = fk1 * rho13;
+   if (twodens5 < flt_minimum) {
+     expbe_a = (scalar_type)0.0f;
+     vxpbe_a = (scalar_type)0.0f;
+     ecpbe   = (scalar_type)0.0f;
+     if (!small_dens) {
+        expbe = expbe_a;
+     }
+     return;
+   } else {
+     rho13 = cbrt((scalar_type)twodens);
+     fk1 = cbrt((scalar_type)EASYPBE_PI32);
+     fk = fk1 * rho13;
 
-   twofk = (scalar_type)2.0f * fk;
-   twofk2 = twofk * twofk;
-   twofk3 = twofk * twofk2;
+     twofk = (scalar_type)2.0f * fk;
+     twofk2 = twofk * twofk;
+     twofk3 = twofk * twofk2;
+ 
+     s = ((scalar_type)2.0f * dgrad_b)   / (twodens * twofk);
+     v = ((scalar_type)2.0f * rlap_b)    / (twodens * twofk2);
+     u = ((scalar_type)4.0f * delgrad_b) / (twodens2 * twofk3);
+     pbeOS_exch(twodens, s, u, v, expbe_b, vxpbe_b);
+   }
 
-   s = ((scalar_type)2.0f * dgrad_b)   / (twodens * twofk);
-   v = ((scalar_type)2.0f * rlap_b)    / (twodens * twofk2);
-   u = ((scalar_type)4.0f * delgrad_b) / (twodens2 * twofk3);
-
-   pbeOS_exch(twodens, s, u, v, expbe_b, vxpbe_b);
+   if (small_dens) {
+      expbe = expbe_b;
+      ecpbe = (scalar_type)0.0f;
+      return;
+   }
 
    // Construct total density and contribution to Ex
    scalar_type rho = dens_a + dens_b;
@@ -172,6 +192,14 @@ __host__ __device__ void pbeOS_main(
   corr2 = h;
   vcpbe_a = vc_a + dvc_a;
   vcpbe_b = vc_b + dvc_b;
+//  if (expbe_a != expbe_a) { printf("NaN in expbe_a \n");};
+//  if (expbe_b != expbe_b) { printf("NaN in expbe_b \n");};
+//  if (ec != ec) { printf("NaN in ec \n");};
+//  if (h != h) { printf("NaN in h \n");};
+//  if (vc_a != vc_a) { printf("NaN in vc_a \n");};
+//  if (dvc_a != dvc_a) { printf("NaN in dvc_a \n");};
+//  if (vc_b != vc_b) { printf("NaN in vc_b \n");};
+//  if (dvc_b!= dvc_b) { printf("NaN in dvc_b \n");};
 }  // pbeOS_main
 
 #undef EASYPBE_PI


### PR DESCRIPTION
Fixed a bug in OS correlation calculation, in which some numbers ended in a "inf / inf = NaN" situation. Solved by altering the way operations were performed. Although calculations are similar in closed-shell, I could not find a system to reproduce this bug, so I left CS as it is.

Also, added a small check in OS exchange correlation for very small beta densities (in order to avoid further NaNs).

Left some NaN checks commented out on purpose, to turn them later in a proper debugging tool. I'll be merging this tomorrow.