### PR TITLE
Add a Github action to run a code linter

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -1,0 +1,30 @@
+# This action runs a linter in the codebase.
+#
+# From https://github.com/github/super-linter, it 
+name: Lint Code Base
+
+on:
+  pull_request:
+    branches: [master, develop]
+
+jobs:
+  build:
+    name: Lint Code Base
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+      - name: Lint Code Base
+        uses: github/super-linter/slim@v4
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: master
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Disable copy detection among files since it is very noisy in fortran.
+          VALIDATE_JSCPD: false
+          # Remove these lines once the CPP and Python are clang-format and pep8 compliant.
+          VALIDATE_CPP: false
+          VALIDATE_PYTHON: false 

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -28,14 +28,12 @@ jobs:
           # We enable explicitly YAML so it doesn't check for anything else.
           # Only YAML should be .github/workflows.
           VALIDATE_YAML: true
-          # Disable copy detection among files since it is very noisy in fortran.
-          VALIDATE_JSCPD: false
           # TODO: Enable this when codebase is clang-format compliant.
-          VALIDATE_CPP: false
+          # VALIDATE_CPP: true
           # TODO: Enable this when codebase is autopep8 compliant.
-          VALIDATE_PYTHON: false
+          # VALIDATE_PYTHON: true
           # TODO: Enable this when codebase is bash-exec compliant.
-          VALIDATE_BASH: false 
-          VALIDATE_BASH_EXEC: false 
+          # VALIDATE_BASH: true 
+          # VALIDATE_BASH_EXEC: true 
           # TODO: Enable this when codebase is chktex compliant.
-          VALIDATE_LATEX: false 
+          # VALIDATE_LATEX: true 

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -1,7 +1,7 @@
 # This action runs a linter in the codebase.
 #
 # From https://github.com/github/super-linter, it runs a VM that checks all the code
-# for code formatting stand
+# for code formatting style consistency.
 name: Lint Code Base
 
 on:

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -1,6 +1,7 @@
 # This action runs a linter in the codebase.
 #
-# From https://github.com/github/super-linter, it 
+# From https://github.com/github/super-linter, it runs a VM that checks all the code
+# for code formatting stand
 name: Lint Code Base
 
 on:
@@ -22,9 +23,19 @@ jobs:
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: master
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}          
+          # https://github.com/github/super-linter#environment-variables
+          # We enable explicitly YAML so it doesn't check for anything else.
+          # Only YAML should be .github/workflows.
+          VALIDATE_YAML: true
           # Disable copy detection among files since it is very noisy in fortran.
           VALIDATE_JSCPD: false
-          # Remove these lines once the CPP and Python are clang-format and pep8 compliant.
+          # TODO: Enable this when codebase is clang-format compliant.
           VALIDATE_CPP: false
-          VALIDATE_PYTHON: false 
+          # TODO: Enable this when codebase is autopep8 compliant.
+          VALIDATE_PYTHON: false
+          # TODO: Enable this when codebase is bash-exec compliant.
+          VALIDATE_BASH: false 
+          VALIDATE_BASH_EXEC: false 
+          # TODO: Enable this when codebase is chktex compliant.
+          VALIDATE_LATEX: false 


### PR DESCRIPTION
This PR adds a Github action that will autocheck code-style in order to have a consistent style across the codebase.

This won't affect any forks since it will only run on `develop` and `master` branches, so people are free to code as they see fit, but will get a warning if the code doesn't pass the check when they try to merge upstream.

For now all languages are disabled (cpp, python, bash, latex) except for yaml in order to not have spurious warnings. Other PRs will format those accordingly and then those languages can be enabled. A fortran linter is not available in this docker image, but might be available in others, so we can try to find one to enable.

See a full run here to see how it looks (just YAML checked for now):
https://github.com/manuelF/lio/runs/4217154472?check_suite_focus=true

This is a full run with all the issues:
https://github.com/manuelF/lio/runs/4216930074?check_suite_focus=true