### PR TITLE
Small fix in densdif.py

### DIFF
--- a/tools/densdif.py
+++ b/tools/densdif.py
@@ -1,11 +1,6 @@
 #!/usr/bin/python3
-#import matplotlib
-#import matplotlib.pyplot as plt
-#import numpy as npy
-#
-#
-#
-################################################################################
+import numpy as np
+
 def read_dens( file_name ):
 
     data_file = open( file_name, "r" )
@@ -17,24 +12,33 @@ def read_dens( file_name ):
 
     data_file.close()
     return dens_vals
-#
-#
-#
-#------------------------------------------------------------------------------#
-def print_dens( file_name, dens_vals ):
+
+def print_dens_td( file_name, dens_vals ):
 
     data_file = open( file_name, 'w')
 
     for dens_val1 in dens_vals:
         data_file.write( (" %12.9E  %12.9E \n") % (dens_val1,0.0) )
-#        print( '{:.9E}  {:.9E}'.format(dens_val1,0.0), file=data_file )
 
     data_file.close()
     return 0
-#
-#
-#
-################################################################################
+
+def print_dens( file_name, dens_vals ):
+
+    data_file = open( file_name, 'w')
+
+    basis_size = int(np.sqrt(len(dens_vals)))
+    n_count = 0
+    for dens_val1 in dens_vals:
+        if ( n_count % basis_size != 0):
+            dens_val1 = dens_val1 * 2.0
+        data_file.write( (" %12.9E ") % (dens_val1) )
+
+        n_count = n_count +1
+        if (n_count % basis_size == 0):
+            data_file.write ("\n")
+    data_file.close()
+    return 0
 
 dens0 = read_dens("dens_neg.in")
 dens1 = read_dens("dens_pos.in")
@@ -44,5 +48,4 @@ for idx in range( len( dens1 ) ):
     densf.append( dens1[idx] - dens0[idx] )
 
 print_dens("dens_dif.out", densf)
-
-################################################################################
+print_dens_td("dens_dif_td.out", densf)


### PR DESCRIPTION
Small fix in density substraction subroutine. Now non-diagonal elements are properly halved, and the script returns two outputs: a TD-like restart and an SCF-like restart.