### PR TITLE
Small fixes in GPU code.

### DIFF
--- a/g2g/analytic_integral/os_cutoff.cpp
+++ b/g2g/analytic_integral/os_cutoff.cpp
@@ -77,6 +77,7 @@ void OSIntegral<scalar_type>::new_cutoff(void) {
 
   for (uint current_term_type = 0; current_term_type < NUM_TERM_TYPES;
        current_term_type++) {
+    this->dens_offsets[current_term_type] = 0;
     this->term_type_counts[current_term_type] = 0;
     i_begin = i_begin_vals[current_term_type];
     i_end = i_end_vals[current_term_type];
@@ -196,12 +197,16 @@ void OSIntegral<scalar_type>::new_cutoff(void) {
       this->local_dens.push_back(
           local_dens[term_type_offsets[current_term_type]]);
     }
-    for (j = 0; j < QMMM_BLOCK_SIZE -
-                        (dens_counts[current_term_type] % QMMM_BLOCK_SIZE);
-         j++) {
-      this->dens_values.push_back(dens_values[dens_offsets[current_term_type]]);
-      this->local2globaldens.push_back(
-          local2globaldens[dens_offsets[current_term_type]]);
+    if (term_type_counts[current_term_type] > 0) {
+      for (j = 0; j < QMMM_BLOCK_SIZE - (dens_counts[current_term_type] % QMMM_BLOCK_SIZE); j++) {
+        this->dens_values.push_back(dens_values[dens_offsets[current_term_type]]);
+        this->local2globaldens.push_back(local2globaldens[dens_offsets[current_term_type]]);
+      }
+    } else {
+      for (j = 0; j < QMMM_BLOCK_SIZE - (dens_counts[current_term_type] % QMMM_BLOCK_SIZE); j++) {
+        this->dens_values.push_back(0.0f);
+        this->local2globaldens.push_back(0);
+      }
     }
   }
 

--- a/g2g/cuda/kernels/accumulate_point.h
+++ b/g2g/cuda/kernels/accumulate_point.h
@@ -94,10 +94,13 @@ __global__ void gpu_accumulate_point(
 
   calc_ggaCS_in<scalar_type, 4>(_partial_density, _dxyz, _dd1, _dd2, exc_x,
                                 exc_c, y2a, 9);
-  exc_corr = exc_x + exc_c;
 
-  if (compute_energy && valid_thread)
+  if (compute_energy && valid_thread) {
+    exc_corr = exc_x + exc_c;
     energy[point] = (_partial_density * point_weight) * exc_corr;
+  }
 
-  if (compute_factor && valid_thread) factor[point] = point_weight * y2a;
+  if (compute_factor && valid_thread) {
+    factor[point] = point_weight * y2a;
+  }
 }

--- a/g2g/pointxc/calc_ggaCS.h
+++ b/g2g/pointxc/calc_ggaCS.h
@@ -47,6 +47,7 @@ __host__ __device__ void calc_ggaCS(scalar_type dens,
 #endif
   if (dens < MINIMUM_DENSITY_VALUE) {
     ex = ec = (scalar_type) 0.0f;
+    y2a = (scalar_type) 0.0f;
     return;
   }
 
@@ -150,6 +151,11 @@ __host__ __device__ void calc_ggaCS(scalar_type dens,
     ex = expbe;
     ec = ecpbe;
     y2a = vxpbe + vcpbe;
+#ifdef _DEBUG
+    if (expbe != expbe) printf("NaN in expbe \n");
+    if (ecpbe != ecpbe) printf("NaN in ecpbe \n");
+    if (y2a != y2a) printf("NAN in y2a, vc %E, vx, %E \n", vcpbe, vxpbe);
+#endif
     return;
   }
 


### PR DESCRIPTION
* Fixed a precision issue in closed-shell PBE (can't believe these are still there).
* Fixed a bug in term counting in AINT module, which would appear if terms of a certain type are abstent while existing bigger ones (e.g. when there are no pp terms but there are ds terms).

With these changes, AINT routines are somehow fixed for architectures 3.0-5.2 in GeForce 10XX, and I do not understand why.