### PR TITLE
Fixed precision warnings.

### DIFF
--- a/g2g/classify_functions.cpp
+++ b/g2g/classify_functions.cpp
@@ -140,5 +140,8 @@ void PointGroup<scalar_type>::assign_functions_as_sphere(
   compute_nucleii_maps();
 }
 
+#if FULL_DOUBLE
 template class PointGroup<double>;
+#else
 template class PointGroup<float>;
+#endif

--- a/g2g/cpu/functions.cpp
+++ b/g2g/cpu/functions.cpp
@@ -353,6 +353,9 @@ void PointGroupCPU<scalar_type>::compute_functions(bool forces, bool gga) {
   function_values.transpose(function_values_transposed);
 }
 
+#if FULL_DOUBLE
 template class PointGroupCPU<double>;
+#else
 template class PointGroupCPU<float>;
+#endif
 }

--- a/g2g/cpu/iteration.cpp
+++ b/g2g/cpu/iteration.cpp
@@ -621,8 +621,11 @@ void PointGroupCPU<scalar_type>::solve_opened(
 #endif
 }
 
+#if FULL_DOUBLE
 template class PointGroup<double>;
-template class PointGroup<float>;
 template class PointGroupCPU<double>;
+#else
+template class PointGroup<float>;
 template class PointGroupCPU<float>;
+#endif
 }

--- a/g2g/cpu/weight.cpp
+++ b/g2g/cpu/weight.cpp
@@ -110,9 +110,11 @@ void PointGroupCPU<scalar_type>::compute_weights(void) {
     this->number_of_points = this->points.size();
   }
 }
-
-template class PointGroup<float>;
+#if FULL_DOUBLE
 template class PointGroup<double>;
 template class PointGroupCPU<double>;
+#else
+template class PointGroup<float>;
 template class PointGroupCPU<float>;
+#endif
 }

--- a/g2g/cuda/iteration.cu
+++ b/g2g/cuda/iteration.cu
@@ -260,7 +260,7 @@ void PointGroupGPU<scalar_type>::solve_closed(
 	    if (fortran_vars.use_libxc) {
 	      // Accumulate the data for libxc
 	      gpu_accumulate_point_for_libxc<scalar_type, true, true, false><<<threadGrid_accumulate, threadBlock_accumulate>>> (
-		point_weights_gpu.data, this->number_of_points, block_height, 
+		point_weights_gpu.data, this->number_of_points, block_height,
 		partial_densities_gpu.data, dxyz_gpu.data, dd1_gpu.data, dd2_gpu.data,
 		accumulated_densities_gpu.data, dxyz_accum_gpu.data, dd1_accum_gpu.data, dd2_accum_gpu.data);
 	#if LIBXC_CPU
@@ -300,7 +300,7 @@ void PointGroupGPU<scalar_type>::solve_closed(
 
 	  // Accumulate the data.
 	  gpu_accumulate_point_for_libxc<scalar_type, true, false, false><<<threadGrid_accumulate, threadBlock_accumulate>>> (point_weights_gpu.data,
-            this->number_of_points, block_height, 
+            this->number_of_points, block_height,
 	    partial_densities_gpu.data, dxyz_gpu.data, dd1_gpu.data, dd2_gpu.data,
 	    accumulated_densities_gpu.data, dxyz_accum_gpu.data, dd1_accum_gpu.data, dd2_accum_gpu.data);
 
@@ -354,7 +354,7 @@ void PointGroupGPU<scalar_type>::solve_closed(
         if (fortran_vars.use_libxc) {
 	  // Accumulate the data.
 	  gpu_accumulate_point_for_libxc<scalar_type, false, true, false><<<threadGrid_accumulate, threadBlock_accumulate>>> (point_weights_gpu.data,
-            this->number_of_points, block_height, 
+            this->number_of_points, block_height,
 	    partial_densities_gpu.data, dxyz_gpu.data, dd1_gpu.data, dd2_gpu.data,
 	    accumulated_densities_gpu.data, dxyz_accum_gpu.data, dd1_accum_gpu.data, dd2_accum_gpu.data);
 
@@ -915,9 +915,12 @@ void PointGroupGPU<scalar_type>::compute_weights(void)
     }
 }
 
+#if FULL_DOUBLE
 template class PointGroup<double>;
-template class PointGroup<float>;
 template class PointGroupGPU<double>;
+#else
+template class PointGroup<float>;
 template class PointGroupGPU<float>;
+#endif
 
 }

--- a/g2g/partition.cpp
+++ b/g2g/partition.cpp
@@ -590,12 +590,17 @@ void Partition::solve(Timers& timers, bool compute_rmm, bool lda,
   }
 }
 
+#if FULL_DOUBLE
 template class PointGroup<double>;
-template class PointGroup<float>;
 template class PointGroupCPU<double>;
-template class PointGroupCPU<float>;
 #if GPU_KERNELS
 template class PointGroupGPU<double>;
+#endif
+#else
+template class PointGroup<float>;
+template class PointGroupCPU<float>;
+#if GPU_KERNELS
 template class PointGroupGPU<float>;
+#endif
 #endif
 }

--- a/g2g/pointxc/calc_ldaCS.h
+++ b/g2g/pointxc/calc_ldaCS.h
@@ -98,7 +98,6 @@ __host__ __device__ void calc_ldaCS(scalar_type dens, scalar_type& ex,
     } break;
     default:
       throw std::runtime_error("Error, invalid iexch");
-      break;
   }
 }
 


### PR DESCRIPTION
Fixed g2g precision warnings when compiling with precision=1 (FULL_DOUBLE). Thanks to this, now lio g2g part compiles a little faster since it no longer instances PointGroup<float> and PointGroup<double> in the same compilation.