### PR TITLE
TB Fermi energy calculation - DFT charge calibration

### DIFF
--- a/lioamber/Makefile.depends
+++ b/lioamber/Makefile.depends
@@ -221,6 +221,7 @@ tmplist += ehrensubs.o init_lio.o lio_finalize.o propagators.o
 tmplist += subm_int1.o  subm_int1G.o  subm_int2.o  subm_int2G.o  subm_int3G.o
 tmplist += subm_int3lu.o  subm_int3mem.o  subm_intfld.o  subm_intSG.o
 tmplist += subm_intsol.o  subm_intsolG.o  intECP.o lrtddft.o
+tmplist += tbdft_subs.o
 $(tmplist:%.o=$(OBJPATH)/%.o) : $(OBJPATH)/basis_data.mod
 
 ################################################################################
@@ -399,6 +400,7 @@ tmplist += SCF_exter.o
 tmplist += intECP.o SCF_aux.o
 tmplist += geometry_optim.o transport.o
 tmplist += lionml_subs.o
+tmplist += tbdft_subs.o
 $(tmplist:%.o=$(OBJPATH)/%.o) : $(OBJPATH)/garcha_mod.mod
 
 
@@ -408,7 +410,7 @@ $(tmplist:%.o=$(OBJPATH)/%.o) : $(OBJPATH)/garcha_mod.mod
 OBJECTS += SCF_aux.o
 
 tmplist :=
-tmplist += SCF.o liomain.o initial_guess.o
+tmplist += SCF.o liomain.o initial_guess.o tbdft_subs.o
 $(tmplist:%.o=$(OBJPATH)/%.o) : $(OBJPATH)/SCF_aux.mod
 
 ################################################################################

--- a/lioamber/liomain.f90
+++ b/lioamber/liomain.f90
@@ -28,7 +28,8 @@ subroutine liomain(E, dipxyz)
    use geometry_optim  , only: do_steep
    use mask_ecp        , only: ECP_init
    use tbdft_data      , only: MTB, tbdft_calc
-   use tbdft_subs      , only: tbdft_init, tbdft_scf_output, write_rhofirstTB
+   use tbdft_subs      , only: tbdft_init, tbdft_scf_output, write_rhofirstTB, &
+                               tbdft_calibration
    use td_data         , only: tdrestart, timedep
    use time_dependent  , only: TD
    use typedef_operator, only: operator
@@ -67,6 +68,8 @@ subroutine liomain(E, dipxyz)
       call ehrendyn_main(E, dipxyz)
    else if (cubegen_only) then
       call cubegen_vecin(M, MO_coef_at)
+   else if (tbdft_calc == 4) then
+      call tbdft_calibration(E, fock_aop, rho_aop, fock_bop, rho_bop)
    else
       if (.not. tdrestart) then
          if (doing_cdft) then

--- a/lioamber/lionml_data.f90
+++ b/lioamber/lionml_data.f90
@@ -19,8 +19,10 @@ module lionml_data
                                  lineal_search, timers, IGRID, IGRID2,         &
                                  use_libxc, ex_functional_id, ec_functional_id,&
                                  gpu_level, becke
-   use tbdft_data         , only: tbdft_calc, MTB, alfaTB, betaTB, gammaTB,      &
-                                  start_tdtb, end_tdtb,n_biasTB, driving_rateTB
+   use tbdft_data         , only: tbdft_calc, MTB, alfaTB, betaTB, gammaTB,    &
+                                  start_tdtb, end_tdtb,n_biasTB,               &
+                                  driving_rateTB, TB_q_tot, TB_charge_ref,     &
+                                  TB_q_told
    use ECP_mod           , only: ecpmode, ecptypes, tipeECP, ZlistECP,         &
                                  verbose_ECP, cutECP, local_nonlocal,          &
                                  ecp_debug, FOCK_ECP_read, FOCK_ECP_write,     &
@@ -105,7 +107,8 @@ module lionml_data
                   save_charge_freq, driving_rate, Pop_Drive,                   &
                   ! Variables for TBDFT
                   tbdft_calc, MTB, alfaTB, betaTB, gammaTB, start_tdtb,        &
-                  end_tdtb,n_biasTB, driving_rateTB,                           &
+                  end_tdtb,n_biasTB, driving_rateTB, TB_q_tot, TB_charge_ref,  &
+                  TB_q_told,                                                   &
                   !Fockbias
                   fockbias_is_active, fockbias_is_shaped, fockbias_readfile,   &
                   fockbias_timegrow , fockbias_timefall , fockbias_timeamp0,   &
@@ -163,10 +166,11 @@ module lionml_data
                           remove_zero_weights
       ! Transport and TBDFT
       double precision :: alfaTB, betaTB, driving_rate, gammaTB, Vbias_TB,     &
-                          driving_rateTB
+                          driving_rateTB, TB_charge_ref, TB_q_told
       logical          :: gate_field, generate_rho0, transport_calc
       integer          :: tbdft_calc, end_bTB, end_tdtb, MTB, pop_drive,       &
-                          save_charge_freq, start_tdtb, nbias, n_biasTB
+                          save_charge_freq, start_tdtb, nbias, n_biasTB,       &
+                          TB_q_tot
       ! Ehrenfest
       character*80     :: rsti_fname, rsto_fname, wdip_fname
       double precision :: eefld_ampx, eefld_ampy, eefld_ampz, eefld_timeamp,   &
@@ -221,7 +225,7 @@ subroutine get_namelist(lio_in)
    lio_in%print_coeffs     = print_coeffs    ; lio_in%writeforces = writeforces
    lio_in%verbose          = verbose         ; lio_in%rst_dens    = rst_dens
    lio_in%becke            = becke           ;
-   
+
    ! TDDFT - Fields
    lio_in%field_aniso_file = field_aniso_file; lio_in%a0         = a0
    lio_in%field_iso_file   = field_iso_file  ; lio_in%epsilon    = epsilon
@@ -266,11 +270,12 @@ subroutine get_namelist(lio_in)
    lio_in%driving_rate     = driving_rate    ; lio_in%alfaTB    = alfaTB
    lio_in%tbdft_calc        = tbdft_calc     ; lio_in%betaTB    = betaTB
    lio_in%nbias            = nbias           ; lio_in%gammaTB   = gammaTB
-   lio_in%generate_rho0    = generate_rho0
+   lio_in%generate_rho0    = generate_rho0   ; lio_in%TB_q_tot  = TB_q_tot
    lio_in%transport_calc   = transport_calc  ; lio_in%n_biasTB  = n_biasTB
    lio_in%end_tdtb         = end_tdtb        ; lio_in%pop_drive = pop_drive
    lio_in%save_charge_freq = save_charge_freq; lio_in%MTB       = MTB
-   lio_in%start_tdtb       = start_tdtb
+   lio_in%start_tdtb       = start_tdtb      ; lio_in%TB_q_told = TB_q_told
+   lio_in%TB_charge_ref    = TB_charge_ref
    lio_in%driving_rateTB   = driving_rateTB
    ! Ghost atoms
    lio_in%n_ghosts = n_ghosts ; lio_in%ghost_atoms = ghost_atoms

--- a/lioamber/lionml_subs.f90
+++ b/lioamber/lionml_subs.f90
@@ -187,7 +187,8 @@ subroutine lionml_write_dull()
    write(*,8142) inputs%MTB, inputs%alfaTB, inputs%betaTB
    write(*,8143) inputs%gammaTB, inputs%start_tdtb
    write(*,8144) inputs%end_tdtb, inputs%n_biasTB, inputs%driving_rateTB
-   write(*,8145) inputs%nbias
+   write(*,8145) inputs%nbias, inputs%TB_q_tot, inputs%TB_charge_ref,          &
+                 inputs%TB_q_told
    write(*,9000) " ! -- Ehrenfest: -- !"
    write(*,8160) inputs%ndyn_steps, inputs%edyn_steps, inputs%nullify_forces
    write(*,8161) inputs%wdip_nfreq, inputs%wdip_fname, inputs%rsti_loads
@@ -280,7 +281,8 @@ subroutine lionml_write_dull()
             I5, ",")
 8144 FORMAT(2x, "end_TDTB = ", I5,", n_biasTB = ", I5, ", driving_rateTB=",    &
             F14.8, "," )
-8145 FORMAT(2x, "nbias=",I5)
+8145 FORMAT(2x, "nbias=",I5, ", TB_q_tot =",I5,", TB_charge_ref=",F14.8,        &
+            ", TB_q_told=", F14.8)
 ! Ehrenfest
 8160 FORMAT(2x, "ndyn_steps = ", I6, ", edyn_steps = ", I6, &
             ", nullify_forces = ", L2, ",")
@@ -410,7 +412,8 @@ subroutine lionml_write_style()
    write(*,8458) inputs%alfaTB        ; write(*,8459) inputs%betaTB
    write(*,8460) inputs%gammaTB       ; write(*,8461) inputs%n_biasTB
    write(*,8462) inputs%start_tdtb    ; write(*,8463) inputs%end_tdtb
-   write(*,8464) inputs%driving_rateTB
+   write(*,8464) inputs%driving_rateTB; write(*,8465) inputs%TB_q_tot
+   write(*,8466) inputs%TB_charge_ref ; write(*,8467) inputs%TB_q_told
    write(*,8003)
 
    ! Ehrenfest
@@ -589,6 +592,9 @@ subroutine lionml_write_style()
 8462 FORMAT(4x,"║  start_tdtb          ║  ",18x,I5,2x,"║")
 8463 FORMAT(4x,"║  end_tdtb            ║  ",18x,I5,2x,"║")
 8464 FORMAT(4x,"║  driving_rateTB      ║  ",18x,F14.8,2x,"║")
+8465 FORMAT(4x,"║  TB_q_tot            ║  ",18x,I5,2x,"║")
+8466 FORMAT(4x,"║  TB_charge_ref       ║  ",18x,F14.8,2x,"║")
+8467 FORMAT(4x,"║  TB_q_told           ║  ",18x,F14.8,2x,"║")
 ! Ehrenfest
 8500 FORMAT(4x,"║  ndyn_steps          ║  ",17x,I6,2x,"║")
 8501 FORMAT(4x,"║  edyn_steps          ║  ",17x,I6,2x,"║")

--- a/lioamber/tbdft_data.f90
+++ b/lioamber/tbdft_data.f90
@@ -5,7 +5,7 @@ module tbdft_data
 !Important input variables:                                                    !
 ! * tbdft_calc : integer, indicates the different calculation options (0 off - !
 !               1 microcanonical dynamic - 2 DLVN rho0 generation -            !
-!               3 DLVN dynamic )                                               !
+!               3 DLVN dynamic - 4 charge calibration of the DFT part)                                               !
 ! * MTB        : Integer, total of TB elements.                                !
 ! * n_biasTB   : Integer, number of electrodes.                                !
 ! * start_tdtb : Integer, initial TD step for the aplication of the bias.      !
@@ -15,6 +15,11 @@ module tbdft_data
 !                this also control the band with of TB DOS.                    !
 ! * gammaTB    : Double precision real, coupling terms between TB and DFT part !
 ! * driving_rateTB : Double precision real, driving rate for DLVN calculation  !
+! * TB_q_tot   : Integer, maximum number of steps for TB charge calibration    !
+! * TB_charge_ref: Double precision real, reference charge for TB charge       !
+!                  calibration.                                                !
+! * TB_q_told  : Double precision real, convergence criteria of the charge     !
+!                during TB charge convergence.                                 !
 !                                                                              !
 !Input variables readed from the file gamma.in in the next order:              !
 ! * VbiasTB    : Double precision real array, store the bias of each electrode !
@@ -35,10 +40,13 @@ module tbdft_data
    integer      :: end_bTB
    integer      :: n_biasTB
    integer      :: n_atperbias
-   real(kind=8) :: alfaTB
+   integer      :: TB_q_tot   = 10
+   real(kind=8) :: alfaTB = 0.0d0
    real(kind=8) :: betaTB
    real(kind=8) :: gammaTB
    real(kind=8) :: driving_rateTB = 0.00d0
+   real(kind=8) :: TB_charge_ref = 0.0d0
+   real(kind=8) :: TB_q_told = 1.0d-6
    integer        , allocatable :: Iend_TB(:,:)        ! Index matrix for coupling.
    integer        , allocatable :: linkTB(:,:)
    integer        , allocatable :: basTB(:)


### PR DESCRIPTION
In this pull request, a new subroutine was implemented for calculating the Fermi energy of the TB part using as control parameter the total charge in the DFT part. This calculation is iterative, in each step a new SCF calculation runs with a Fermi energy modified and comparing  the DFT charge with an input reference.