### PR TITLE
Add a Github "build all" and "build and test" actions to replace Travis

### DIFF
--- a/.github/workflows/build-all.yaml
+++ b/.github/workflows/build-all.yaml
@@ -1,0 +1,28 @@
+# This action compiles only the different variants of CPU and GPU.
+#
+# It does not run tests since the workers are CPU-only Virtual Machines.
+# To enable GPU tests it would have to build a GPU version and run it on
+# an external Github worker in some other cloud.
+
+name: Compile-only CPU and CPU-GPU variants
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: 'Build with ${{ matrix.cuda_option }} ${{ matrix.precision }} ${{ matrix.analytics }}'
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        cuda_option: ['cuda=0', 'cuda=1']
+        precision: ['precision=0', 'precision=1']
+        analytics: ['analytics=0', 'analytics=2']
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: get packages
+      run: sudo apt install -y gfortran liblapack-dev libblas-dev python3.9 linux-headers-$(uname -r) nvidia-cuda-toolkit
+    - name: configure
+      run: ./configure
+    - name: make ${{ matrix.cuda_option }} ${{ matrix.precision }} ${{ matrix.analytics }}
+      run: make -j ${{ matrix.cuda_option}} ${{ matrix.precision }} ${{ matrix.analytics }}

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,0 +1,27 @@
+# This action compiles and runs tests in CPU-only variant.
+#
+# To enable GPU tests it would have to build a GPU version and run it on 
+# an external Github worker in some other cloud.
+
+name: Compile and run CPU tests
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: 'Build and run tests with ${{ matrix.cuda_option }}'
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        cuda_option: ['cuda=0']
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: get packages
+      run: sudo apt install -y gfortran liblapack-dev libblas-dev python3.9
+    - name: configure
+      run: ./configure
+    - name: make ${{ matrix.cuda_option }} 
+      run: make -j ${{ matrix.cuda_option}}
+    - name: run tests
+      run: cd test && ./run_travis_test.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: cpp
-sudo: required
-before_install:
-  - sudo add-apt-repository universe
-  - sudo apt update
-  - sudo apt install gfortran liblapack-dev libblas-dev python3.5
-before_script: ./configure && make -j cuda=0 && cd test
-script: travis_wait ./run_travis_test.py


### PR DESCRIPTION
Travis is no longer the preferred tool (many changes around open source availability).

Github actions are native to Github and run fast. There is also a huge ecosystem where they other things such as linters, coming in another PR.

Still no GPU support [1]. However this PR adds also Build in GPU configurations (and full double) so it at least covers the cases where it works.

Link to a full execution of these actions shows the right things [2][3]

[1] https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
[2] https://github.com/manuelF/lio/actions/runs/1458487902
[3] https://github.com/manuelF/lio/actions/runs/1458742553