### PR TITLE
Setting the GPU level in runtime.

### DIFF
--- a/g2g/Makefile
+++ b/g2g/Makefile
@@ -48,10 +48,6 @@ else
 endif
 endif
 
-ifneq ($(aint_gpu_level),)
-  CXXFLAGS     += -DAINT_GPU_LEVEL=$(aint_gpu_level)
-  NVCCFLAGS    += -DAINT_GPU_LEVEL=$(aint_gpu_level)
-endif
 ifeq ($(aint_mp),1)
   CXXFLAGS     += -DAINT_MP=1
   NVCCFLAGS    += -DAINT_MP=1

--- a/g2g/analytic_integral/aint_common.h
+++ b/g2g/analytic_integral/aint_common.h
@@ -6,6 +6,4 @@
 
 #define MAX_TERM_TYPES 6
 
-#define AINT_DEFAULT_GPU_LEVEL 4
-
 #endif

--- a/g2g/analytic_integral/aint_init.h
+++ b/g2g/analytic_integral/aint_init.h
@@ -7,6 +7,7 @@ namespace AINT {
 
 struct FortranVars {
   uint clatoms;
+  int  gpu_level;
 
   /* ---DENSITY BASIS--- */
   uint gaussians_dens, s_gaussians_dens, p_gaussians_dens;

--- a/lioamber/drive.f90
+++ b/lioamber/drive.f90
@@ -20,7 +20,7 @@
       Rm2, rqm, rmax, Nunp, nl, nt, ng, ngd, restart_freq,             &
       writexyz, number_restr, restr_pairs,restr_index,restr_k,restr_w,restr_r0,&
       mulliken, MO_coef_at, MO_coef_at_b, use_libxc, ex_functional_id, &
-      ec_functional_id
+      ec_functional_id, gpu_level
 
       USE ECP_mod, ONLY : ecpmode, asignacion
       USE fileio , ONLY : read_coef_restart, read_rho_restart
@@ -1062,12 +1062,11 @@
                              NCO,OPEN,Nunp,nopt,Iexch, &
                              e_, e_2, e3, wang, wang2, wang3, &
 			                    use_libxc, ex_functional_id, ec_functional_id)
-              call summon_ghosts(Iz, natom, verbose)
+      call summon_ghosts(Iz, natom, verbose)
 
-      call aint_query_gpu_level(igpu)
-      if (igpu.gt.1) then
-      call aint_parameter_init(Md, ncontd, nshelld, cd, ad, Nucd, &
-      af, RMM, M9, M11, STR, FAC, rmax, Iz)
+      if (gpu_level .ne. 0) then
+         call aint_parameter_init(Md, ncontd, nshelld, cd, ad, Nucd, af, RMM, &
+                                  M9, M11, STR, FAC, rmax, Iz, gpu_level)
       endif
       allocate(X(M,4*M))
 

--- a/lioamber/liomods/garcha_mod.f
+++ b/lioamber/liomods/garcha_mod.f
@@ -135,7 +135,7 @@ c necessary)
       real*8 :: Force_cut, Energy_cut, minimzation_steep !energy and force convergence crit and initial steep
       integer :: n_points ! number of points scaned for lineal search
       integer :: n_min_steeps !number of optimization steps
-      integer :: charge
+      integer :: charge, gpu_level=4
       logical :: lineal_search !enable lineal search
 
 

--- a/lioamber/lionml_data.f90
+++ b/lioamber/lionml_data.f90
@@ -20,7 +20,8 @@ module lionml_data
                                  Dbug, steep, Force_cut, Energy_cut, charge,   &
                                  minimzation_steep, n_min_steeps, n_points,    &
                                  lineal_search, timers, IGRID, IGRID2,         &
-                                 use_libxc, ex_functional_id, ec_functional_id
+                                 use_libxc, ex_functional_id, ec_functional_id,&
+                                 gpu_level
    use dftb_data         , only: dftb_calc, MTB, alfaTB, betaTB, gammaTB,      &
                                  Vbias_TB, end_bTB, start_tdtb, end_tdtb,      &
                                  TBsave, TBload
@@ -61,7 +62,7 @@ module lionml_data
                      eefld_timepos, eefld_timeamp,                             &
                      fockbias_is_active, fockbias_is_shaped, fockbias_readfile,&
                      fockbias_timegrow , fockbias_timefall , fockbias_timeamp0,&
-		     use_libxc, ex_functional_id, ec_functional_id
+		               use_libxc, ex_functional_id, ec_functional_id
 
    namelist /lio/ OPEN, NMAX, Nunp, VCINP, GOLD, told, Etold, rmax, rmaxs,     &
                   predcoef, writexyz, DIIS, ndiis, Iexch, igrid, igrid2,       &
@@ -104,7 +105,7 @@ module lionml_data
                    ! Libxc variables
                   use_libxc, ex_functional_id, ec_functional_id,               &
                   ! Variables for Ghost atoms:
-                  n_ghosts, ghost_atoms
+                  n_ghosts, ghost_atoms, gpu_level
 
    type lio_input_data
       ! COMMON
@@ -141,7 +142,7 @@ module lionml_data
                           cube_sqrt_orb
       ! GPU Options
       double precision :: free_global_memory, little_cube_size, sphere_radius
-      integer          :: min_points_per_cube, max_function_exponent
+      integer          :: min_points_per_cube, max_function_exponent, gpu_level
       logical          :: assign_all_functions, energy_all_iterations,         &
                           remove_zero_weights
       ! Transport and DFTB
@@ -237,6 +238,7 @@ subroutine get_namelist(lio_in)
    lio_in%assign_all_functions  = assign_all_functions
    lio_in%energy_all_iterations = energy_all_iterations
    lio_in%remove_zero_weights   = remove_zero_weights
+   lio_in%gpu_level             = gpu_level
    ! Transport and DFTB
    lio_in%driving_rate     = driving_rate    ; lio_in%alfaTB    = alfaTB
    lio_in%dftb_calc        = dftb_calc       ; lio_in%betaTB    = betaTB

--- a/lioamber/lionml_subs.f90
+++ b/lioamber/lionml_subs.f90
@@ -157,7 +157,7 @@ subroutine lionml_write_dull()
                  inputs%remove_zero_weights
    write(*,8121) inputs%max_function_exponent, inputs%free_global_memory
    write(*,8122) inputs%sphere_radius, inputs%little_cube_size
-   write(*,8123) inputs%min_points_per_cube
+   write(*,8123) inputs%min_points_per_cube, inputs%gpu_level
    write(*,9000) " ! -- Transport and DFTB: -- !"
    write(*,8140) inputs%transport_calc, inputs%generate_rho0, &
                  inputs%driving_rate
@@ -242,7 +242,7 @@ subroutine lionml_write_dull()
 8121 FORMAT(2x, "max_function_exponent = ", I5, ", free_global_memory = ", &
             F14.8, ",")
 8122 FORMAT(2x, "sphere_radius = ", F14.8, ", little_cube_size = ", F14.8, ",")
-8123 FORMAT(2x, "min_points_per_cube = ", I5)
+8123 FORMAT(2x, "min_points_per_cube = ", I5, ", gpu_level = ", I5)
 ! Transport and DFTB
 8140 FORMAT(2x, "transport_calc = ", L2, ", generate_rho0 = ", L2, &
             ", driving_rate = ", F14.8, ",")
@@ -370,6 +370,7 @@ subroutine lionml_write_style()
    write(*,8425) inputs%little_cube_size
    write(*,8426) inputs%free_global_memory
    write(*,8427) inputs%sphere_radius
+   write(*,8428) inputs%gpu_level
    write(*,8003)
 
    ! Transport and DFTB
@@ -535,6 +536,7 @@ subroutine lionml_write_style()
 8425 FORMAT(4x,"║  little_cube_size    ║  ",9x,F14.8,2x,"║")
 8426 FORMAT(4x,"║  free_global_memory  ║  ",9x,F14.8,2x,"║")
 8427 FORMAT(4x,"║  sphere_radius       ║  ",9x,F14.8,2x,"║")
+8428 FORMAT(4x,"║  gpu_level           ║  ",18x,I5,2x,"║")
 ! Transport and DFTB
 8450 FORMAT(4x,"║  transport_calc      ║  ",21x,L2,2x,"║")
 8451 FORMAT(4x,"║  generate_rho0       ║  ",21x,L2,2x,"║")


### PR DESCRIPTION
Small PR here, now instead of recompiling over and over again with AINT_GPU_LEVEL, you just need to set "gpu_level=X" in the &lio namelist, where X is the desired GPU level (0 = no analytic integrals in GPU, and then scaling up to % = everything in GPU).