### PR TITLE
CEED implementation

### DIFF
--- a/lioamber/Makefile.depends
+++ b/lioamber/Makefile.depends
@@ -148,7 +148,7 @@ OBJECTS += ceed_data.o
 OBJECTS += ceed_subs.o
 
 tmplist :=
-tmplist += TD.o
+tmplist += TD.o lio_finalize.o
 $(tmplist:%.o=$(OBJPATH)/%.o) : $(OBJPATH)/ceed_subs.mod
 
 tmplist :=

--- a/lioamber/Makefile.depends
+++ b/lioamber/Makefile.depends
@@ -53,7 +53,7 @@ OBJECTS += convert_types.o
 # GENERIC DEPENDENCIES
 TD.o : properties.o
 
-tmplist := 
+tmplist :=
 tmplist += packed_storage.o propagators.o tbdft_subs.o TD.o liosubs_math.o
 $(tmplist:%.o=$(OBJPATH)/%.o) : convert_types.o
 
@@ -144,6 +144,17 @@ tmplist += dos_subs.o lionml_data.o
 $(tmplist:%.o=$(OBJPATH)/%.o) : $(OBJPATH)/dos_data.mod
 
 ################################################################################
+OBJECTS += ceed_data.o
+OBJECTS += ceed_subs.o
+
+tmplist :=
+tmplist += TD.o
+$(tmplist:%.o=$(OBJPATH)/%.o) : $(OBJPATH)/ceed_subs.mod
+
+tmplist :=
+tmplist += TD.o ceed_subs.o
+$(tmplist:%.o=$(OBJPATH)/%.o) : $(OBJPATH)/ceed_data.mod
+################################################################################
 include converger_subs/conver.mk
 OBJECTS += converger_data.o
 OBJECTS += converger_subs.o
@@ -196,7 +207,7 @@ $(tmplist:%.o=$(OBJPATH)/%.o) : $(OBJPATH)/transport.mod
 OBJECTS += TD.o
 
 tmplist :=
-tmplist += input_read.o init_lio.o ehrensubs.o lionml_data.o drive.o 
+tmplist += input_read.o init_lio.o ehrensubs.o lionml_data.o drive.o
 $(tmplist:%.o=$(OBJPATH)/%.o) : $(OBJPATH)/TD.mod
 ################################################################################
 OBJECTS += fockbias_data.o
@@ -248,7 +259,7 @@ OBJECTS += faint_cpu.o
 modusrs :=
 modusrs += cublasmath.o ehrensubs.o liomain.o converger_subs.o
 modusrs += propagators.o SCF.o TD.o field_subs.o excitedsubs.o generalECP.o
-modusrs += dft_get_mm_forces.o dft_get_qm_forces.o
+modusrs += dft_get_mm_forces.o dft_get_qm_forces.o ceed_subs.o
 $(modusrs:%.o=$(OBJPATH)/%.o) : ${OBJPATH}/faint_cpu.mod
 
 ################################################################################
@@ -257,14 +268,14 @@ SRCDIRS += dftd3
 OBJECTS += dftd3.o
 
 tmplist :=
-tmplist += 
-tmplist += 
+tmplist +=
+tmplist +=
 tmplist += SCF.o dft_get_mm_forces.o dft_get_qm_forces.o lionml_data.o
 $(tmplist:%.o=$(OBJPATH)/%.o) : $(OBJPATH)/dftd3.o
 
 ################################################################################
-tmplist := 
-tmplist += cubegen.o 
+tmplist :=
+tmplist += cubegen.o
 tmplist += init_lio.o
 tmplist += liomain.o
 tmplist += lionml_data.o
@@ -322,7 +333,7 @@ SRCDIRS += typedef_cumat
 OBJECTS += typedef_cumat.o
 #
 modusrs := SCF.o converger_subs.o typedef_operator.o transport.o propagators.o tbdft_subs.o
-modusrs +=
+modusrs += ceed_data.o
 $(modusrs:%.o=$(OBJPATH)/%.o) : ${OBJPATH}/typedef_cumat.mod
 
 ################################################################################
@@ -341,7 +352,7 @@ OBJECTS += typedef_operator.o
 #
 modusrs :=
 modusrs += SCF.o converger_subs.o TD.o geometry_optim.o liomain.o CDFT.o
-modusrs += tbdft_subs.o
+modusrs += tbdft_subs.o ceed_data.o
 $(modusrs:%.o=$(OBJPATH)/%.o) : ${OBJPATH}/typedef_operator.mod
 ################################################################################
 OBJECTS += mask_ecp.o

--- a/lioamber/TD.f90
+++ b/lioamber/TD.f90
@@ -902,7 +902,6 @@ subroutine td_verlet(M, M_f, dim3, OPEN, fock_aop, rhold, rho_aop, rhonew, &
    TDCOMPLEX              :: liocmplx                  
 
    allocate(rho(M_f, M_f, dim3), rho_aux(M_f,M_f,dim3))
-   if (ceed_calc) allocate(fock_aux(M_f,M_f,dim3))
    call rho_aop%Gets_dataC_ON(rho(:,:,1))
    if (OPEN) call rho_bop%Gets_dataC_ON(rho(:,:,2))
 
@@ -942,6 +941,8 @@ subroutine td_verlet(M, M_f, dim3, OPEN, fock_aop, rhold, rho_aop, rhonew, &
 
    !Including CEED term
    if(ceed_calc) then
+      allocate(fock_aux(M_f,M_f,dim3))
+
       call fock_aop%Gets_data_ON(fock_aux(:,:,1))
       call rho_aop%Gets_dataC_ON(rho_aux(:,:,1))
       if (OPEN) then
@@ -957,6 +958,8 @@ subroutine td_verlet(M, M_f, dim3, OPEN, fock_aop, rhold, rho_aop, rhonew, &
          rhonew = rhonew + liocmplx(2.0d0,0.0d0)*real(dt_lpfrg,COMPLEX_SIZE/2)*&
                            rho_aux
       end if
+
+      deallocate(fock_aux)
    end if
 
    !Transport: Add the driving term to the propagation.

--- a/lioamber/TD.f90
+++ b/lioamber/TD.f90
@@ -899,7 +899,7 @@ subroutine td_verlet(M, M_f, dim3, OPEN, fock_aop, rhold, rho_aop, rhonew, &
 
    LIODBLE  , allocatable :: fock_aux(:,:,:)
    TDCOMPLEX, allocatable :: rho(:,:,:), rho_aux(:,:,:)
-   TDCOMPLEX              :: liocmplx                  
+   TDCOMPLEX              :: liocmplx
 
    allocate(rho(M_f, M_f, dim3), rho_aux(M_f,M_f,dim3))
    call rho_aop%Gets_dataC_ON(rho(:,:,1))
@@ -987,6 +987,9 @@ subroutine td_verlet(M, M_f, dim3, OPEN, fock_aop, rhold, rho_aop, rhonew, &
          call Xtrans%change_base(rhonew_AOTB(:,:,2), 'dir')
       endif
    endif
+
+   deallocate(fock_aux, rho, rho_aux)
+   
 end subroutine td_verlet
 
 subroutine td_magnus(M, dim3, OPEN, fock_aop, F1a, F1b, rho_aop, rhonew,       &

--- a/lioamber/TD.f90
+++ b/lioamber/TD.f90
@@ -68,7 +68,6 @@ subroutine TD(fock_aop, rho_aop, fock_bop, rho_bop)
    use typedef_operator, only: operator
    use typedef_cumat   , only: cumat_x, cumat_r
    use faint_cpu       , only: int2
-   use ceed_data       , only: ceed_calc
    use ceed_subs       , only: ceed_init
 
    implicit none
@@ -898,8 +897,9 @@ subroutine td_verlet(M, M_f, dim3, OPEN, fock_aop, rhold, rho_aop, rhonew, &
    type(operator), intent(inout) :: fock_aop, rho_aop
    type(operator), intent(inout), optional :: fock_bop, rho_bop
 
-   LIODBLE , allocatable :: fock_aux(:,:,:)
-   TDCOMPLEX,  allocatable :: rho(:,:,:), rho_aux(:,:,:)
+   LIODBLE  , allocatable :: fock_aux(:,:,:)
+   TDCOMPLEX, allocatable :: rho(:,:,:), rho_aux(:,:,:)
+   TDCOMPLEX              :: liocmplx                  
 
    allocate(rho(M_f, M_f, dim3), rho_aux(M_f,M_f,dim3))
    if (ceed_calc) allocate(fock_aux(M_f,M_f,dim3))
@@ -933,7 +933,8 @@ subroutine td_verlet(M, M_f, dim3, OPEN, fock_aop, rhold, rho_aop, rhonew, &
 
    !Including Euler steps if they are required
    if ((td_eu_step /= 0).and.(mod(istep, td_eu_step)==0)) then
-      rhonew = rho - 0.5d0*real(dt_lpfrg,COMPLEX_SIZE/2) * (Im * rhonew)
+      rhonew = rho - liocmplx(0.5d0,0.0d0)*real(dt_lpfrg,COMPLEX_SIZE/2) *     &
+                     (Im * rhonew)
    else
       rhonew = rhold - real(dt_lpfrg,COMPLEX_SIZE/2) * (Im * rhonew)
    end if
@@ -953,7 +954,8 @@ subroutine td_verlet(M, M_f, dim3, OPEN, fock_aop, rhold, rho_aop, rhonew, &
       if ((td_eu_step /= 0).and.(mod(istep, td_eu_step)==0)) then
          rhonew = rhonew + real(dt_lpfrg,COMPLEX_SIZE/2) * rho_aux
       else
-         rhonew = rhonew + 2.0d0 * real(dt_lpfrg,COMPLEX_SIZE/2) * rho_aux
+         rhonew = rhonew + liocmplx(2.0d0,0.0d0)*real(dt_lpfrg,COMPLEX_SIZE/2)*&
+                           rho_aux
       end if
    end if
 

--- a/lioamber/TD.f90
+++ b/lioamber/TD.f90
@@ -988,7 +988,7 @@ subroutine td_verlet(M, M_f, dim3, OPEN, fock_aop, rhold, rho_aop, rhonew, &
       endif
    endif
 
-   deallocate(fock_aux, rho, rho_aux)
+   deallocate(rho, rho_aux)
    
 end subroutine td_verlet
 

--- a/lioamber/TD.f90
+++ b/lioamber/TD.f90
@@ -33,7 +33,9 @@ module td_data
    integer :: timedep   = 0
    integer :: ntdstep   = 0
    integer :: td_do_pop = 0
-   LIODBLE  :: tdstep    = 2.0D-3
+   integer :: td_eu_step = 0      !Include Euler steps each td_eu_step steps
+                                  !only in Verlet propagator.
+   LIODBLE :: tdstep    = 2.0D-3
    logical :: tdrestart = .false.
    logical :: writedens = .false.
    LIODBLE  :: pert_time = 2.0D-1
@@ -51,7 +53,7 @@ subroutine TD(fock_aop, rho_aop, fock_bop, rho_bop)
    use basis_data    , only: M, Nuc, MM
    use basis_subs    , only: neighbour_list_2e
    use td_data       , only: td_rst_freq, tdstep, ntdstep, tdrestart, &
-                             writedens, pert_time
+                             writedens, pert_time, td_eu_step
    use field_data    , only: field, fx, fy, fz
    use field_subs    , only: field_setup_old, field_finalize
    use transport_data, only: transport_calc
@@ -66,6 +68,8 @@ subroutine TD(fock_aop, rho_aop, fock_bop, rho_bop)
    use typedef_operator, only: operator
    use typedef_cumat   , only: cumat_x, cumat_r
    use faint_cpu       , only: int2
+   use ceed_data       , only: ceed_calc
+   use ceed_subs       , only: ceed_init
 
    implicit none
 !carlos: Operator inserted for TD
@@ -213,6 +217,8 @@ subroutine TD(fock_aop, rho_aop, fock_bop, rho_bop)
    ! Diagonalizes Smat and calculates the base change matrices (x,y,Xtrans)
    call td_overlap_diag(M_f, M, Smat, Xmat, Xtrans, Ymat)
 
+   call ceed_init(M, OPEN, r, d, natom, ntatom, propagator)
+
    call rho_aop%BChange_AOtoON(Ymat, M_f)
    if (OPEN) call rho_bop%BChange_AOtoON(Ymat, M_f)
 
@@ -277,13 +283,14 @@ subroutine TD(fock_aop, rho_aop, fock_bop, rho_bop)
             call td_bc_fock(M_f, M, Fmat_vec2, fock_bop, Xmat, istep, &
                             t/0.024190D0)
             call td_verlet(M, M_f, dim3, OPEN, fock_aop, rhold, rho_aop, &
-                           rhonew, istep, Im, dt_lpfrg, transport_calc,  &
-                           natom, Nuc, Iz, overlap, sqsm, Ymat, Xtrans,  &
-                           fock_bop, rho_bop)
+                           rhonew, istep, td_eu_step, Im, dt_lpfrg,            &
+                           transport_calc, natom, Nuc, Iz, overlap, sqsm, Ymat,&
+                           Xtrans, fock_bop, rho_bop)
          else
             call td_verlet(M, M_f, dim3, OPEN, fock_aop, rhold, rho_aop, &
-                           rhonew, istep, Im, dt_lpfrg, transport_calc,  &
-                           natom, Nuc, Iz, overlap, sqsm, Ymat, Xtrans)
+                           rhonew, istep, td_eu_step, Im, dt_lpfrg,            &
+                           transport_calc, natom, Nuc, Iz, overlap, sqsm, Ymat,&
+                           Xtrans)
          end if
 
          if (propagator == 2) then
@@ -572,6 +579,7 @@ end subroutine td_integral_1e
 subroutine td_overlap_diag(M_f, M, Smat, Xmat, Xtrans, Ymat)
    use typedef_cumat, only: cumat_r, cumat_x
    use tbdft_subs   , only: getXY_TBDFT
+   use ceed_data    , only: ceed_calc, Xmat_ceed
 
    implicit none
    integer      , intent(in)    :: M_f, M
@@ -623,6 +631,8 @@ subroutine td_overlap_diag(M_f, M, Smat, Xmat, Xtrans, Ymat)
       endif
    enddo
 
+   ! CEED: X_min most be stored for CEED no matter the kind of calculation
+   if (ceed_calc) call Xmat_ceed%init(M, X_min)
    ! TBDFT: Xmat and Ymat are adapted for TBDFT
    call getXY_TBDFT(M, X_min, Y_min, X_mat, Y_mat)
 
@@ -866,29 +876,33 @@ subroutine td_bc_fock(M_f, M, Fmat, fock_op, Xmat, istep, time)
 end subroutine td_bc_fock
 
 subroutine td_verlet(M, M_f, dim3, OPEN, fock_aop, rhold, rho_aop, rhonew, &
-                     istep, Im, dt_lpfrg, transport_calc, natom, Nuc, Iz,  &
-                     overlap, sqsm, Ymat, Xtrans, fock_bop, rho_bop)
+                     istep, td_eu_step, Im, dt_lpfrg, transport_calc, natom,   &
+                     Nuc, Iz, overlap, sqsm, Ymat, Xtrans, fock_bop, rho_bop)
    use transport_subs  , only: transport_propagate
-   use tbdft_data      , only: tbdft_calc, rhold_AOTB, rhonew_AOTB
+   use tbdft_data      , only: tbdft_calc, rhold_AOTB, rhonew_AOTB, MTB
    use tbdft_subs      , only: transport_TB
    use typedef_operator, only: operator
    use typedef_cumat   , only: cumat_x
+   use ceed_data       , only: ceed_calc
+   use ceed_subs       , only: ceed_fock_calculation
    implicit none
 
    logical       , intent(in)    :: OPEN
-   integer       , intent(in)    :: M,M_f, istep, natom, Nuc(M), Iz(natom), dim3
+   integer       , intent(in)    :: M, M_f, natom, Nuc(M), Iz(natom), dim3
+   integer       , intent(in)    :: istep, td_eu_step
    logical       , intent(in)    :: transport_calc
-   LIODBLE  , intent(in)    :: dt_lpfrg, overlap(:,:), sqsm(M,M)
+   LIODBLE       , intent(in)    :: dt_lpfrg, overlap(:,:), sqsm(M,M)
    TDCOMPLEX     , intent(in)    :: Im
    type(cumat_x) , intent(in)    :: Ymat, Xtrans
    TDCOMPLEX     , intent(inout) :: rhold(M_f,M_f, dim3), rhonew(M_f,M_f, dim3)
    type(operator), intent(inout) :: fock_aop, rho_aop
    type(operator), intent(inout), optional :: fock_bop, rho_bop
 
+   LIODBLE , allocatable :: fock_aux(:,:,:)
    TDCOMPLEX,  allocatable :: rho(:,:,:), rho_aux(:,:,:)
 
    allocate(rho(M_f, M_f, dim3), rho_aux(M_f,M_f,dim3))
-
+   if (ceed_calc) allocate(fock_aux(M_f,M_f,dim3))
    call rho_aop%Gets_dataC_ON(rho(:,:,1))
    if (OPEN) call rho_bop%Gets_dataC_ON(rho(:,:,2))
 
@@ -916,8 +930,32 @@ subroutine td_verlet(M, M_f, dim3, OPEN, fock_aop, rhold, rho_aop, rhonew, &
    call g2g_timer_start('commutator')
    call fock_aop%Commut_data_c(rho(:,:,1), rhonew(:,:,1), M_f)
    if (OPEN) call fock_bop%Commut_data_c(rho(:,:,2), rhonew(:,:,2), M_f)
-   rhonew = rhold - real(dt_lpfrg,COMPLEX_SIZE/2) * (Im * rhonew)
+
+   !Including Euler steps if they are required
+   if ((td_eu_step /= 0).and.(mod(istep, td_eu_step)==0)) then
+      rhonew = rho - 0.5d0*real(dt_lpfrg,COMPLEX_SIZE/2) * (Im * rhonew)
+   else
+      rhonew = rhold - real(dt_lpfrg,COMPLEX_SIZE/2) * (Im * rhonew)
+   end if
    call g2g_timer_stop('commutator')
+
+   !Including CEED term
+   if(ceed_calc) then
+      call fock_aop%Gets_data_ON(fock_aux(:,:,1))
+      call rho_aop%Gets_dataC_ON(rho_aux(:,:,1))
+      if (OPEN) then
+         call fock_bop%Gets_data_ON(fock_aux(:,:,2))
+         call rho_bop%Gets_dataC_ON(rho_aux(:,:,2))
+      end if
+      call ceed_fock_calculation(fock_aux(MTB+1:M_f,MTB+1:M_f,:),              &
+                                 rho_aux(MTB+1:M_f,MTB+1:M_f,:), M, istep,     &
+                                 dim3, OPEN)
+      if ((td_eu_step /= 0).and.(mod(istep, td_eu_step)==0)) then
+         rhonew = rhonew + real(dt_lpfrg,COMPLEX_SIZE/2) * rho_aux
+      else
+         rhonew = rhonew + 2.0d0 * real(dt_lpfrg,COMPLEX_SIZE/2) * rho_aux
+      end if
+   end if
 
    !Transport: Add the driving term to the propagation.
    if ((istep >= 3) .and. (transport_calc)) then

--- a/lioamber/ceed_data.f90
+++ b/lioamber/ceed_data.f90
@@ -1,0 +1,29 @@
+#include "datatypes/datatypes.fh"
+module ceed_data
+   use typedef_operator, only: operator
+   use typedef_cumat   , only: cumat_r
+
+   implicit none
+
+!Important input variables:
+! * ceed_calc    : logical, indicates if a CEED calculation will be performed.
+! * ceed_td_step : integer, indicates what step CEED will be start.
+! * k_ceed       : Double precision, acceleration factor for CEED term.
+   logical                     :: ceed_calc      = .false.
+   integer                     :: ceed_td_step = 100
+   LIODBLE                     :: k_ceed         = 1.0d0
+   LIODBLE       , parameter   :: A_ceed         = 2.592668788247536d-7
+                                                  !2/3 \hbar \alpha/c^2
+   LIODBLE       , allocatable :: d2dip_ceed(:,:) !Matrix to store the total 
+                                                  !second derivatives of the
+                                                  !dipole moment in the 3
+                                                  !coordinates.
+   type(cumat_r)               :: Xmat_ceed !Base change operator
+   type(operator), allocatable :: dip_ceed_op(:) !Dipole matrix operator for
+                                                 !each coordinate.
+   type(operator), allocatable :: d2ip_ceed_op(:,:)!Second derivative dipole
+                                                   !matrix operator for each
+                                                   !coordinate and each spin.
+   type(operator), allocatable :: fock_ceed_op(:)!Auxiliar fock matrix operator.
+
+end module ceed_data

--- a/lioamber/ceed_subs.f90
+++ b/lioamber/ceed_subs.f90
@@ -124,5 +124,18 @@ subroutine ceed_fock_calculation(fock, rho_aux, M, t_step, dim3, open_shell)
 end subroutine ceed_fock_calculation
 
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine ceed_finalize()
+   use ceed_data, only: ceed_calc, dip_ceed_op, d2ip_ceed_op,            &
+                         fock_ceed_op, d2dip_ceed, Xmat_ceed
+   implicit none
 
+   if(.not.ceed_calc) return
+   deallocate(dip_ceed_op)
+   deallocate(d2ip_ceed_op)
+   deallocate(fock_ceed_op)
+   deallocate(d2dip_ceed)
+   call Xmat_ceed%destroy()
+
+end subroutine ceed_finalize
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
 end module ceed_subs

--- a/lioamber/ceed_subs.f90
+++ b/lioamber/ceed_subs.f90
@@ -7,7 +7,7 @@ contains
 subroutine ceed_init(M, open_shell, r, d, natom, ntatom, propagator)
 ! This subroutine initialize the variables for CEED calculations
    use ceed_data, only: ceed_calc, dip_ceed_op, d2ip_ceed_op,            &
-                         fock_ceed_op, d2dip_ceed, Xmat_ceed, k_ceed
+                         fock_ceed_op, d2dip_ceed, Xmat_ceed
    use faint_cpu , only: intfld
 
    implicit none
@@ -68,7 +68,7 @@ subroutine ceed_fock_calculation(fock, rho_aux, M, t_step, dim3, open_shell)
 !             A_ceed = 2/3 \alpha/c^2 = 2.592668788247536d-7
 
    use ceed_data, only: ceed_calc, dip_ceed_op, d2ip_ceed_op, d2dip_ceed,     &
-                         A_ceed, fock_ceed_op, k_ceed,ceed_td_step
+                         A_ceed, fock_ceed_op, k_ceed, ceed_td_step
    implicit none
 
    logical   , intent(in)    :: open_shell
@@ -83,11 +83,12 @@ subroutine ceed_fock_calculation(fock, rho_aux, M, t_step, dim3, open_shell)
    LIODBLE                :: aux_mat2(M,M,dim3)
    LIODBLE                :: aux_mat3(M,M,dim3)
    TDCOMPLEX              :: aux_mat4(M,M,dim3)
+   TDCOMPLEX              :: liocmplx
 
    if (.not.ceed_calc) return
 
    aux_mat3 = 0.0d0
-   aux_mat4 = 0.0d0
+   aux_mat4 = liocmplx(0.0d0,0.0d0)
 
    if (t_step > ceed_td_step) then
       do ii = 1,3

--- a/lioamber/ceed_subs.f90
+++ b/lioamber/ceed_subs.f90
@@ -1,0 +1,127 @@
+#include "datatypes/datatypes.fh"
+module ceed_subs
+   implicit none
+contains
+
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine ceed_init(M, open_shell, r, d, natom, ntatom, propagator)
+! This subroutine initialize the variables for CEED calculations
+   use ceed_data, only: ceed_calc, dip_ceed_op, d2ip_ceed_op,            &
+                         fock_ceed_op, d2dip_ceed, Xmat_ceed, k_ceed
+   use faint_cpu , only: intfld
+
+   implicit none
+   logical, intent(in)  :: open_shell
+   integer, intent(in)  :: M
+   integer, intent(in)  :: propagator
+   integer, intent(in)  :: natom
+   integer, intent(in)  :: ntatom
+   LIODBLE, intent(in)  :: r(ntatom,3)
+   LIODBLE, intent(in)  :: d(natom,natom)
+   integer              :: ii
+   integer              :: MM
+   LIODBLE              :: vec_aux(3)
+   LIODBLE, allocatable :: dip_array(:)
+   LIODBLE, allocatable :: dip_mat_aux(:,:)
+
+   if (.not. ceed_calc) return
+
+   if (propagator /= 1) then
+      write(*,*) "CEED calculation can only be performed with Verlet propagator"
+      write(*,*) "Stopping LIO"
+      stop
+   end if
+
+   MM = M*(M+1)/2
+
+   allocate(dip_ceed_op(3),dip_array(MM), dip_mat_aux(M, M))
+
+   if (.not.open_shell) then
+      allocate(fock_ceed_op(1), d2ip_ceed_op(3,1), d2dip_ceed(3,1))
+   else
+      allocate(fock_ceed_op(2), d2ip_ceed_op(3,2), d2dip_ceed(3,2))
+   end if
+
+   do ii=1, 3
+      dip_array    = 0.0d0
+      dip_mat_aux  = 0.0d0
+      vec_aux      = 0.0d0
+      vec_aux(ii)  = 1.0d0
+      call intfld(dip_array, dip_array, r, d, natom, ntatom, .false., 1.0d0,   &
+                  vec_aux(1), vec_aux(2), vec_aux(3))
+      call spunpack('L', M, dip_array, dip_mat_aux)
+      call dip_ceed_op(ii)%Sets_data_AO(dip_mat_aux)
+      call dip_ceed_op(ii)%BChange_AOtoON(Xmat_ceed, M)
+   end do
+
+end subroutine ceed_init
+
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine ceed_fock_calculation(fock, rho_aux, M, t_step, dim3, open_shell)
+!This subroutine includes the CEED term in the evolution of the density matrix.
+!At the end of the subroutine rho_aux store the commutator -i[H_CEED,\rho],
+!were:
+!              H_CEED =  -i A_ceed d^2<\mu>/dt^2 . [\mu , H]
+!d^2<\mu>/dt^2 is approximated as:
+!               d^2<\mu>/dt^2 = - Tr(\rho . [[\mu,H],H])
+!and:
+!             A_ceed = 2/3 \alpha/c^2 = 2.592668788247536d-7
+
+   use ceed_data, only: ceed_calc, dip_ceed_op, d2ip_ceed_op, d2dip_ceed,     &
+                         A_ceed, fock_ceed_op, k_ceed,ceed_td_step
+   implicit none
+
+   logical   , intent(in)    :: open_shell
+   integer   , intent(in)    :: M
+   integer   , intent(in)    :: dim3
+   integer   , intent(in)    :: t_step
+   LIODBLE   , intent(in)    :: fock(M,M,dim3)
+   TDCOMPLEX , intent(inout) :: rho_aux(M,M,dim3)
+   integer                :: ii, jj, kk, ss
+   LIODBLE                :: aux1
+   LIODBLE                :: aux_mat1(M,M,dim3)
+   LIODBLE                :: aux_mat2(M,M,dim3)
+   LIODBLE                :: aux_mat3(M,M,dim3)
+   TDCOMPLEX              :: aux_mat4(M,M,dim3)
+
+   if (.not.ceed_calc) return
+
+   aux_mat3 = 0.0d0
+   aux_mat4 = 0.0d0
+
+   if (t_step > ceed_td_step) then
+      do ii = 1,3
+      do ss = 1,dim3
+         call dip_ceed_op(ii)%Commut_data_r(fock(:,:,ss), aux_mat1(:,:,ss), M)
+         call d2ip_ceed_op(ii,ss)%Sets_data_ON(aux_mat1(:,:,ss))
+         call d2ip_ceed_op(ii,ss)%Commut_data_r(fock(:,:,ss),aux_mat2(:,:,ss),M)
+         d2dip_ceed(ii,ss) = 0.0d0
+         do jj=1, M
+         do kk=1, M
+            aux1 = dble(rho_aux(jj,kk,ss)*aux_mat2(kk,jj,ss))
+            d2dip_ceed(ii,ss) = d2dip_ceed(ii,ss) - aux1
+         end do
+         end do
+
+      end do
+         aux1     = d2dip_ceed(ii,1)
+         if (open_shell) aux1 = aux1 + d2dip_ceed(ii,2)
+         aux_mat3 = aux_mat3 + k_ceed * A_ceed * aux1 * aux_mat1
+      end do
+
+      do ss = 1,dim3
+         call fock_ceed_op(ss)%Sets_data_ON(aux_mat3(:,:,ss))
+         call fock_ceed_op(ss)%Commut_data_c(rho_aux(:,:,ss),                  &
+                                             aux_mat4(:,:,ss), M)
+      end do
+
+   end if
+
+   rho_aux = aux_mat4
+
+
+end subroutine ceed_fock_calculation
+
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+
+end module ceed_subs

--- a/lioamber/ceed_subs.f90
+++ b/lioamber/ceed_subs.f90
@@ -34,7 +34,7 @@ subroutine ceed_init(M, open_shell, r, d, natom, ntatom, propagator)
 
    MM = M*(M+1)/2
 
-   allocate(dip_ceed_op(3),dip_array(MM), dip_mat_aux(M, M))
+   allocate(dip_ceed_op(3), dip_array(MM), dip_mat_aux(M, M))
 
    if (.not.open_shell) then
       allocate(fock_ceed_op(1), d2ip_ceed_op(3,1), d2dip_ceed(3,1))
@@ -54,6 +54,7 @@ subroutine ceed_init(M, open_shell, r, d, natom, ntatom, propagator)
       call dip_ceed_op(ii)%BChange_AOtoON(Xmat_ceed, M)
    end do
 
+   deallocate(dip_array, dip_mat_aux)
 end subroutine ceed_init
 
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
@@ -126,14 +127,14 @@ end subroutine ceed_fock_calculation
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
 subroutine ceed_finalize()
    use ceed_data, only: ceed_calc, dip_ceed_op, d2ip_ceed_op,            &
-                         fock_ceed_op, d2dip_ceed, Xmat_ceed
+                        fock_ceed_op, d2dip_ceed, Xmat_ceed
    implicit none
 
-   if(.not.ceed_calc) return
-   deallocate(dip_ceed_op)
-   deallocate(d2ip_ceed_op)
-   deallocate(fock_ceed_op)
-   deallocate(d2dip_ceed)
+   if (.not.ceed_calc) return
+   if (allocated(dip_ceed_op) ) deallocate(dip_ceed_op)
+   if (allocated(d2ip_ceed_op)) deallocate(d2ip_ceed_op)
+   if (allocated(fock_ceed_op)) deallocate(fock_ceed_op)
+   if (allocated(d2dip_ceed)  ) deallocate(d2dip_ceed)
    call Xmat_ceed%destroy()
 
 end subroutine ceed_finalize

--- a/lioamber/lio_finalize.f90
+++ b/lioamber/lio_finalize.f90
@@ -10,7 +10,8 @@ subroutine lio_finalize()
    use basis_subs    , only: basis_deinit
    use converger_subs, only: converger_finalise
    use dftd3         , only: dftd3_finalise
- 
+   use ceed_subs     , only: ceed_finalize
+
    implicit none
    call basis_deinit() ! Deallocates basis variables.
    call io_finish_outputs(dipole, 69)
@@ -37,4 +38,5 @@ subroutine lio_finalize()
    call g2g_deinit()
    call converger_finalise()
    call dftd3_finalise()
+   call ceed_finalize()
 end subroutine

--- a/lioamber/lionml_data.f90
+++ b/lioamber/lionml_data.f90
@@ -168,10 +168,10 @@ module lionml_data
       logical          :: diis, hybrid_converg, open, vcinp, writexyz, &
                           level_shift
       ! FILE IO
-      character(len=80):: basis_set, fitting_set
-      character(len=40):: frestartin, frestart
-      integer          :: restart_freq, timers, verbose, rst_dens
-      logical          :: dbug, dipole, fukui, gaussian_convert, int_basis,   &
+      character(len=100):: basis_set, fitting_set
+      character(len=40) :: frestartin, frestart
+      integer           :: restart_freq, timers, verbose, rst_dens
+      logical           :: dbug, dipole, fukui, gaussian_convert, int_basis,   &
                           lowdin, mulliken, print_coeffs, style, writeforces, &
                           becke
       ! TD-DFT and FIELD

--- a/lioamber/lionml_data.f90
+++ b/lioamber/lionml_data.f90
@@ -45,7 +45,7 @@ module lionml_data
                                  fockbias_timeamp0 , fockbias_readfile
    use initial_guess_data, only: initial_guess
    use td_data           , only: tdrestart, writedens, td_rst_freq, tdstep,    &
-                                 ntdstep, timedep, td_do_pop
+                                 ntdstep, timedep, td_do_pop, td_eu_step
    use trans_Data        , only: gaussian_convert
    use transport_data    , only: transport_calc, generate_rho0, nbias,         &
                                  save_charge_freq, driving_rate, Pop_Drive
@@ -70,9 +70,10 @@ module lionml_data
                                  w_rho_zmax, w_rho_dx,  w_rho_dy, w_rho_dz,    &
                                  w_rho_rmin, w_rho_rmax, w_rho_dr,             &
                                  w_rho_dtheta, w_rho_dphi, write1Drho
+   use ceed_data         , only: ceed_calc, ceed_td_step, k_ceed
    use extern_functional_data, only: extern_functional, functional_id
 
-   
+
    implicit none
 
 !  Namelist definition
@@ -100,7 +101,7 @@ module lionml_data
                   rst_dens, becke,                                             &
                   ! DFT and TD-DFT Variables.
                   timedep, tdstep, ntdstep, propagator, NBCH, tdrestart,       &
-                  writedens, td_rst_freq, td_do_pop,                           &
+                  writedens, td_rst_freq, td_do_pop, td_eu_step,               &
                   ! Field Variables
                   field, epsilon, a0, Fx, Fy, Fz, nfields_iso, nfields_aniso,  &
                   field_aniso_file, field_iso_file,                            &
@@ -154,7 +155,9 @@ module lionml_data
                   ! Dispersion corrections.
                   dftd3,                                                       &
                   ! Extern Functional
-                  extern_functional, functional_id
+                  extern_functional, functional_id,                            &
+                  ! Variavles for CEED
+                  ceed_calc, ceed_td_step, k_ceed
 
    type lio_input_data
       ! COMMON
@@ -175,7 +178,8 @@ module lionml_data
       character(len=40):: field_aniso_file, field_iso_file
       LIODBLE :: a0, epsilon, Fx, Fy, Fz, tdstep
       integer          :: NBCH, nfields_aniso, nfields_iso, ntdstep,           &
-                          propagator, td_rst_freq, timedep, td_do_pop
+                          propagator, td_rst_freq, timedep, td_do_pop,         &
+                          td_eu_step
       logical          :: tdrestart, writedens, field
       ! ECP
       character(len=30):: tipeECP
@@ -198,7 +202,7 @@ module lionml_data
       logical          :: assign_all_functions, energy_all_iterations,         &
                           remove_zero_weights
       ! Transport and TBDFT
-      LIODBLE :: alfaTB, betaTB, driving_rate, gammaTB, Vbias_TB,     &
+      LIODBLE          :: alfaTB, betaTB, driving_rate, gammaTB, Vbias_TB,     &
                           driving_rateTB, TB_charge_ref, TB_q_told
       logical          :: gate_field, generate_rho0, transport_calc
       integer          :: tbdft_calc, end_bTB, end_tdtb, MTB, pop_drive,       &
@@ -225,6 +229,10 @@ module lionml_data
       logical          :: dos_calc, pdos_calc, pdos_allb
       ! DFTD3
       logical          :: dftd3
+      ! CEED
+      logical          :: ceed_calc
+      integer          :: ceed_td_step
+      LIODBLE          :: k_ceed
    end type lio_input_data
 contains
 
@@ -271,7 +279,7 @@ subroutine get_namelist(lio_in)
    lio_in%ntdstep          = ntdstep         ; lio_in%propagator = propagator
    lio_in%timedep          = timedep         ; lio_in%tdrestart  = tdrestart
    lio_in%writedens        = writedens       ; lio_in%field      = field
-   lio_in%td_do_pop        = td_do_pop       ;
+   lio_in%td_do_pop        = td_do_pop       ; lio_in%td_eu_step = td_eu_step
    ! ECP
    lio_in%ecp_full_range_int = ecp_full_range_int; lio_in%cut2_0    = cut2_0
    lio_in%verbose_ECP        = verbose_ECP       ; lio_in%cut3_0    = cut3_0
@@ -337,9 +345,14 @@ subroutine get_namelist(lio_in)
    lio_in%dos_calc = dos_calc
    lio_in%pdos_calc= pdos_calc
    lio_in%pdos_allb= pdos_allb
-   
+
    ! Dispersion corrections
    lio_in%dftd3 = dftd3
+
+   !CEED
+   lio_in%ceed_calc    = ceed_calc
+   lio_in%ceed_td_step = ceed_td_step
+   lio_in%k_ceed       = k_ceed
    ! Libxc configuration
    !lio_in%ex_functional_id = ex_functional_id
    !lio_in%ec_functional_id = ec_functional_id

--- a/lioamber/lionml_subs.f90
+++ b/lioamber/lionml_subs.f90
@@ -155,7 +155,7 @@ subroutine lionml_write_dull()
    write(*,8041) inputs%NBCH, inputs%field, inputs%a0, inputs%epsilon
    write(*,8042) inputs%Fx, inputs%Fy, inputs%Fz, inputs%nfields_iso
    write(*,8043) inputs%nfields_aniso, inputs%field_iso_file
-   write(*,8044) inputs%field_aniso_file, inputs%td_do_pop
+   write(*,8044) inputs%field_aniso_file, inputs%td_do_pop, inputs%td_eu_step
    write(*,9000) " ! -- Effective Core Potentials: -- !"
    write(*,8060) inputs%Ecpmode, inputs%Ecptypes, inputs%TipeECP
    write(*,8061) inputs%Fock_ECP_read, inputs%Fock_ECP_write, inputs%cutECP, &
@@ -207,6 +207,8 @@ subroutine lionml_write_dull()
    write(*,8201) inputs%dos_calc, inputs%pdos_calc, inputs%pdos_allb
    write(*,9000) " ! -- VdW interaction options: -- !"
    write(*,8220) inputs%dftd3
+   write(*,9000) " ! -- CEED calculation: -- !"
+   write(*,8230) inputs%ceed_calc, inputs%ceed_td_step, inputs%k_ceed
 
 ! General
 9000 FORMAT(A)
@@ -246,7 +248,8 @@ subroutine lionml_write_dull()
 8042 FORMAT(2x, "Fx = ", F14.8, ", Fy = ", F14.8, ", Fz = ", F14.8, &
             ", n_fields_iso = ", I5, ",")
 8043 FORMAT(2x,"n_fields_aniso = ", I5, ", field_iso_file = ", A25, ",")
-8044 FORMAT(2x,"field_aniso_file = ", A25, ", td_do_pop = ", I5)
+8044 FORMAT(2x,"field_aniso_file = ", A25, ", td_do_pop = ", I5,               &
+            ", td_eu_step = ", I5)
 ! ECP
 8060 FORMAT(2x, "ECPMode = ", L2, ", ECPTypes = ", I3, ", TipeECP = ", A25, ",")
 8061 FORMAT(2x, "Fock_ECP_read = ", L2, ", Fock_ECP_write = ", L2, &
@@ -308,6 +311,9 @@ subroutine lionml_write_dull()
 8201 FORMAT(2x, "dos_calc = ", L2, ", pdos_calc = ", L2,", pdos_allb = ", L2 )
 ! VdW
 8220 FORMAT(2x, "dftd3 = ", L2)
+! CEED
+8230 FORMAT(2x, "ceed_calc = ", L2 , ", ceed_td_step = ", I6 , ", k_ceed = ",  &
+            ES9.2)
    return
 end subroutine lionml_write_dull
 
@@ -334,7 +340,7 @@ subroutine lionml_write_style()
    write(*,8214) inputs%hybrid_converg; write(*,8215) inputs%good_cut
    write(*,8216) inputs%Rmax          ; write(*,8217) inputs%RmaxS
    write(*,8218) inputs%Iexch         ; write(*,8219) inputs%Igrid
-   write(*,8220) inputs%Igrid2        ; 
+   write(*,8220) inputs%Igrid2        ;
    write(*,8222) inputs%initial_guess ; write(*,8223) inputs%dbug
    write(*,8224) inputs%n_ghosts
    write(*,8003)
@@ -363,7 +369,7 @@ subroutine lionml_write_style()
    write(*,8310) inputs%Fz           ; write(*,8311) inputs%nfields_iso
    write(*,8312) inputs%nfields_aniso; write(*,8313) inputs%field_iso_file
    write(*,8314) inputs%field_aniso_file
-   write(*,8315) inputs%td_do_pop
+   write(*,8315) inputs%td_do_pop    ; write(*,8316) inputs%td_eu_step
    write(*,8003)
 
    ! Effective Core Potential
@@ -450,7 +456,11 @@ subroutine lionml_write_style()
    write(*,8601) inputs%pdos_calc
    write(*,8602) inputs%pdos_allb
    write(*,8003)
-
+   !CEED
+   write(*,8000); write(*,8111); write(*,8002)
+   write(*,8700) inputs%ceed_calc
+   write(*,8701) inputs%ceed_td_step
+   write(*,8702) inputs%k_ceed
 
    return;
 8000 FORMAT(4x,"╔═════════════════════════════════", &
@@ -537,6 +547,7 @@ subroutine lionml_write_style()
 8313 FORMAT(4x,"║  field_iso_file      ║  ",A25,"║")
 8314 FORMAT(4x,"║  field_aniso_file    ║  ",A25,"║")
 8315 FORMAT(4x,"║  td_do_pop           ║  ",18x,I5,2x,"║")
+8316 FORMAT(4x,"║  td_eu_step          ║  ",18x,I5,2x,"║")
 !Effective Core Potential
 8350 FORMAT(4x,"║  Ecpmode             ║  ",21x,L2,2x,"║")
 8351 FORMAT(4x,"║  Ecptypes            ║  ",20x,I3,2x,"║")
@@ -630,6 +641,10 @@ subroutine lionml_write_style()
 8600 FORMAT(4x,"║  dos_calc            ║  ",21x,L2,2x,"║")
 8601 FORMAT(4x,"║  pdos_calc           ║  ",21x,L2,2x,"║")
 8602 FORMAT(4x,"║  pdos_allb           ║  ",21x,L2,2x,"║")
+!CEED
+8700 FORMAT(4x,"║  ceed_calc           ║  ",21x,L2,2x,"║")
+8701 FORMAT(4x,"║  ceed_td_step        ║  ",18x,I5,2x,"║")
+8702 FORMAT(4x,"║  k_ceed              ║  ",9x,F14.8,2x,"║")
 end subroutine lionml_write_style
 
 subroutine write_Zlist_ECP_dull(ZlistECP, D)


### PR DESCRIPTION
CEED includes radiative dissipiation during
electron dynamics based on Scherlis equations.
The following modifications were made:
- The modules ceed_subs and ceed_data were included
  for CEED calculations.
- Temporarily, CEED can only be performed with Verlet.
- The variable td_eu_step has been included in td_data.
  This variable includes every td_eu_step Verlet steps,
  an Euler step in order to stabilize the dynamic.