### PR TITLE
Changed behaviour for basis files and int_basis.

### DIFF
--- a/lioamber/basis_data.f90
+++ b/lioamber/basis_data.f90
@@ -526,14 +526,14 @@ subroutine check_basis(atom_bas_done, atom_fit_done, n_atoms, atom_Z, iostatus)
    iostatus = 0
    do iatom = 1, n_atoms
       if ( .not. atom_bas_done(atom_Z(iatom)) ) then
-         call atom_name(iatom, iatom_name)
+         call atom_name(atom_Z(iatom), iatom_name)
          write(*,'(A)') "  Error: Basis set not found for ", &
                         trim(iatom_name), "."
          iostatus = 1
          return
       endif
       if ( .not. atom_fit_done(atom_Z(iatom)) ) then
-         call atom_name(iatom, iatom_name)
+         call atom_name(atom_Z(iatom), iatom_name)
          write(*,'(A)') "  Error: Fitting set not found for ", &
                         trim(iatom_name), "."
          iostatus = 1

--- a/lioamber/basis_data.f90
+++ b/lioamber/basis_data.f90
@@ -34,7 +34,7 @@ module basis_data
    ! norm       : Normalize integrals (deprecated).
    character(len=100) :: basis_set   = "DZVP"
    character(len=100) :: fitting_set = "DZVP Coulomb Fitting"
-   logical            :: int_basis   = .false.
+   logical            :: int_basis   = .true.
    double precision   :: rMax        = 16.0D0
    double precision   :: rMaxs       =  5.0D0
    logical            :: norm        = .true.

--- a/lioamber/init_lio.f90
+++ b/lioamber/init_lio.f90
@@ -257,20 +257,28 @@ subroutine init_lio_amber(natomin, Izin, nclatom, charge_i, basis_i            &
                            Fulltimer_ECP, cut2_0, cut3_0
 
     implicit none
-    integer , intent(in) :: charge_i, nclatom, natomin, Izin(natomin)
-    character(len=20) :: basis_i, fcoord_i, fmulliken_i, frestart_i, &
-                         frestartin_i, inputFile
-    logical           :: verbose_i, OPEN_i, VCINP_i, predcoef_i, writexyz_i,   &
-                         DIIS_i, field_i, exter_i, writedens_i, tdrestart_i
-    integer           :: NMAX_i, NUNP_i, ndiis_i, Iexch_i, IGRID_i, IGRID2_i,  &
-                         timedep_i, ntdstep_i, NBCH_i, propagator_i, ierr
-    real*8            :: GOLD_i, told_i, rmax_i, rmaxs_i, tdstep_i,  &
-                         a0_i, epsilon_i, Fx_i, Fy_i, Fz_i
+    ! Variables received from &lio namelist in amber input file.
+    character(len=20), intent(in) :: basis_i, fcoord_i, fmulliken_i, &
+                                     frestart_i, frestartin_i
+    integer          , intent(in) :: charge_i, nclatom, natomin, Izin(natomin),&
+                                     NMAX_i, NUNP_i, ndiis_i, Iexch_i, IGRID_i,&
+                                     IGRID2_i, timedep_i, ntdstep_i, NBCH_i,   &
+                                     propagator_i
+    logical          , intent(in) :: verbose_i, OPEN_i, VCINP_i, predcoef_i,   &
+                                     writexyz_i, DIIS_i, field_i, exter_i,     &
+                                     writedens_i, tdrestart_i
+    real(kind=8)     , intent(in) :: GOLD_i, told_i, rmax_i, rmaxs_i, tdstep_i,&
+                                     a0_i, epsilon_i, Fx_i, Fy_i, Fz_i
+
     ! Deprecated or removed variables
-    character(len=20) :: output_i
-    integer           :: idip_i
-    logical           :: intsoldouble_i, dens_i, integ_i
-    double precision  :: dgtrig_i
+    character(len=20), intent(in) :: output_i
+    integer          , intent(in) :: idip_i
+    logical          , intent(in) :: intsoldouble_i, dens_i, integ_i
+    real(kind=8)     , intent(in) :: dgtrig_i
+
+    character(len=20) :: inputFile
+    integer           :: ierr
+    logical           :: file_exists
 
     ! Gives default values to variables.
     call lio_defaults()
@@ -301,8 +309,13 @@ subroutine init_lio_amber(natomin, Izin, nclatom, charge_i, basis_i            &
     inputFile = 'lio.in'
     call read_options(inputFile, ierr)
     if (ierr > 0) return
-    if ((.not. int_basis) .and. (basis_i .ne. 'basis')) basis_set = basis_i
 
+    inquire(file = basis_i, exist = file_exists)
+    if (file_exists) then
+        write(*,'(A)') "LIO - Custom basis set found, using present file."
+        int_basis = .false.
+        basis_set = basis_i
+    endif
 
     ! Initializes LIO. The last argument indicates LIO is not being used alone.
     call init_lio_common(natomin, Izin, nclatom, 1)

--- a/liosolo/liosolo.f90
+++ b/liosolo/liosolo.f90
@@ -26,12 +26,11 @@ program liosolo
                 call get_command_argument(i+1,inpfile)
             case("-b")
                 call get_command_argument(i+1,basis_set)
+                int_basis = .false.
             case("-bs")
                 call get_command_argument(i+1,basis_set)
             case("-fs")
                 call get_command_argument(i+1,fitting_set)
-            case("-ib")
-                int_basis=.true.
             case("-c")
                 call get_command_argument(i+1,inpcoords)
             case("-v")


### PR DESCRIPTION
Small PR to streamline usage with amber. Unless a custom basis set file is found in the working directory, LIO defaults to its internal basis sets.

Now int_basis is true by default, and set to false if liosolo is run with -b option.