### PR TITLE
TD orbital occupation

### DIFF
--- a/docs/manual/tables/keywords_tddft.tex
+++ b/docs/manual/tables/keywords_tddft.tex
@@ -53,6 +53,12 @@
    & Number of step stride in which the pop will be written.
    (0 means it is never written).\\* \\
 
+   \textbf{td\_do\_opop}
+   &  \textit{default = 0}
+   \\*\textit{integer}
+   & Number of step stride in which the orbital occupation
+   pop will be written. (0 means it is never written).\\* \\
+
    \textbf{writeDens}
    &  \textit{default = .false. }
    \\*\textit{logical}

--- a/lioamber/TD.f90
+++ b/lioamber/TD.f90
@@ -873,11 +873,11 @@ subroutine td_orbital_population(rho_alf, rho_bet, open_shell, nstep, &
    call rho_alf%diagon_datamat(eivec, eival)
 
    if (open_shell) then
+      allocate(eival2(basis_m), eivec2(basis_m, basis_m))
       call rho_bet%gets_dataC_ON(tmp_mat)
       eivec2 = dble(tmp_mat)
       call rho_bet%sets_data_ON(eivec2)
 
-      allocate(eival2(basis_m), eivec2(basis_m, basis_m))
       call rho_bet%diagon_datamat(eivec2, eival2)
 
       call write_orbital_population(eival, eival2)

--- a/lioamber/fileio/output_others.f90
+++ b/lioamber/fileio/output_others.f90
@@ -402,3 +402,37 @@ subroutine io_finish_outputs(is_dipole, uid_dipole)
      "═════╝")
 end subroutine io_finish_outputs
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+
+!% WRITE_ORBITAL_POPULATION %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+! Writes the orbital population to an output file.                             !
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+subroutine write_orbital_population(ocup_a, ocup_b)
+   implicit none
+   LIODBLE, intent(in)           :: ocup_a(:)
+   LIODBLE, intent(in), optional :: ocup_b(:)
+
+   integer :: ocup_size, icount
+   logical :: is_open
+   
+   ocup_size = size(ocup_a,1)
+
+   inquire(unit = 1444, opened = is_open)
+   if (.not. is_open) then
+      open(file = 'orb_pops', unit = 1444)
+      write(1444,'(A)') "Orbital occupations (density eigenvalues)"
+   endif
+   
+   write(1444,'(A)') ""
+   if (present(ocup_b)) then
+      do icount = 1, ocup_size
+         write(1444,'(I4,F14.7,F14.7,F14.7)')          &
+               icount, ocup_a(icount), ocup_b(icount), &
+               ocup_a(icount) + ocup_b(icount) 
+      enddo
+   else
+      do icount = 1, ocup_size
+         write(1444,'(I4,F14.7)') icount, ocup_a(icount)
+      enddo
+   endif
+end subroutine write_orbital_population
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!

--- a/lioamber/lionml_data.f90
+++ b/lioamber/lionml_data.f90
@@ -45,7 +45,8 @@ module lionml_data
                                  fockbias_timeamp0 , fockbias_readfile
    use initial_guess_data, only: initial_guess
    use td_data           , only: tdrestart, writedens, td_rst_freq, tdstep,    &
-                                 ntdstep, timedep, td_do_pop, td_eu_step
+                                 ntdstep, timedep, td_do_pop, td_do_opop,      &
+                                 td_eu_step
    use trans_Data        , only: gaussian_convert
    use transport_data    , only: transport_calc, generate_rho0, nbias,         &
                                  save_charge_freq, driving_rate, Pop_Drive
@@ -101,7 +102,7 @@ module lionml_data
                   rst_dens, becke,                                             &
                   ! DFT and TD-DFT Variables.
                   timedep, tdstep, ntdstep, propagator, NBCH, tdrestart,       &
-                  writedens, td_rst_freq, td_do_pop, td_eu_step,               &
+                  writedens, td_rst_freq, td_do_pop, td_eu_step, td_do_opop,   &
                   ! Field Variables
                   field, epsilon, a0, Fx, Fy, Fz, nfields_iso, nfields_aniso,  &
                   field_aniso_file, field_iso_file,                            &
@@ -179,7 +180,7 @@ module lionml_data
       LIODBLE :: a0, epsilon, Fx, Fy, Fz, tdstep
       integer          :: NBCH, nfields_aniso, nfields_iso, ntdstep,           &
                           propagator, td_rst_freq, timedep, td_do_pop,         &
-                          td_eu_step
+                          td_eu_step, td_do_opop
       logical          :: tdrestart, writedens, field
       ! ECP
       character(len=30):: tipeECP
@@ -280,6 +281,7 @@ subroutine get_namelist(lio_in)
    lio_in%timedep          = timedep         ; lio_in%tdrestart  = tdrestart
    lio_in%writedens        = writedens       ; lio_in%field      = field
    lio_in%td_do_pop        = td_do_pop       ; lio_in%td_eu_step = td_eu_step
+   lio_in%td_do_opop       = td_do_opop
    ! ECP
    lio_in%ecp_full_range_int = ecp_full_range_int; lio_in%cut2_0    = cut2_0
    lio_in%verbose_ECP        = verbose_ECP       ; lio_in%cut3_0    = cut3_0

--- a/lioamber/lionml_subs.f90
+++ b/lioamber/lionml_subs.f90
@@ -156,6 +156,7 @@ subroutine lionml_write_dull()
    write(*,8042) inputs%Fx, inputs%Fy, inputs%Fz, inputs%nfields_iso
    write(*,8043) inputs%nfields_aniso, inputs%field_iso_file
    write(*,8044) inputs%field_aniso_file, inputs%td_do_pop, inputs%td_eu_step
+   write(*,8045) inputs%td_do_opop
    write(*,9000) " ! -- Effective Core Potentials: -- !"
    write(*,8060) inputs%Ecpmode, inputs%Ecptypes, inputs%TipeECP
    write(*,8061) inputs%Fock_ECP_read, inputs%Fock_ECP_write, inputs%cutECP, &
@@ -250,6 +251,7 @@ subroutine lionml_write_dull()
 8043 FORMAT(2x,"n_fields_aniso = ", I5, ", field_iso_file = ", A25, ",")
 8044 FORMAT(2x,"field_aniso_file = ", A25, ", td_do_pop = ", I5,               &
             ", td_eu_step = ", I5)
+8045 FORMAT(2x,"td_do_opop = ", I5)
 ! ECP
 8060 FORMAT(2x, "ECPMode = ", L2, ", ECPTypes = ", I3, ", TipeECP = ", A25, ",")
 8061 FORMAT(2x, "Fock_ECP_read = ", L2, ", Fock_ECP_write = ", L2, &
@@ -370,6 +372,7 @@ subroutine lionml_write_style()
    write(*,8312) inputs%nfields_aniso; write(*,8313) inputs%field_iso_file
    write(*,8314) inputs%field_aniso_file
    write(*,8315) inputs%td_do_pop    ; write(*,8316) inputs%td_eu_step
+   write(*,8317) inputs%td_do_opop
    write(*,8003)
 
    ! Effective Core Potential
@@ -548,6 +551,7 @@ subroutine lionml_write_style()
 8314 FORMAT(4x,"║  field_aniso_file    ║  ",A25,"║")
 8315 FORMAT(4x,"║  td_do_pop           ║  ",18x,I5,2x,"║")
 8316 FORMAT(4x,"║  td_eu_step          ║  ",18x,I5,2x,"║")
+8317 FORMAT(4x,"║  td_do_opop          ║  ",18x,I5,2x,"║")
 !Effective Core Potential
 8350 FORMAT(4x,"║  Ecpmode             ║  ",21x,L2,2x,"║")
 8351 FORMAT(4x,"║  Ecptypes            ║  ",20x,I3,2x,"║")


### PR DESCRIPTION
Small addition to TD: now it can print "orbital occupations", undestood as the otrhonormal density matrix eigenvalues. This is not intended to evaluate MO evolution itself (since the identity of MOs may change from step to step), but rather as a sanity check in cases where the initial state for TD may not come from a simple SCF (such as densities obtained by addition/substraction).