### PR TITLE
Add reading and writing 4 center integrals in memory

### DIFF
--- a/g2g/init.h
+++ b/g2g/init.h
@@ -4,7 +4,10 @@
 #include "matrix.h"
 
 #if USE_LIBINT
+#include <unordered_map>
 #include "libint/libintproxy.h"
+using shellpair_list_t = std::unordered_map<size_t, std::vector<size_t>>;
+using shellpair_data_t = std::vector<std::vector<std::shared_ptr<libint2::ShellPair>>>;
 #endif
 
 using std::vector;
@@ -73,8 +76,10 @@ struct FortranVars {
   vector<libint2::Shell> obs; // Basis (in libint format)
   vector<int> shell2bf;       // first basis function
   vector<int> shell2atom;     // atom centre of shell
-  uint center4Recalc;
-  double* integrals;
+  uint center4Recalc;  // Method
+  double* integrals;   // Integrals in memory
+  shellpair_list_t obs_shellpair_list;  // shellpair list for precalculated Integral
+  shellpair_data_t obs_shellpair_data;  // shellpair data for precalculated Integral
 #endif
   /////////////////////
   

--- a/g2g/libint/libintproxy.h
+++ b/g2g/libint/libintproxy.h
@@ -67,14 +67,22 @@ private:
        // Save Integrals
        int save_ints(vector<Shell>& ,vector<int>&);
 
+       // Write Integrals
+       int write_ints(vector<Shell>& ,vector<int>& );
+
        // Closed shell
        Matrix_E exchange(vector<Shell>&,int,vector<int>&,Matrix_E&);
 
        Matrix_E exchange_saving(vector<Shell>&,int,vector<int>&,double*,Matrix_E&);
 
+       Matrix_E exchange_reading(vector<Shell>&,int,vector<int>&,Matrix_E&);
+
        vector<Matrix_E> CoulombExchange(vector<Shell>&,int,vector<int>&,double,int,vector<Matrix_E>&);
 
        vector<Matrix_E> CoulombExchange_saving(vector<Shell>&,int,vector<int>&,double,
+                                               int,double*,vector<Matrix_E>&);
+
+       vector<Matrix_E> CoulombExchange_reading(vector<Shell>&,int,vector<int>&,double,
                                                int,double*,vector<Matrix_E>&);
 
        vector<Matrix_E> compute_deriv(vector<Shell>&,vector<int>&,vector<int>&,

--- a/g2g/libint/libintproxy.h
+++ b/g2g/libint/libintproxy.h
@@ -3,6 +3,7 @@
 
 #include <libint2.hpp>
 #include "../init.h"
+#include <unordered_map>
 #include <string>
 
 typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> Matrix_E;
@@ -18,6 +19,10 @@ using libint2::BraKet;
 // namespace STD
 using std::vector;
 using std::string;
+
+// Precalculated Integrals
+using shellpair_list_t = std::unordered_map<size_t, std::vector<size_t>>;
+using shellpair_data_t = std::vector<std::vector<std::shared_ptr<libint2::ShellPair>>>;
 
 typedef unsigned int uint;
 
@@ -50,6 +55,10 @@ private:
        int make_basis(const
             vector<Atom>&,double*,double*,uint*,
             uint*,int,int,int,int);
+
+       std::tuple<shellpair_list_t,shellpair_data_t>
+       compute_shellpairs(vector<Shell>&,
+                          double threshold = 1e-12);
 
        int map_shell();
 


### PR DESCRIPTION
Add new method in four center integrals with libint. This method can read and write the integrals in a binary file scratch. In order to use this method you have to set the option libint_recalc=2