### PR TITLE
Clang-format all files (.cpp, .h, .cu)

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -28,7 +28,9 @@ jobs:
           # We enable explicitly YAML so it doesn't check for anything else.
           # Only YAML should be .github/workflows.
           VALIDATE_YAML: true
-          # TODO: Enable this when codebase is clang-format compliant.
+          # Validates C++ (.cpp, .h and .cu) match the standard.
+          VALIDATE_CLANG_FORMAT: true
+          # TODO: Enable this when codebase is cpplint compliant.
           # VALIDATE_CPP: true
           # TODO: Enable this when codebase is autopep8 compliant.
           # VALIDATE_PYTHON: true

--- a/g2g/analytic_integral/aint_init.cpp
+++ b/g2g/analytic_integral/aint_init.cpp
@@ -12,11 +12,11 @@
 #include "qmmm_integral.h"
 #include "coulomb_integral.h"
 
+using std::boolalpha;
 using std::cout;
 using std::endl;
-using std::boolalpha;
-using std::runtime_error;
 using std::ifstream;
+using std::runtime_error;
 using std::string;
 
 using namespace AINT;
@@ -33,15 +33,15 @@ OSIntegral<float> os_integral;
 QMMMIntegral<float> qmmm_integral(os_integral);
 CoulombIntegral<float> coulomb_integral(os_integral);
 #endif
-}
+}  // namespace AINT
 //==========================================================================================
 extern "C" void aint_parameter_init_(const unsigned int& Md,
                                      unsigned int* ncontd,
                                      const unsigned int* nshelld, double* cd,
                                      double* ad, unsigned int* Nucd, double* af,
-                                     double* G_inv, double* Hmat_vec, double* str,
-                                     double* fac, double& rmax, uint* atomZ_i,
-                                     const int& level_of_gpu) {
+                                     double* G_inv, double* Hmat_vec,
+                                     double* str, double* fac, double& rmax,
+                                     uint* atomZ_i, const int& level_of_gpu) {
   /* DENSITY BASIS SET */
   integral_vars.s_funcs_dens = nshelld[0];
   integral_vars.p_funcs_dens = nshelld[1] / 3;
@@ -49,21 +49,20 @@ extern "C" void aint_parameter_init_(const unsigned int& Md,
   // Md =	# of contractions
   integral_vars.m_dens = Md;
 
-
   integral_vars.gpu_level = level_of_gpu;
   if (level_of_gpu < 0) integral_vars.gpu_level = 0;
   if (level_of_gpu > 5) integral_vars.gpu_level = 5;
 
   if (G2G::verbose > 3) {
-     cout << "AINT initialisation." << endl;
-     cout << "  Density basis - s: " << integral_vars.s_funcs_dens
-          << " p: " << integral_vars.p_funcs_dens
-          << " d: " << integral_vars.d_funcs_dens
-          << " - Total (w/contractions): " << integral_vars.m_dens << endl;
+    cout << "AINT initialisation." << endl;
+    cout << "  Density basis - s: " << integral_vars.s_funcs_dens
+         << " p: " << integral_vars.p_funcs_dens
+         << " d: " << integral_vars.d_funcs_dens
+         << " - Total (w/contractions): " << integral_vars.m_dens << endl;
   }
-  integral_vars.spd_funcs_dens = integral_vars.s_funcs_dens +
-                                 integral_vars.p_funcs_dens +
-                                 integral_vars.d_funcs_dens;  /* DENSITY BASIS SET */
+  integral_vars.spd_funcs_dens =
+      integral_vars.s_funcs_dens + integral_vars.p_funcs_dens +
+      integral_vars.d_funcs_dens; /* DENSITY BASIS SET */
   integral_vars.nucleii_dens =
       G2G::FortranMatrix<uint>(Nucd, integral_vars.m_dens, 1, 1);
   integral_vars.contractions_dens =
@@ -95,10 +94,10 @@ extern "C" void aint_parameter_init_(const unsigned int& Md,
       cd, integral_vars.m_dens, MAX_CONTRACTIONS, num_dens_gauss);
   // 1e Fock matrix
   integral_vars.rmm_1e_output = G2G::FortranMatrix<double>(
-      Hmat_vec, (G2G::fortran_vars.m * (G2G::fortran_vars.m + 1)) / 2 );
+      Hmat_vec, (G2G::fortran_vars.m * (G2G::fortran_vars.m + 1)) / 2);
   // Inverse of G matrix for Coulomb fitting
   integral_vars.Ginv_input = G2G::FortranMatrix<double>(
-      G_inv, (integral_vars.m_dens * (integral_vars.m_dens + 1)) / 2 );
+      G_inv, (integral_vars.m_dens * (integral_vars.m_dens + 1)) / 2);
   // Fitted density in density basis
   integral_vars.af_input_ndens1 =
       G2G::FortranMatrix<double>(af, integral_vars.m_dens);

--- a/g2g/analytic_integral/aint_init.h
+++ b/g2g/analytic_integral/aint_init.h
@@ -7,7 +7,7 @@ namespace AINT {
 
 struct FortranVars {
   uint clatoms;
-  int  gpu_level;
+  int gpu_level;
 
   /* ---DENSITY BASIS--- */
   uint gaussians_dens, s_gaussians_dens, p_gaussians_dens;
@@ -34,6 +34,6 @@ struct FortranVars {
 extern AINT::FortranVars integral_vars;
 
 extern uint NUM_TERM_TYPES;
-}
+}  // namespace AINT
 
 #endif

--- a/g2g/analytic_integral/coulomb_integral.h
+++ b/g2g/analytic_integral/coulomb_integral.h
@@ -64,6 +64,6 @@ class CoulombIntegral {
 
   void clear(void);
 };
-}
+}  // namespace AINT
 
 #endif

--- a/g2g/analytic_integral/cuda/coulomb.cu
+++ b/g2g/analytic_integral/cuda/coulomb.cu
@@ -14,19 +14,17 @@
 #include "../aint_init.h"
 #include "../aint_common.h"
 
-namespace G2G
-{
+namespace G2G {
 #include "gpu_vars/g2g_gpu_variables.h"
 
 extern double free_global_memory;
-}
+}  // namespace G2G
 
 using std::cout;
-using std::vector;
 using std::endl;
+using std::vector;
 
-namespace AINT
-{
+namespace AINT {
 
 #include "gpu_vars/os_gpu_variables.h"
 #include "gpu_vars/coulomb_gpu_variables.h"
@@ -38,11 +36,10 @@ namespace AINT
 
 // -----------------------------------------------------------------------------------------------------------------
 template <class scalar_type>
-bool CoulombIntegral<scalar_type>::load_aux_basis( void )
-{
-  std::vector<G2G::vec_type<scalar_type,2> > factor_ac_dens_cpu;
+bool CoulombIntegral<scalar_type>::load_aux_basis(void) {
+  std::vector<G2G::vec_type<scalar_type, 2>> factor_ac_dens_cpu;
   std::vector<scalar_type> fit_dens_cpu;
-  std::vector<G2G::vec_type<scalar_type,3> > nuc_dens_cpu;
+  std::vector<G2G::vec_type<scalar_type, 3>> nuc_dens_cpu;
   std::vector<uint> nuc_ind_dens_cpu;
 
   input_size = 0;
@@ -51,8 +48,11 @@ bool CoulombIntegral<scalar_type>::load_aux_basis( void )
     uint nuc_ind = integral_vars.nucleii_dens(func) - 1;
     double3 nuc_pos = G2G::fortran_vars.atom_positions(nuc_ind);
     for (uint k = 0; k < integral_vars.contractions_dens(func); k++) {
-      factor_ac_dens_cpu.push_back(G2G::vec_type<scalar_type,2>(integral_vars.a_values_dens(func,k),integral_vars.c_values_dens(func,k)));
-      nuc_dens_cpu.push_back(G2G::vec_type<scalar_type, 3>(nuc_pos.x, nuc_pos.y, nuc_pos.z));
+      factor_ac_dens_cpu.push_back(
+          G2G::vec_type<scalar_type, 2>(integral_vars.a_values_dens(func, k),
+                                        integral_vars.c_values_dens(func, k)));
+      nuc_dens_cpu.push_back(
+          G2G::vec_type<scalar_type, 3>(nuc_pos.x, nuc_pos.y, nuc_pos.z));
       nuc_ind_dens_cpu.push_back(nuc_ind);
       input_ind_cpu.push_back(input_size);
       input_size++;
@@ -60,35 +60,47 @@ bool CoulombIntegral<scalar_type>::load_aux_basis( void )
   }
 
   s_end = input_size;
-  cudaMemcpyToSymbol(gpu_s_end, &s_end, sizeof(s_end), 0, cudaMemcpyHostToDevice);
+  cudaMemcpyToSymbol(gpu_s_end, &s_end, sizeof(s_end), 0,
+                     cudaMemcpyHostToDevice);
 
   uint tmp_size = input_size;
   for (uint func = tmp_size; func < COALESCED_DIMENSION(tmp_size); func++) {
-    factor_ac_dens_cpu.push_back(factor_ac_dens_cpu[tmp_size-1]);
-    nuc_dens_cpu.push_back(nuc_dens_cpu[tmp_size-1]);
-    nuc_ind_dens_cpu.push_back(nuc_ind_dens_cpu[tmp_size-1]);
+    factor_ac_dens_cpu.push_back(factor_ac_dens_cpu[tmp_size - 1]);
+    nuc_dens_cpu.push_back(nuc_dens_cpu[tmp_size - 1]);
+    nuc_ind_dens_cpu.push_back(nuc_ind_dens_cpu[tmp_size - 1]);
     input_size++;
   }
 
   p_offset = input_size;
-  cudaMemcpyToSymbol(gpu_p_offset, &p_offset, sizeof(p_offset), 0, cudaMemcpyHostToDevice);
+  cudaMemcpyToSymbol(gpu_p_offset, &p_offset, sizeof(p_offset), 0,
+                     cudaMemcpyHostToDevice);
 
   tmp_size = 0;
-  for (uint func = integral_vars.s_funcs_dens; func < integral_vars.s_funcs_dens+integral_vars.p_funcs_dens*3; func += 3) {
+  for (uint func = integral_vars.s_funcs_dens;
+       func < integral_vars.s_funcs_dens + integral_vars.p_funcs_dens * 3;
+       func += 3) {
     uint nuc_ind = integral_vars.nucleii_dens(func) - 1;
     double3 nuc_pos = G2G::fortran_vars.atom_positions(nuc_ind);
     for (uint k = 0; k < integral_vars.contractions_dens(func); k++) {
       for (uint f = 0; f < 3; f++) {
-        factor_ac_dens_cpu.push_back(G2G::vec_type<scalar_type,2>(integral_vars.a_values_dens(func,k),integral_vars.c_values_dens(func,k)));
-        nuc_dens_cpu.push_back(G2G::vec_type<scalar_type, 3>(nuc_pos.x, nuc_pos.y, nuc_pos.z));
+        factor_ac_dens_cpu.push_back(G2G::vec_type<scalar_type, 2>(
+            integral_vars.a_values_dens(func, k),
+            integral_vars.c_values_dens(func, k)));
+        nuc_dens_cpu.push_back(
+            G2G::vec_type<scalar_type, 3>(nuc_pos.x, nuc_pos.y, nuc_pos.z));
         nuc_ind_dens_cpu.push_back(nuc_ind);
-        input_ind_cpu.push_back(input_size+f);
+        input_ind_cpu.push_back(input_size + f);
       }
       tmp_size += 3;
       input_size += 3;
       if (tmp_size == 126) {
-        for (uint f = 0; f < 2; f++) factor_ac_dens_cpu.push_back(G2G::vec_type<scalar_type,2>(integral_vars.a_values_dens(func,k),integral_vars.c_values_dens(func,k)));
-        for (uint f = 0; f < 2; f++) nuc_dens_cpu.push_back(G2G::vec_type<scalar_type, 3>(nuc_pos.x, nuc_pos.y, nuc_pos.z));
+        for (uint f = 0; f < 2; f++)
+          factor_ac_dens_cpu.push_back(G2G::vec_type<scalar_type, 2>(
+              integral_vars.a_values_dens(func, k),
+              integral_vars.c_values_dens(func, k)));
+        for (uint f = 0; f < 2; f++)
+          nuc_dens_cpu.push_back(
+              G2G::vec_type<scalar_type, 3>(nuc_pos.x, nuc_pos.y, nuc_pos.z));
         for (uint f = 0; f < 2; f++) nuc_ind_dens_cpu.push_back(nuc_ind);
         tmp_size = 0;
         input_size += 2;
@@ -97,35 +109,46 @@ bool CoulombIntegral<scalar_type>::load_aux_basis( void )
   }
 
   p_end = input_size;
-  cudaMemcpyToSymbol(gpu_p_end, &p_end, sizeof(p_end), 0, cudaMemcpyHostToDevice);
+  cudaMemcpyToSymbol(gpu_p_end, &p_end, sizeof(p_end), 0,
+                     cudaMemcpyHostToDevice);
 
   tmp_size = input_size;
   for (uint func = tmp_size; func < COALESCED_DIMENSION(tmp_size); func++) {
-    factor_ac_dens_cpu.push_back(factor_ac_dens_cpu[tmp_size-1]);
-    nuc_dens_cpu.push_back(nuc_dens_cpu[tmp_size-1]);
-    nuc_ind_dens_cpu.push_back(nuc_ind_dens_cpu[tmp_size-1]);
+    factor_ac_dens_cpu.push_back(factor_ac_dens_cpu[tmp_size - 1]);
+    nuc_dens_cpu.push_back(nuc_dens_cpu[tmp_size - 1]);
+    nuc_ind_dens_cpu.push_back(nuc_ind_dens_cpu[tmp_size - 1]);
     input_size++;
   }
 
   d_offset = input_size;
-  cudaMemcpyToSymbol(gpu_d_offset, &d_offset, sizeof(d_offset), 0, cudaMemcpyHostToDevice);
+  cudaMemcpyToSymbol(gpu_d_offset, &d_offset, sizeof(d_offset), 0,
+                     cudaMemcpyHostToDevice);
 
   tmp_size = 0;
-  for (uint func = integral_vars.s_funcs_dens+integral_vars.p_funcs_dens*3; func < integral_vars.m_dens; func += 6) {
+  for (uint func = integral_vars.s_funcs_dens + integral_vars.p_funcs_dens * 3;
+       func < integral_vars.m_dens; func += 6) {
     uint nuc_ind = integral_vars.nucleii_dens(func) - 1;
     double3 nuc_pos = G2G::fortran_vars.atom_positions(nuc_ind);
     for (uint k = 0; k < integral_vars.contractions_dens(func); k++) {
       for (uint f = 0; f < 6; f++) {
-        factor_ac_dens_cpu.push_back(G2G::vec_type<scalar_type,2>(integral_vars.a_values_dens(func,k),integral_vars.c_values_dens(func,k)));
-        nuc_dens_cpu.push_back(G2G::vec_type<scalar_type, 3>(nuc_pos.x, nuc_pos.y, nuc_pos.z));
+        factor_ac_dens_cpu.push_back(G2G::vec_type<scalar_type, 2>(
+            integral_vars.a_values_dens(func, k),
+            integral_vars.c_values_dens(func, k)));
+        nuc_dens_cpu.push_back(
+            G2G::vec_type<scalar_type, 3>(nuc_pos.x, nuc_pos.y, nuc_pos.z));
         nuc_ind_dens_cpu.push_back(nuc_ind);
-        input_ind_cpu.push_back(input_size+f);
+        input_ind_cpu.push_back(input_size + f);
       }
       tmp_size += 6;
       input_size += 6;
       if (tmp_size == 126) {
-        for (uint f = 0; f < 2; f++) factor_ac_dens_cpu.push_back(G2G::vec_type<scalar_type,2>(integral_vars.a_values_dens(func,k),integral_vars.c_values_dens(func,k)));
-        for (uint f = 0; f < 2; f++) nuc_dens_cpu.push_back(G2G::vec_type<scalar_type, 3>(nuc_pos.x, nuc_pos.y, nuc_pos.z));
+        for (uint f = 0; f < 2; f++)
+          factor_ac_dens_cpu.push_back(G2G::vec_type<scalar_type, 2>(
+              integral_vars.a_values_dens(func, k),
+              integral_vars.c_values_dens(func, k)));
+        for (uint f = 0; f < 2; f++)
+          nuc_dens_cpu.push_back(
+              G2G::vec_type<scalar_type, 3>(nuc_pos.x, nuc_pos.y, nuc_pos.z));
         for (uint f = 0; f < 2; f++) nuc_ind_dens_cpu.push_back(nuc_ind);
         tmp_size = 0;
         input_size += 2;
@@ -134,15 +157,17 @@ bool CoulombIntegral<scalar_type>::load_aux_basis( void )
   }
 
   d_end = input_size;
-  cudaMemcpyToSymbol(gpu_d_end, &d_end, sizeof(d_end), 0, cudaMemcpyHostToDevice);
+  cudaMemcpyToSymbol(gpu_d_end, &d_end, sizeof(d_end), 0,
+                     cudaMemcpyHostToDevice);
 
   size_t gpu_size = factor_ac_dens_cpu.size() * 2 * sizeof(scalar_type);
   gpu_size += nuc_dens_cpu.size() * 3 * sizeof(scalar_type);
   gpu_size += (nuc_ind_dens_cpu.size() + input_ind_cpu.size()) * sizeof(uint);
   gpu_size += input_size * sizeof(scalar_type);
-//  float mb_size = (float)gpu_size / 1048576.0f;
-//  cout << "Coulomb aux basis input size: " << mb_size << " MB" << endl;
-  if (GlobalMemoryPool::tryAlloc(gpu_size) && G2G::free_global_memory > 0.0) return false;
+  //  float mb_size = (float)gpu_size / 1048576.0f;
+  //  cout << "Coulomb aux basis input size: " << mb_size << " MB" << endl;
+  if (GlobalMemoryPool::tryAlloc(gpu_size) && G2G::free_global_memory > 0.0)
+    return false;
 
   factor_ac_dens_dev = factor_ac_dens_cpu;
   nuc_dens_dev = nuc_dens_cpu;
@@ -157,342 +182,428 @@ bool CoulombIntegral<scalar_type>::load_aux_basis( void )
 }
 
 template <class scalar_type>
-bool CoulombIntegral<scalar_type>::load_input( void )
-{
-    
-    G2G::HostMatrix<double> Ginv_h(COALESCED_DIMENSION(integral_vars.m_dens),integral_vars.m_dens);
-    for (uint i = 0; i < integral_vars.m_dens; i++)
-    {
-      for (uint j = 0; j < i; j++)
-      {
-        Ginv_h(i,j) = integral_vars.Ginv_input(i+(2*integral_vars.m_dens-(j+1))*j/2);
-      }
-      for (uint j = i; j < integral_vars.m_dens; j++)
-      {
-        Ginv_h(i,j) = integral_vars.Ginv_input(j+(2*integral_vars.m_dens-(i+1))*i/2);
-      }
+bool CoulombIntegral<scalar_type>::load_input(void) {
+  G2G::HostMatrix<double> Ginv_h(COALESCED_DIMENSION(integral_vars.m_dens),
+                                 integral_vars.m_dens);
+  for (uint i = 0; i < integral_vars.m_dens; i++) {
+    for (uint j = 0; j < i; j++) {
+      Ginv_h(i, j) = integral_vars.Ginv_input(
+          i + (2 * integral_vars.m_dens - (j + 1)) * j / 2);
     }
-    size_t gpu_size = Ginv_h.bytes();
-//    float mb_size = (float)gpu_size / 1048576.0f;
-//    cout << "Coulomb input size: " << mb_size << " MB" << endl;
-    if (GlobalMemoryPool::tryAlloc(gpu_size) && G2G::free_global_memory > 0.0) return false;
-    
-    Ginv_dev = Ginv_h;
+    for (uint j = i; j < integral_vars.m_dens; j++) {
+      Ginv_h(i, j) = integral_vars.Ginv_input(
+          j + (2 * integral_vars.m_dens - (i + 1)) * i / 2);
+    }
+  }
+  size_t gpu_size = Ginv_h.bytes();
+  //    float mb_size = (float)gpu_size / 1048576.0f;
+  //    cout << "Coulomb input size: " << mb_size << " MB" << endl;
+  if (GlobalMemoryPool::tryAlloc(gpu_size) && G2G::free_global_memory > 0.0)
+    return false;
 
-    cudaMemcpyToSymbol(gpu_out_offsets,os_int.out_offsets,NUM_TERM_TYPES*sizeof(uint),0,cudaMemcpyHostToDevice);
+  Ginv_dev = Ginv_h;
 
-    cudaAssertNoError("CoulombIntegral::load_input");
+  cudaMemcpyToSymbol(gpu_out_offsets, os_int.out_offsets,
+                     NUM_TERM_TYPES * sizeof(uint), 0, cudaMemcpyHostToDevice);
 
-    return true;
+  cudaAssertNoError("CoulombIntegral::load_input");
+
+  return true;
 }
 
 template <class scalar_type>
-bool CoulombIntegral<scalar_type>::alloc_output( void )
-{
-    uint partial_out_size = 0;
-    // Output arrays (probably) don't need to be padded for alignment as only one (or three) threads per block write to them
-    for (uint i = 0; i < NUM_TERM_TYPES; i++) {
-      uint this_count = divUp(os_int.term_type_counts[i],QMMM_BLOCK_SIZE);
-      partial_out_size += this_count;
-    }
-    size_t gpu_size = COALESCED_DIMENSION(integral_vars.m_dens) * partial_out_size * sizeof(double);
-//    float mb_size = (float)gpu_size / 1048576.0f;
-//    cout << "Coulomb output size: " << mb_size << " MB" << endl;
-    if (GlobalMemoryPool::tryAlloc(gpu_size) && G2G::free_global_memory > 0.0) return false;
+bool CoulombIntegral<scalar_type>::alloc_output(void) {
+  uint partial_out_size = 0;
+  // Output arrays (probably) don't need to be padded for alignment as only one
+  // (or three) threads per block write to them
+  for (uint i = 0; i < NUM_TERM_TYPES; i++) {
+    uint this_count = divUp(os_int.term_type_counts[i], QMMM_BLOCK_SIZE);
+    partial_out_size += this_count;
+  }
+  size_t gpu_size = COALESCED_DIMENSION(integral_vars.m_dens) *
+                    partial_out_size * sizeof(double);
+  //    float mb_size = (float)gpu_size / 1048576.0f;
+  //    cout << "Coulomb output size: " << mb_size << " MB" << endl;
+  if (GlobalMemoryPool::tryAlloc(gpu_size) && G2G::free_global_memory > 0.0)
+    return false;
 
-    rc_partial_dev.resize(COALESCED_DIMENSION(integral_vars.m_dens),partial_out_size);
+  rc_partial_dev.resize(COALESCED_DIMENSION(integral_vars.m_dens),
+                        partial_out_size);
 
-    cudaAssertNoError("CoulombIntegral::alloc_output");
+  cudaAssertNoError("CoulombIntegral::alloc_output");
 
-    return true;
+  return true;
 }
 
 template <class scalar_type>
-void CoulombIntegral<scalar_type>::clear( void )
-{
-    input_ind_cpu.clear();
+void CoulombIntegral<scalar_type>::clear(void) {
+  input_ind_cpu.clear();
 
-    if (fit_dens_dev.is_allocated() && G2G::free_global_memory > 0.0) {
-      size_t gpu_size = fit_dens_dev.bytes() + factor_ac_dens_dev.bytes() + nuc_dens_dev.bytes() + nuc_ind_dens_dev.bytes() + input_ind_dev.bytes();
-      GlobalMemoryPool::dealloc(gpu_size);
-    }
-    fit_dens_dev.deallocate();
-    factor_ac_dens_dev.deallocate();
-    nuc_dens_dev.deallocate();
-    nuc_ind_dens_dev.deallocate();
-    input_ind_dev.deallocate();
-    if (Ginv_dev.is_allocated() && G2G::free_global_memory > 0.0) {
-      size_t gpu_size = Ginv_dev.bytes();
-      GlobalMemoryPool::dealloc(gpu_size);
-    }
-    Ginv_dev.deallocate();
-    if (rc_partial_dev.is_allocated() && G2G::free_global_memory > 0.0) {
-      size_t gpu_size = rc_partial_dev.bytes();
-      GlobalMemoryPool::dealloc(gpu_size);
-    }
-    rc_partial_dev.deallocate();
+  if (fit_dens_dev.is_allocated() && G2G::free_global_memory > 0.0) {
+    size_t gpu_size = fit_dens_dev.bytes() + factor_ac_dens_dev.bytes() +
+                      nuc_dens_dev.bytes() + nuc_ind_dens_dev.bytes() +
+                      input_ind_dev.bytes();
+    GlobalMemoryPool::dealloc(gpu_size);
+  }
+  fit_dens_dev.deallocate();
+  factor_ac_dens_dev.deallocate();
+  nuc_dens_dev.deallocate();
+  nuc_ind_dens_dev.deallocate();
+  input_ind_dev.deallocate();
+  if (Ginv_dev.is_allocated() && G2G::free_global_memory > 0.0) {
+    size_t gpu_size = Ginv_dev.bytes();
+    GlobalMemoryPool::dealloc(gpu_size);
+  }
+  Ginv_dev.deallocate();
+  if (rc_partial_dev.is_allocated() && G2G::free_global_memory > 0.0) {
+    size_t gpu_size = rc_partial_dev.bytes();
+    GlobalMemoryPool::dealloc(gpu_size);
+  }
+  rc_partial_dev.deallocate();
 
-    cudaAssertNoError("CoulombIntegral::clear");
+  cudaAssertNoError("CoulombIntegral::clear");
 }
 
 template <class scalar_type>
-void CoulombIntegral<scalar_type>::calc_gradient( double* qm_forces, bool cpu_fit_dens )
-{
+void CoulombIntegral<scalar_type>::calc_gradient(double* qm_forces,
+                                                 bool cpu_fit_dens) {
+  os_int.reload_density();
 
-    os_int.reload_density();
-
-    if (cpu_fit_dens) {
+  if (cpu_fit_dens) {
     G2G::HostMatrix<scalar_type> fit_dens_h(input_size);
     for (uint i = 0; i < input_size; i++) fit_dens_h(i) = 0.0;
     for (uint i = 0; i < integral_vars.m_dens; i++) {
       fit_dens_h(input_ind_cpu[i]) = integral_vars.af_input_ndens1(i);
     }
     fit_dens_dev = fit_dens_h;
+  }
+
+  uint partial_out_size = 0, max_partial_size = 0;
+  for (uint i = 0; i < NUM_TERM_TYPES; i++) {
+    uint this_count = divUp(os_int.term_type_counts[i], QMMM_BLOCK_SIZE);
+    if (this_count > max_partial_size) max_partial_size = this_count;
+    partial_out_size += this_count;
+  }
+
+  {
+    dim3 threads(COALESCED_DIMENSION(partial_out_size),
+                 G2G::fortran_vars.atoms);
+    dim3 blockSize(32, 4);
+    dim3 gridSize = divUp(threads, blockSize);
+    zero_forces<scalar_type><<<gridSize, blockSize>>>(
+        os_int.partial_qm_forces_dev.data,
+        COALESCED_DIMENSION(partial_out_size), G2G::fortran_vars.atoms);
+  }
+
+  //
+  // The STR table for F(m,U) calculation is being accessed via texture fetches
+  //
+  cudaBindTextureToArray(str_tex, gammaArray);
+
+#define coulomb_forces_parameters                                              \
+  os_int.term_type_counts[i], os_int.factor_ac_dev.data, os_int.nuc_dev.data,  \
+      os_int.dens_values_dev.data + dens_offset,                               \
+      os_int.func_code_dev.data + offset, os_int.local_dens_dev.data + offset, \
+      os_int.partial_qm_forces_dev.data + force_offset,                        \
+      COALESCED_DIMENSION(partial_out_size), factor_ac_dens_dev.data,          \
+      nuc_dens_dev.data, nuc_ind_dens_dev.data, fit_dens_dev.data, s_end,      \
+      p_end, d_end, p_offset, d_offset
+  // Each term type is calculated asynchronously
+  cudaStream_t stream[NUM_TERM_TYPES];
+  for (uint i = 0; i < NUM_TERM_TYPES; i++) {
+    cudaStreamCreate(&stream[i]);
+  }
+  //
+  // Begin launching kernels (one for each type of term, 0 = s-s, 1 = p-s, etc)
+  //
+  for (uint i = 0; i < NUM_TERM_TYPES; i++) {
+    uint offset = os_int.term_type_offsets[i];
+    uint dens_offset = os_int.dens_offsets[i];
+    uint force_offset = os_int.out_offsets[i];
+    dim3 threads = os_int.term_type_counts[i];
+    dim3 blockSize(QMMM_BLOCK_SIZE);
+    dim3 gridSize = divUp(threads, blockSize);
+    switch (i) {
+      case 0:
+        gpu_coulomb_forces<scalar_type, 0>
+            <<<gridSize, blockSize, 0, stream[i]>>>(coulomb_forces_parameters);
+        break;
+      case 1:
+        gpu_coulomb_forces<scalar_type, 1>
+            <<<gridSize, blockSize, 0, stream[i]>>>(coulomb_forces_parameters);
+        break;
+      case 2:
+        gpu_coulomb_forces<scalar_type, 2>
+            <<<gridSize, blockSize, 0, stream[i]>>>(coulomb_forces_parameters);
+        break;
+      case 3:
+        gpu_coulomb_forces<scalar_type, 3>
+            <<<gridSize, blockSize, 0, stream[i]>>>(coulomb_forces_parameters);
+        break;
+      case 4:
+        gpu_coulomb_forces<scalar_type, 4>
+            <<<gridSize, blockSize, 0, stream[i]>>>(coulomb_forces_parameters);
+        break;
+      case 5:
+        gpu_coulomb_forces<scalar_type, 5>
+            <<<gridSize, blockSize, 0, stream[i]>>>(coulomb_forces_parameters);
+        break;
     }
+  }
+  cudaDeviceSynchronize();
+  for (uint i = 0; i < NUM_TERM_TYPES; i++) {
+    cudaStreamDestroy(stream[i]);
+  }
 
-    uint partial_out_size = 0, max_partial_size = 0;
-    for (uint i = 0; i < NUM_TERM_TYPES; i++) {
-      uint this_count = divUp(os_int.term_type_counts[i],QMMM_BLOCK_SIZE);
-      if (this_count > max_partial_size) max_partial_size = this_count;
-      partial_out_size += this_count;
-    }
+  cudaUnbindTexture(str_tex);
 
-    {
-        dim3 threads(COALESCED_DIMENSION(partial_out_size),G2G::fortran_vars.atoms);
-        dim3 blockSize(32,4);
-        dim3 gridSize = divUp(threads,blockSize);
-        zero_forces<scalar_type><<<gridSize,blockSize>>>(os_int.partial_qm_forces_dev.data,COALESCED_DIMENSION(partial_out_size),G2G::fortran_vars.atoms);
-    }
+  os_int.get_gradient_output(qm_forces, partial_out_size);
 
-    //
-    // The STR table for F(m,U) calculation is being accessed via texture fetches
-    //
-    cudaBindTextureToArray(str_tex,gammaArray);
-
-#define coulomb_forces_parameters \
-  os_int.term_type_counts[i], os_int.factor_ac_dev.data, os_int.nuc_dev.data, os_int.dens_values_dev.data+dens_offset, os_int.func_code_dev.data+offset,os_int.local_dens_dev.data+offset, \
-  os_int.partial_qm_forces_dev.data+force_offset, COALESCED_DIMENSION(partial_out_size),factor_ac_dens_dev.data,nuc_dens_dev.data,nuc_ind_dens_dev.data,fit_dens_dev.data, \
-  s_end, p_end, d_end, p_offset, d_offset
-    // Each term type is calculated asynchronously
-    cudaStream_t stream[NUM_TERM_TYPES];
-    for (uint i = 0; i < NUM_TERM_TYPES; i++) {
-      cudaStreamCreate(&stream[i]);
-    }
-    //
-    // Begin launching kernels (one for each type of term, 0 = s-s, 1 = p-s, etc)
-    //
-    for (uint i = 0; i < NUM_TERM_TYPES; i++)
-    {
-      uint offset = os_int.term_type_offsets[i];
-      uint dens_offset = os_int.dens_offsets[i];
-      uint force_offset = os_int.out_offsets[i];
-      dim3 threads = os_int.term_type_counts[i];
-      dim3 blockSize(QMMM_BLOCK_SIZE);
-      dim3 gridSize = divUp(threads, blockSize);
-      switch (i) {
-        case 0: gpu_coulomb_forces<scalar_type,0><<<gridSize,blockSize,0,stream[i]>>>( coulomb_forces_parameters ); break;
-        case 1: gpu_coulomb_forces<scalar_type,1><<<gridSize,blockSize,0,stream[i]>>>( coulomb_forces_parameters ); break;
-        case 2: gpu_coulomb_forces<scalar_type,2><<<gridSize,blockSize,0,stream[i]>>>( coulomb_forces_parameters ); break;
-        case 3: gpu_coulomb_forces<scalar_type,3><<<gridSize,blockSize,0,stream[i]>>>( coulomb_forces_parameters ); break;
-        case 4: gpu_coulomb_forces<scalar_type,4><<<gridSize,blockSize,0,stream[i]>>>( coulomb_forces_parameters ); break;
-        case 5: gpu_coulomb_forces<scalar_type,5><<<gridSize,blockSize,0,stream[i]>>>( coulomb_forces_parameters ); break;
-      }
-    }
-    cudaDeviceSynchronize();
-    for (uint i = 0; i < NUM_TERM_TYPES; i++) {
-      cudaStreamDestroy(stream[i]);
-    }
-
-    cudaUnbindTexture(str_tex);
-
-    os_int.get_gradient_output(qm_forces, partial_out_size);
-
-    cudaAssertNoError("CoulombIntegral::calc_gradient");
+  cudaAssertNoError("CoulombIntegral::calc_gradient");
 }
 
-template<class scalar_type>
-void CoulombIntegral<scalar_type>::fit_aux_density( void )
-{
-    os_int.reload_density();
-    uint partial_out_size = 0, max_partial_size = 0;
-    for (uint i = 0; i < NUM_TERM_TYPES; i++) {
-      uint this_count = divUp(os_int.term_type_counts[i],QMMM_BLOCK_SIZE);
-      if (this_count > max_partial_size) max_partial_size = this_count;
-      partial_out_size += this_count;
-    }
+template <class scalar_type>
+void CoulombIntegral<scalar_type>::fit_aux_density(void) {
+  os_int.reload_density();
+  uint partial_out_size = 0, max_partial_size = 0;
+  for (uint i = 0; i < NUM_TERM_TYPES; i++) {
+    uint this_count = divUp(os_int.term_type_counts[i], QMMM_BLOCK_SIZE);
+    if (this_count > max_partial_size) max_partial_size = this_count;
+    partial_out_size += this_count;
+  }
 
-    {
-      dim3 threads(input_size);
-      dim3 blockSize(QMMM_BLOCK_SIZE);
-      dim3 gridSize = divUp(threads,blockSize);
-      zero_fock<scalar_type><<<gridSize,blockSize>>>(fit_dens_dev.data,input_size,1);
-    }
-    {
-      dim3 threads(COALESCED_DIMENSION(integral_vars.m_dens),partial_out_size);
-      dim3 blockSize(32,4);
-      dim3 gridSize = divUp(threads,blockSize);
-      zero_fock<double><<<gridSize,blockSize>>>(rc_partial_dev.data,COALESCED_DIMENSION(integral_vars.m_dens),partial_out_size);
-    }
+  {
+    dim3 threads(input_size);
+    dim3 blockSize(QMMM_BLOCK_SIZE);
+    dim3 gridSize = divUp(threads, blockSize);
+    zero_fock<scalar_type>
+        <<<gridSize, blockSize>>>(fit_dens_dev.data, input_size, 1);
+  }
+  {
+    dim3 threads(COALESCED_DIMENSION(integral_vars.m_dens), partial_out_size);
+    dim3 blockSize(32, 4);
+    dim3 gridSize = divUp(threads, blockSize);
+    zero_fock<double><<<gridSize, blockSize>>>(
+        rc_partial_dev.data, COALESCED_DIMENSION(integral_vars.m_dens),
+        partial_out_size);
+  }
 
-    //
-    // The STR table for F(m,U) calculation is being accessed via texture fetches
-    //
-    cudaBindTextureToArray(str_tex,gammaArray);
+  //
+  // The STR table for F(m,U) calculation is being accessed via texture fetches
+  //
+  cudaBindTextureToArray(str_tex, gammaArray);
 
-#define fit1_parameters \
-  os_int.term_type_counts[i], os_int.factor_ac_dev.data, os_int.nuc_dev.data, os_int.dens_values_dev.data+dens_offset, os_int.func_code_dev.data+offset,os_int.local_dens_dev.data+offset, \
-  rc_partial_dev.data+rc_offset, COALESCED_DIMENSION(integral_vars.m_dens),factor_ac_dens_dev.data,nuc_dens_dev.data, \
-  s_end, p_end, d_end, p_offset, d_offset
-    // Each term type is calculated asynchronously
-    cudaStream_t stream[NUM_TERM_TYPES];
-    for (uint i = 0; i < NUM_TERM_TYPES; i++) {
-      cudaStreamCreate(&stream[i]);
+#define fit1_parameters                                                        \
+  os_int.term_type_counts[i], os_int.factor_ac_dev.data, os_int.nuc_dev.data,  \
+      os_int.dens_values_dev.data + dens_offset,                               \
+      os_int.func_code_dev.data + offset, os_int.local_dens_dev.data + offset, \
+      rc_partial_dev.data + rc_offset,                                         \
+      COALESCED_DIMENSION(integral_vars.m_dens), factor_ac_dens_dev.data,      \
+      nuc_dens_dev.data, s_end, p_end, d_end, p_offset, d_offset
+  // Each term type is calculated asynchronously
+  cudaStream_t stream[NUM_TERM_TYPES];
+  for (uint i = 0; i < NUM_TERM_TYPES; i++) {
+    cudaStreamCreate(&stream[i]);
+  }
+  //
+  // Begin launching kernels (one for each type of term, 0 = s-s, 1 = p-s, etc)
+  //
+  for (uint i = 0; i < NUM_TERM_TYPES; i++) {
+    uint offset = os_int.term_type_offsets[i];
+    uint dens_offset = os_int.dens_offsets[i];
+    uint rc_offset =
+        os_int.out_offsets[i] * COALESCED_DIMENSION(integral_vars.m_dens);
+    dim3 threads = os_int.term_type_counts[i];
+    dim3 blockSize(QMMM_BLOCK_SIZE);
+    dim3 gridSize = divUp(threads, blockSize);
+    switch (i) {
+      case 0:
+        gpu_coulomb_fit1<scalar_type, 0>
+            <<<gridSize, blockSize, 0, stream[i]>>>(fit1_parameters);
+        break;
+      case 1:
+        gpu_coulomb_fit1<scalar_type, 1>
+            <<<gridSize, blockSize, 0, stream[i]>>>(fit1_parameters);
+        break;
+      case 2:
+        gpu_coulomb_fit1<scalar_type, 2>
+            <<<gridSize, blockSize, 0, stream[i]>>>(fit1_parameters);
+        break;
+      case 3:
+        gpu_coulomb_fit1<scalar_type, 3>
+            <<<gridSize, blockSize, 0, stream[i]>>>(fit1_parameters);
+        break;
+      case 4:
+        gpu_coulomb_fit1<scalar_type, 4>
+            <<<gridSize, blockSize, 0, stream[i]>>>(fit1_parameters);
+        break;
+      case 5:
+        gpu_coulomb_fit1<scalar_type, 5>
+            <<<gridSize, blockSize, 0, stream[i]>>>(fit1_parameters);
+        break;
     }
-    //
-    // Begin launching kernels (one for each type of term, 0 = s-s, 1 = p-s, etc)
-    //
-    for (uint i = 0; i < NUM_TERM_TYPES; i++)
-    {
-      uint offset = os_int.term_type_offsets[i];
-      uint dens_offset = os_int.dens_offsets[i];
-      uint rc_offset = os_int.out_offsets[i] * COALESCED_DIMENSION(integral_vars.m_dens);
-      dim3 threads = os_int.term_type_counts[i];
-      dim3 blockSize(QMMM_BLOCK_SIZE);
-      dim3 gridSize = divUp(threads, blockSize);
-      switch (i) {
-        case 0: gpu_coulomb_fit1<scalar_type,0><<<gridSize,blockSize,0,stream[i]>>>( fit1_parameters ); break;
-        case 1: gpu_coulomb_fit1<scalar_type,1><<<gridSize,blockSize,0,stream[i]>>>( fit1_parameters ); break;
-        case 2: gpu_coulomb_fit1<scalar_type,2><<<gridSize,blockSize,0,stream[i]>>>( fit1_parameters ); break;
-        case 3: gpu_coulomb_fit1<scalar_type,3><<<gridSize,blockSize,0,stream[i]>>>( fit1_parameters ); break;
-        case 4: gpu_coulomb_fit1<scalar_type,4><<<gridSize,blockSize,0,stream[i]>>>( fit1_parameters ); break;
-        case 5: gpu_coulomb_fit1<scalar_type,5><<<gridSize,blockSize,0,stream[i]>>>( fit1_parameters ); break;
-      }
-      dim3 reduceThreads = integral_vars.m_dens;
-      dim3 reduceBlockSize(QMMM_REDUCE_BLOCK_SIZE);
-      dim3 reduceGridSize = divUp(reduceThreads,reduceBlockSize);
-      gpu_coulomb_rc_term_reduce<scalar_type><<<reduceGridSize,reduceBlockSize,0,stream[i]>>>( rc_partial_dev.data,COALESCED_DIMENSION(integral_vars.m_dens),
-                                                                                               os_int.out_offsets[i], (i<NUM_TERM_TYPES-1?os_int.out_offsets[i+1]:partial_out_size) ,integral_vars.m_dens );
-    }
-    cudaDeviceSynchronize();
-    for (uint i = 0; i < NUM_TERM_TYPES; i++) {
-      cudaStreamDestroy(stream[i]);
-    }
+    dim3 reduceThreads = integral_vars.m_dens;
+    dim3 reduceBlockSize(QMMM_REDUCE_BLOCK_SIZE);
+    dim3 reduceGridSize = divUp(reduceThreads, reduceBlockSize);
+    gpu_coulomb_rc_term_reduce<scalar_type>
+        <<<reduceGridSize, reduceBlockSize, 0, stream[i]>>>(
+            rc_partial_dev.data, COALESCED_DIMENSION(integral_vars.m_dens),
+            os_int.out_offsets[i],
+            (i < NUM_TERM_TYPES - 1 ? os_int.out_offsets[i + 1]
+                                    : partial_out_size),
+            integral_vars.m_dens);
+  }
+  cudaDeviceSynchronize();
+  for (uint i = 0; i < NUM_TERM_TYPES; i++) {
+    cudaStreamDestroy(stream[i]);
+  }
 
-    {
-      dim3 reduceThreads = integral_vars.m_dens;
-      dim3 reduceBlockSize(QMMM_REDUCE_BLOCK_SIZE);
-      dim3 reduceGridSize = divUp(reduceThreads,reduceBlockSize);
-      gpu_coulomb_rc_reduce<scalar_type><<<reduceGridSize,reduceBlockSize>>>( rc_partial_dev.data,COALESCED_DIMENSION(integral_vars.m_dens),integral_vars.m_dens,NUM_TERM_TYPES );
-    }
-    cudaDeviceSynchronize();
-    {
-      dim3 threads = integral_vars.m_dens;
-      dim3 blockSize(QMMM_BLOCK_SIZE);
-      dim3 gridSize = divUp(threads,blockSize);
-      gpu_coulomb_fit2<scalar_type><<<gridSize,blockSize>>>( rc_partial_dev.data,fit_dens_dev.data,Ginv_dev.data,input_ind_dev.data,integral_vars.m_dens );
-    }
-    cudaDeviceSynchronize();
+  {
+    dim3 reduceThreads = integral_vars.m_dens;
+    dim3 reduceBlockSize(QMMM_REDUCE_BLOCK_SIZE);
+    dim3 reduceGridSize = divUp(reduceThreads, reduceBlockSize);
+    gpu_coulomb_rc_reduce<scalar_type><<<reduceGridSize, reduceBlockSize>>>(
+        rc_partial_dev.data, COALESCED_DIMENSION(integral_vars.m_dens),
+        integral_vars.m_dens, NUM_TERM_TYPES);
+  }
+  cudaDeviceSynchronize();
+  {
+    dim3 threads = integral_vars.m_dens;
+    dim3 blockSize(QMMM_BLOCK_SIZE);
+    dim3 gridSize = divUp(threads, blockSize);
+    gpu_coulomb_fit2<scalar_type><<<gridSize, blockSize>>>(
+        rc_partial_dev.data, fit_dens_dev.data, Ginv_dev.data,
+        input_ind_dev.data, integral_vars.m_dens);
+  }
+  cudaDeviceSynchronize();
 
-    G2G::HostMatrix<scalar_type> fit_dens_h(fit_dens_dev);
-    for (uint i = 0; i < integral_vars.m_dens; i++) {
-      integral_vars.af_input_ndens1(i) = fit_dens_h(input_ind_cpu[i]);
-    }
+  G2G::HostMatrix<scalar_type> fit_dens_h(fit_dens_dev);
+  for (uint i = 0; i < integral_vars.m_dens; i++) {
+    integral_vars.af_input_ndens1(i) = fit_dens_h(input_ind_cpu[i]);
+  }
 
-    //cudaUnbindTexture(str_tex);
+  // cudaUnbindTexture(str_tex);
 
-    cudaAssertNoError("CoulombIntegral::fit_aux_density");
+  cudaAssertNoError("CoulombIntegral::fit_aux_density");
 }
 
-template<class scalar_type>
-void CoulombIntegral<scalar_type>::calc_fock( double& Es )
-{
-    uint partial_out_size = 0, max_partial_size = 0;
-    for (uint i = 0; i < NUM_TERM_TYPES; i++) {
-      uint this_count = divUp(os_int.term_type_counts[i],QMMM_BLOCK_SIZE);
-      if (this_count > max_partial_size) max_partial_size = this_count;
-      partial_out_size += this_count;
-    }
+template <class scalar_type>
+void CoulombIntegral<scalar_type>::calc_fock(double& Es) {
+  uint partial_out_size = 0, max_partial_size = 0;
+  for (uint i = 0; i < NUM_TERM_TYPES; i++) {
+    uint this_count = divUp(os_int.term_type_counts[i], QMMM_BLOCK_SIZE);
+    if (this_count > max_partial_size) max_partial_size = this_count;
+    partial_out_size += this_count;
+  }
 
-    {
-      // I don't know why, but doing this zeroing kernel with this grid (rather than a more logical 1D grid)
-      // actually seems to speed things up...I can only guess it's due to some synchronization issue
-      dim3 threads(os_int.dens_values.size(),max_partial_size);
-      dim3 blockSize(32,4);//QMMM_BLOCK_SIZE);
-      dim3 gridSize = divUp(threads,blockSize);
-      //
-      // Zero the partial Fock matrix on the GPU
-      //
-      zero_fock<double><<<gridSize,blockSize>>>(os_int.partial_fock_dev.data,os_int.dens_values.size(),1);
+  {
+    // I don't know why, but doing this zeroing kernel with this grid (rather
+    // than a more logical 1D grid) actually seems to speed things up...I can
+    // only guess it's due to some synchronization issue
+    dim3 threads(os_int.dens_values.size(), max_partial_size);
+    dim3 blockSize(32, 4);  // QMMM_BLOCK_SIZE);
+    dim3 gridSize = divUp(threads, blockSize);
+    //
+    // Zero the partial Fock matrix on the GPU
+    //
+    zero_fock<double><<<gridSize, blockSize>>>(os_int.partial_fock_dev.data,
+                                               os_int.dens_values.size(), 1);
+  }
+
+  //
+  // The STR table for F(m,U) calculation is being accessed via texture fetches
+  //
+  // cudaBindTextureToArray(str_tex,gammaArray);
+
+#define coulomb_fock_parameters                                                \
+  os_int.term_type_counts[i], os_int.factor_ac_dev.data, os_int.nuc_dev.data,  \
+      os_int.func_code_dev.data + offset, os_int.local_dens_dev.data + offset, \
+      os_int.partial_fock_dev.data + fock_offset, os_int.dens_values.size(),   \
+      factor_ac_dens_dev.data, nuc_dens_dev.data, fit_dens_dev.data, s_end,    \
+      p_end, d_end, p_offset, d_offset
+  // Each term type is calculated asynchronously
+  cudaStream_t stream[NUM_TERM_TYPES];
+  for (uint i = 0; i < NUM_TERM_TYPES; i++) {
+    cudaStreamCreate(&stream[i]);
+  }
+  //
+  // Begin launching kernels (one for each type of term, 0 = s-s, 1 = p-s, etc)
+  //
+  for (uint i = 0; i < NUM_TERM_TYPES; i++) {
+    uint offset = os_int.term_type_offsets[i];
+    uint fock_offset = os_int.dens_offsets[i];
+    dim3 threads = os_int.term_type_counts[i];
+    dim3 blockSize(QMMM_BLOCK_SIZE);
+    dim3 gridSize = divUp(threads, blockSize);
+    switch (i) {
+      case 0:
+        gpu_coulomb_fock<scalar_type, 0>
+            <<<gridSize, blockSize, 0, stream[i]>>>(coulomb_fock_parameters);
+        break;
+      case 1:
+        gpu_coulomb_fock<scalar_type, 1>
+            <<<gridSize, blockSize, 0, stream[i]>>>(coulomb_fock_parameters);
+        break;
+      case 2:
+        gpu_coulomb_fock<scalar_type, 2>
+            <<<gridSize, blockSize, 0, stream[i]>>>(coulomb_fock_parameters);
+        break;
+      case 3:
+        gpu_coulomb_fock<scalar_type, 3>
+            <<<gridSize, blockSize, 0, stream[i]>>>(coulomb_fock_parameters);
+        break;
+      case 4:
+        gpu_coulomb_fock<scalar_type, 4>
+            <<<gridSize, blockSize, 0, stream[i]>>>(coulomb_fock_parameters);
+        break;
+      case 5:
+        gpu_coulomb_fock<scalar_type, 5>
+            <<<gridSize, blockSize, 0, stream[i]>>>(coulomb_fock_parameters);
+        break;
     }
 
     //
-    // The STR table for F(m,U) calculation is being accessed via texture fetches
+    // Reduce the partial Fock terms for a particular term type as soon as that
+    // kernel is done; also calculate partial energies for that type
     //
-    //cudaBindTextureToArray(str_tex,gammaArray);
+    dim3 reduceThreads = os_int.dens_counts[i];
+    dim3 reduceBlockSize(QMMM_REDUCE_BLOCK_SIZE);
+    dim3 reduceGridSize = divUp(reduceThreads, reduceBlockSize);
+    gpu_fock_reduce<scalar_type>
+        <<<reduceGridSize, reduceBlockSize, 0, stream[i]>>>(
+            os_int.partial_fock_dev.data + fock_offset,
+            os_int.dens_values_dev.data + fock_offset,
+            os_int.partial_energies_dev.data + os_int.energies_offsets[i],
+            os_int.dens_values.size(), max_partial_size, os_int.dens_counts[i]);
+  }
+  cudaDeviceSynchronize();
+  for (uint i = 0; i < NUM_TERM_TYPES; i++) {
+    cudaStreamDestroy(stream[i]);
+  }
 
-#define coulomb_fock_parameters \
-  os_int.term_type_counts[i], os_int.factor_ac_dev.data, os_int.nuc_dev.data, os_int.func_code_dev.data+offset,os_int.local_dens_dev.data+offset, \
-  os_int.partial_fock_dev.data+fock_offset, os_int.dens_values.size(),factor_ac_dens_dev.data,nuc_dens_dev.data,fit_dens_dev.data, \
-  s_end, p_end, d_end, p_offset, d_offset
-    // Each term type is calculated asynchronously
-    cudaStream_t stream[NUM_TERM_TYPES];
-    for (uint i = 0; i < NUM_TERM_TYPES; i++) {
-      cudaStreamCreate(&stream[i]);
-    }
-    //
-    // Begin launching kernels (one for each type of term, 0 = s-s, 1 = p-s, etc)
-    //
-    for (uint i = 0; i < NUM_TERM_TYPES; i++)
-    {
-      uint offset = os_int.term_type_offsets[i];
-      uint fock_offset = os_int.dens_offsets[i];
-      dim3 threads = os_int.term_type_counts[i];
-      dim3 blockSize(QMMM_BLOCK_SIZE);
-      dim3 gridSize = divUp(threads, blockSize);
-      switch (i) {
-        case 0: gpu_coulomb_fock<scalar_type,0><<<gridSize,blockSize,0,stream[i]>>>( coulomb_fock_parameters ); break;
-        case 1: gpu_coulomb_fock<scalar_type,1><<<gridSize,blockSize,0,stream[i]>>>( coulomb_fock_parameters ); break;
-        case 2: gpu_coulomb_fock<scalar_type,2><<<gridSize,blockSize,0,stream[i]>>>( coulomb_fock_parameters ); break;
-        case 3: gpu_coulomb_fock<scalar_type,3><<<gridSize,blockSize,0,stream[i]>>>( coulomb_fock_parameters ); break;
-        case 4: gpu_coulomb_fock<scalar_type,4><<<gridSize,blockSize,0,stream[i]>>>( coulomb_fock_parameters ); break;
-        case 5: gpu_coulomb_fock<scalar_type,5><<<gridSize,blockSize,0,stream[i]>>>( coulomb_fock_parameters ); break;
-      }
+  cudaUnbindTexture(str_tex);
 
-      //
-      // Reduce the partial Fock terms for a particular term type as soon as that kernel is done; also calculate partial energies for that type
-      //
-      dim3 reduceThreads = os_int.dens_counts[i];
-      dim3 reduceBlockSize(QMMM_REDUCE_BLOCK_SIZE);
-      dim3 reduceGridSize = divUp(reduceThreads,reduceBlockSize);
-      gpu_fock_reduce<scalar_type><<<reduceGridSize,reduceBlockSize,0,stream[i]>>>( os_int.partial_fock_dev.data+fock_offset, os_int.dens_values_dev.data+fock_offset,
-                                                                                      os_int.partial_energies_dev.data+os_int.energies_offsets[i],
-                                                                                      os_int.dens_values.size(), max_partial_size, os_int.dens_counts[i] );
-    }
-    cudaDeviceSynchronize();
-    for (uint i = 0; i < NUM_TERM_TYPES; i++) {
-      cudaStreamDestroy(stream[i]);
-    }
+  /* The procedure os_int.get_fock_output will calculate the coulomb term for
+     the fock matrix and the coulomb energy contribution. As for the energy,
+     closed shell goes through N/2 MO and then multiplies times two the results,
+     the procedure directly calculates this doubled energy. Then for the
+     calculation of Ea and Eb the energies obtained have that x2 factor as well,
+     despite each going through Na and Nb MOs, and thus have to be halved when
+     added. This doesn't happen for the fock matrices as each Fa and Fb have the
+     same general expresion as F in closed shell.
+  */
+  if (G2G::fortran_vars.OPEN) {
+    double Ea2, Eb2;
+    os_int.get_fock_output(Ea2, G2G::fortran_vars.rmm_output_a);
+    os_int.get_fock_output(Eb2, G2G::fortran_vars.rmm_output_b);
+    Es = Es + ((Ea2 + Eb2) / 2.0f);
+  } else {
+    double Ecs;
+    os_int.get_fock_output(Ecs, G2G::fortran_vars.rmm_output);
+    Es = Es + Ecs;
+  }
 
-    cudaUnbindTexture(str_tex);
-
-/* The procedure os_int.get_fock_output will calculate the coulomb term for the fock matrix and the coulomb energy
-   contribution. As for the energy, closed shell goes through N/2 MO and then multiplies times two the results, the
-   procedure directly calculates this doubled energy. Then for the calculation of Ea and Eb the energies obtained
-   have that x2 factor as well, despite each going through Na and Nb MOs, and thus have to be halved when added.
-   This doesn't happen for the fock matrices as each Fa and Fb have the same general expresion as F in closed shell.
-*/
-    if (G2G::fortran_vars.OPEN) {
-       double Ea2, Eb2;
-       os_int.get_fock_output(Ea2, G2G::fortran_vars.rmm_output_a);
-       os_int.get_fock_output(Eb2, G2G::fortran_vars.rmm_output_b);
-       Es = Es + ( (Ea2 + Eb2) / 2.0f);
-    } else {
-       double Ecs;
-       os_int.get_fock_output(Ecs, G2G::fortran_vars.rmm_output);
-       Es = Es + Ecs;
-    }
-
-    cudaAssertNoError("CoulombIntegral::calc_fock");
+  cudaAssertNoError("CoulombIntegral::calc_fock");
 }
 
 #if AINT_MP && !FULL_DOUBLE
@@ -501,4 +612,4 @@ template class CoulombIntegral<float>;
 template class CoulombIntegral<double>;
 #endif
 
-}
+}  // namespace AINT

--- a/g2g/analytic_integral/cuda/os_common.cu
+++ b/g2g/analytic_integral/cuda/os_common.cu
@@ -14,287 +14,326 @@
 #include "../aint_init.h"
 #include "../aint_common.h"
 
-namespace G2G
-{
+namespace G2G {
 #include "gpu_vars/g2g_gpu_variables.h"
 
 extern double free_global_memory;
-}
+}  // namespace G2G
 
 using std::cout;
-using std::vector;
 using std::endl;
+using std::vector;
 
-// On-device global data that is common to all analytic (using O-S) integral evaluation
-namespace AINT
-{
+// On-device global data that is common to all analytic (using O-S) integral
+// evaluation
+namespace AINT {
 
 cudaArray* gammaArray;
 __device__ __constant__ uint gpu_m;
 #if !AINT_MP || FULL_DOUBLE
-texture<int2, cudaTextureType2D, cudaReadModeElementType> str_tex; // Texture for STR array (used in F(m,U))
+texture<int2, cudaTextureType2D, cudaReadModeElementType>
+    str_tex;  // Texture for STR array (used in F(m,U))
 __device__ __constant__ double gpu_fac[17];
 #else
 texture<float, cudaTextureType2D, cudaReadModeElementType> str_tex;
 __device__ __constant__ float gpu_fac[17];
 #endif
 
-__device__ __constant__ uint TERM_TYPE_GAUSSIANS[6] = { 1, 3, 9, 6, 18, 36 };
+__device__ __constant__ uint TERM_TYPE_GAUSSIANS[6] = {1, 3, 9, 6, 18, 36};
 __device__ __constant__ uint gpu_atom_types[MAX_ATOMS];
 __device__ __constant__ uint gpu_atom_Z[MAX_ATOMS];
 
-template<class scalar_type>
-void OSIntegral<scalar_type>::load_params(void)
-{
-    // Use the highest cc device available for aint stuff
-    int devcount = cudaGetGPUCount();
-    int devnum = -1, devmajor = -1, devminor = -1;
-    cudaDeviceProp devprop;
-    for (int i = 0; i < devcount; i++) {
-      if (cudaGetDeviceProperties(&devprop, i) != cudaSuccess) throw std::runtime_error("Could not get device properties!");
-      if (devprop.major > devmajor || (devprop.major == devmajor && devprop.minor > devminor)) {
-        devnum = i;
-        devmajor = devprop.major;
-        devminor = devprop.minor;
-      }
+template <class scalar_type>
+void OSIntegral<scalar_type>::load_params(void) {
+  // Use the highest cc device available for aint stuff
+  int devcount = cudaGetGPUCount();
+  int devnum = -1, devmajor = -1, devminor = -1;
+  cudaDeviceProp devprop;
+  for (int i = 0; i < devcount; i++) {
+    if (cudaGetDeviceProperties(&devprop, i) != cudaSuccess)
+      throw std::runtime_error("Could not get device properties!");
+    if (devprop.major > devmajor ||
+        (devprop.major == devmajor && devprop.minor > devminor)) {
+      devnum = i;
+      devmajor = devprop.major;
+      devminor = devprop.minor;
     }
+  }
 
-    if (G2G::verbose > 3) cout << "  Using device " << devnum << " for analytic integral calculations." << endl;
-    this->my_device = devnum;
-    int previous_device; cudaGetDevice(&previous_device);
-    if(cudaSetDevice(devnum) != cudaSuccess) std::cout << "Error: can't set the device " << devnum << std::endl;
+  if (G2G::verbose > 3)
+    cout << "  Using device " << devnum
+         << " for analytic integral calculations." << endl;
+  this->my_device = devnum;
+  int previous_device;
+  cudaGetDevice(&previous_device);
+  if (cudaSetDevice(devnum) != cudaSuccess)
+    std::cout << "Error: can't set the device " << devnum << std::endl;
 
-    cudaMemcpyToSymbol(gpu_m, &G2G::fortran_vars.m, sizeof(G2G::fortran_vars.m), 0, cudaMemcpyHostToDevice);
-    cudaMemcpyToSymbol(gpu_atom_types, G2G::fortran_vars.atom_types.data, G2G::fortran_vars.atom_types.bytes(), 0, cudaMemcpyHostToDevice);
-    cudaMemcpyToSymbol(gpu_atom_Z, integral_vars.atom_Z.data, integral_vars.atom_Z.bytes(), 0, cudaMemcpyHostToDevice);
-    //
-    // Set up arrays needed for F(m,U) calculation in QM/MM kernels (STR and FAC) and send them to device
-    // FAC is small so it's put into constant memory
-    // STR is large and accessed (potentially) with a random access pattern in the first index
-    // TODO: putting STR into texture for now; need to see if there's a better way to access it in the kernel
-    //
+  cudaMemcpyToSymbol(gpu_m, &G2G::fortran_vars.m, sizeof(G2G::fortran_vars.m),
+                     0, cudaMemcpyHostToDevice);
+  cudaMemcpyToSymbol(gpu_atom_types, G2G::fortran_vars.atom_types.data,
+                     G2G::fortran_vars.atom_types.bytes(), 0,
+                     cudaMemcpyHostToDevice);
+  cudaMemcpyToSymbol(gpu_atom_Z, integral_vars.atom_Z.data,
+                     integral_vars.atom_Z.bytes(), 0, cudaMemcpyHostToDevice);
+  //
+  // Set up arrays needed for F(m,U) calculation in QM/MM kernels (STR and FAC)
+  // and send them to device FAC is small so it's put into constant memory STR
+  // is large and accessed (potentially) with a random access pattern in the
+  // first index
+  // TODO: putting STR into texture for now; need to see if there's a better way
+  // to access it in the kernel
+  //
 
-    // Cast STR/FAC to appropriate type (float/double)
-    G2G::HostMatrix<scalar_type> h_str(880,22), h_fac(17);
-    for (uint i = 0; i < 880; i++) {
-      for (uint j = 0; j < 22; j++) {
-        h_str(i,j) = integral_vars.str(i,j);
-      }
+  // Cast STR/FAC to appropriate type (float/double)
+  G2G::HostMatrix<scalar_type> h_str(880, 22), h_fac(17);
+  for (uint i = 0; i < 880; i++) {
+    for (uint j = 0; j < 22; j++) {
+      h_str(i, j) = integral_vars.str(i, j);
     }
-    for (uint i = 0; i < 17; i++) {
-      h_fac(i) = integral_vars.fac(i);
-    }
+  }
+  for (uint i = 0; i < 17; i++) {
+    h_fac(i) = integral_vars.fac(i);
+  }
 
-    str_tex.normalized = false;
-    str_tex.filterMode = cudaFilterModePoint;
+  str_tex.normalized = false;
+  str_tex.filterMode = cudaFilterModePoint;
 
-    cudaMallocArray(&gammaArray,&str_tex.channelDesc,880,22);
-    cudaMemcpyToArray(gammaArray,0,0,h_str.data,sizeof(scalar_type)*880*22,cudaMemcpyHostToDevice);
-    cudaMemcpyToSymbol(gpu_fac,h_fac.data,h_fac.bytes(),0,cudaMemcpyHostToDevice);
+  cudaMallocArray(&gammaArray, &str_tex.channelDesc, 880, 22);
+  cudaMemcpyToArray(gammaArray, 0, 0, h_str.data,
+                    sizeof(scalar_type) * 880 * 22, cudaMemcpyHostToDevice);
+  cudaMemcpyToSymbol(gpu_fac, h_fac.data, h_fac.bytes(), 0,
+                     cudaMemcpyHostToDevice);
 
-    cudaSetDevice(previous_device);
-    cudaAssertNoError("OSIntegral::load_params");
-
+  cudaSetDevice(previous_device);
+  cudaAssertNoError("OSIntegral::load_params");
 }
 
-template<class scalar_type>
-void OSIntegral<scalar_type>::clear( void )
-{
-    func_code.clear();
-    local_dens.clear();
-    dens_values.clear();
-    local2globaldens.clear();
+template <class scalar_type>
+void OSIntegral<scalar_type>::clear(void) {
+  func_code.clear();
+  local_dens.clear();
+  dens_values.clear();
+  local2globaldens.clear();
 
-    if (factor_ac_dev.is_allocated() && G2G::free_global_memory > 0.0) {
-      size_t gpu_size = factor_ac_dev.bytes() + nuc_dev.bytes() + func_code_dev.bytes() + local_dens_dev.bytes() + dens_values_dev.bytes();
-      GlobalMemoryPool::dealloc(gpu_size);
-    }
-    factor_ac_dev.deallocate();
-    nuc_dev.deallocate();
-    func_code_dev.deallocate();
-    local_dens_dev.deallocate();
-    dens_values_dev.deallocate();
+  if (factor_ac_dev.is_allocated() && G2G::free_global_memory > 0.0) {
+    size_t gpu_size = factor_ac_dev.bytes() + nuc_dev.bytes() +
+                      func_code_dev.bytes() + local_dens_dev.bytes() +
+                      dens_values_dev.bytes();
+    GlobalMemoryPool::dealloc(gpu_size);
+  }
+  factor_ac_dev.deallocate();
+  nuc_dev.deallocate();
+  func_code_dev.deallocate();
+  local_dens_dev.deallocate();
+  dens_values_dev.deallocate();
 
-    if (partial_qm_forces_dev.is_allocated() && G2G::free_global_memory > 0.0) {
-      size_t gpu_size = partial_fock_dev.bytes() + partial_energies_dev.bytes() + partial_qm_forces_dev.bytes();
-      GlobalMemoryPool::dealloc(gpu_size);
-    }
-    partial_fock_dev.deallocate();
-    partial_energies_dev.deallocate();
-    partial_qm_forces_dev.deallocate();
+  if (partial_qm_forces_dev.is_allocated() && G2G::free_global_memory > 0.0) {
+    size_t gpu_size = partial_fock_dev.bytes() + partial_energies_dev.bytes() +
+                      partial_qm_forces_dev.bytes();
+    GlobalMemoryPool::dealloc(gpu_size);
+  }
+  partial_fock_dev.deallocate();
+  partial_energies_dev.deallocate();
+  partial_qm_forces_dev.deallocate();
 
-    cudaAssertNoError("OSIntegral::clear");
+  cudaAssertNoError("OSIntegral::clear");
 }
 
-template<class scalar_type>
-void OSIntegral<scalar_type>::deinit( void )
-{
-    clear();
+template <class scalar_type>
+void OSIntegral<scalar_type>::deinit(void) {
+  clear();
 
-    cudaFreeArray(gammaArray);
+  cudaFreeArray(gammaArray);
 
-    cudaAssertNoError("OSIntegral::deinit");
+  cudaAssertNoError("OSIntegral::deinit");
 }
 
-template<class scalar_type>
-bool OSIntegral<scalar_type>::load_input( void )
-{
-    //
-    // Set up device arrays for function values and mapping function -> nuclei
-    //
-    // TODO: tried contracting the nuc / function value arrays to a size of total_funcs rather than m, seems to slow down the kernel
-    // Doing this requires some more indexing math in the kernel, but need to test on bigger test case
-    G2G::HostMatrix<G2G::vec_type<scalar_type, 2> > factor_ac_cpu(COALESCED_DIMENSION(G2G::fortran_vars.m), MAX_CONTRACTIONS);
-    G2G::HostMatrixUInt nuc_cpu(G2G::fortran_vars.m, 1);
+template <class scalar_type>
+bool OSIntegral<scalar_type>::load_input(void) {
+  //
+  // Set up device arrays for function values and mapping function -> nuclei
+  //
+  // TODO: tried contracting the nuc / function value arrays to a size of
+  // total_funcs rather than m, seems to slow down the kernel Doing this
+  // requires some more indexing math in the kernel, but need to test on bigger
+  // test case
+  G2G::HostMatrix<G2G::vec_type<scalar_type, 2> > factor_ac_cpu(
+      COALESCED_DIMENSION(G2G::fortran_vars.m), MAX_CONTRACTIONS);
+  G2G::HostMatrixUInt nuc_cpu(G2G::fortran_vars.m, 1);
 
-    uint localfunc = 0, func = 0;
-    while (func < G2G::fortran_vars.m) {
-      nuc_cpu(localfunc) = G2G::fortran_vars.nucleii(func) - 1;
-      for (uint k = 0; k < G2G::fortran_vars.contractions(func); k++) {
-        factor_ac_cpu(localfunc, k) = G2G::vec_type<scalar_type, 2>(G2G::fortran_vars.a_values(func, k), G2G::fortran_vars.c_values(func, k));
-      }
-      func++;
-      localfunc++;
+  uint localfunc = 0, func = 0;
+  while (func < G2G::fortran_vars.m) {
+    nuc_cpu(localfunc) = G2G::fortran_vars.nucleii(func) - 1;
+    for (uint k = 0; k < G2G::fortran_vars.contractions(func); k++) {
+      factor_ac_cpu(localfunc, k) =
+          G2G::vec_type<scalar_type, 2>(G2G::fortran_vars.a_values(func, k),
+                                        G2G::fortran_vars.c_values(func, k));
     }
-    size_t gpu_size = factor_ac_cpu.bytes() + nuc_cpu.bytes();
-    gpu_size += (func_code.size() + local_dens.size()) * sizeof(uint);
-    gpu_size += dens_values.size() * sizeof(scalar_type);
-//    float mb_size = (float)gpu_size / 1048576.0f;
-//    cout << "O-S common input size: " << mb_size << " MB" << endl;
-    if (GlobalMemoryPool::tryAlloc(gpu_size) && G2G::free_global_memory > 0.0) return false;
+    func++;
+    localfunc++;
+  }
+  size_t gpu_size = factor_ac_cpu.bytes() + nuc_cpu.bytes();
+  gpu_size += (func_code.size() + local_dens.size()) * sizeof(uint);
+  gpu_size += dens_values.size() * sizeof(scalar_type);
+  //    float mb_size = (float)gpu_size / 1048576.0f;
+  //    cout << "O-S common input size: " << mb_size << " MB" << endl;
+  if (GlobalMemoryPool::tryAlloc(gpu_size) && G2G::free_global_memory > 0.0)
+    return false;
 
-    factor_ac_dev = factor_ac_cpu;
-    nuc_dev = nuc_cpu;
+  factor_ac_dev = factor_ac_cpu;
+  nuc_dev = nuc_cpu;
 
-    //
-    // Send input arrays (thread->primitive map and thread->density map) to the device
-    //
-    func_code_dev = func_code;
-    local_dens_dev = local_dens; // TODO: this is probably not necessary here as reload_density gets called before all the major kernel calls
-    //
-    // Send reduced density matrix to the device
-    //
-    dens_values_dev = dens_values;
+  //
+  // Send input arrays (thread->primitive map and thread->density map) to the
+  // device
+  //
+  func_code_dev = func_code;
+  local_dens_dev = local_dens;  // TODO: this is probably not necessary here as
+                                // reload_density gets called before all the
+                                // major kernel calls
+  //
+  // Send reduced density matrix to the device
+  //
+  dens_values_dev = dens_values;
 
-    cudaAssertNoError("OSIntegral::load_input");
+  cudaAssertNoError("OSIntegral::load_input");
 
-    return true;
+  return true;
 }
 
-template<class scalar_type>
-void OSIntegral<scalar_type>::reload_density( void )
-{
-    for (uint i = 0; i < dens_values.size(); i++)
-    {
-      dens_values[i] = G2G::fortran_vars.rmm_input_ndens1.data[local2globaldens[i]];
-    }
-    dens_values_dev = dens_values;
+template <class scalar_type>
+void OSIntegral<scalar_type>::reload_density(void) {
+  for (uint i = 0; i < dens_values.size(); i++) {
+    dens_values[i] =
+        G2G::fortran_vars.rmm_input_ndens1.data[local2globaldens[i]];
+  }
+  dens_values_dev = dens_values;
 
-    cudaAssertNoError("OSIntegral::reload_density");
+  cudaAssertNoError("OSIntegral::reload_density");
 }
 
-template<class scalar_type>
-bool OSIntegral<scalar_type>::alloc_output( void )
-{
-    //
-    // Allocate output arrays on device
-    // Currently, each block in the kernel reduces its output, so the output arrays have length (# block)
-    //
-    uint partial_out_size = 0, max_partial_size = 0;
-    out_offsets[0] = 0;
-    // Output arrays (probably) don't need to be padded for alignment as only one (or three) threads per block write to them
-    for (uint i = 0; i < NUM_TERM_TYPES; i++) {
-      uint this_count = divUp(term_type_counts[i],QMMM_BLOCK_SIZE);
-      if (this_count > max_partial_size) max_partial_size = this_count;
-      partial_out_size += this_count;
-      if (i+1<NUM_TERM_TYPES) { out_offsets[i+1] = partial_out_size; }
+template <class scalar_type>
+bool OSIntegral<scalar_type>::alloc_output(void) {
+  //
+  // Allocate output arrays on device
+  // Currently, each block in the kernel reduces its output, so the output
+  // arrays have length (# block)
+  //
+  uint partial_out_size = 0, max_partial_size = 0;
+  out_offsets[0] = 0;
+  // Output arrays (probably) don't need to be padded for alignment as only one
+  // (or three) threads per block write to them
+  for (uint i = 0; i < NUM_TERM_TYPES; i++) {
+    uint this_count = divUp(term_type_counts[i], QMMM_BLOCK_SIZE);
+    if (this_count > max_partial_size) max_partial_size = this_count;
+    partial_out_size += this_count;
+    if (i + 1 < NUM_TERM_TYPES) {
+      out_offsets[i + 1] = partial_out_size;
     }
-    //
-    // When calculating energies, the energy gets reduced per-block; we figure out the offets/counts of different term types into the partial output energy array here
-    //
-    uint energies_size = 0;
-    for (uint i = 0; i < NUM_TERM_TYPES; i++) {
-      energies_offsets[i] = energies_size;
-      energies_size += divUp(dens_counts[i],QMMM_REDUCE_BLOCK_SIZE);
-    }
+  }
+  //
+  // When calculating energies, the energy gets reduced per-block; we figure out
+  // the offets/counts of different term types into the partial output energy
+  // array here
+  //
+  uint energies_size = 0;
+  for (uint i = 0; i < NUM_TERM_TYPES; i++) {
+    energies_offsets[i] = energies_size;
+    energies_size += divUp(dens_counts[i], QMMM_REDUCE_BLOCK_SIZE);
+  }
 
-    size_t gpu_size = COALESCED_DIMENSION(partial_out_size) * G2G::fortran_vars.atoms * 3 * sizeof(scalar_type);
-    gpu_size += (dens_values.size() /* max_partial_size*/ + energies_size) * sizeof(double);
-//    float mb_size = (float)gpu_size / 1048576.0f;
-//    cout << "O-S common output size: " << mb_size << " MB" << endl;
-    if (GlobalMemoryPool::tryAlloc(gpu_size) && G2G::free_global_memory > 0.0) return false;
+  size_t gpu_size = COALESCED_DIMENSION(partial_out_size) *
+                    G2G::fortran_vars.atoms * 3 * sizeof(scalar_type);
+  gpu_size += (dens_values.size() /* max_partial_size*/ + energies_size) *
+              sizeof(double);
+  //    float mb_size = (float)gpu_size / 1048576.0f;
+  //    cout << "O-S common output size: " << mb_size << " MB" << endl;
+  if (GlobalMemoryPool::tryAlloc(gpu_size) && G2G::free_global_memory > 0.0)
+    return false;
 
-    //
-    // Forces: output is partial forces
-    //
-    partial_qm_forces_dev.resize(COALESCED_DIMENSION(partial_out_size), G2G::fortran_vars.atoms);
-    //
-    // Fock: ouptut is partial Fock elements
-    //
-    // The partial Fock matrix is partitioned by term type, so the second (partial) dimension needs to be as big as largest count of a single term type
-    partial_fock_dev.resize(dens_values.size(),1);//max_partial_size);
+  //
+  // Forces: output is partial forces
+  //
+  partial_qm_forces_dev.resize(COALESCED_DIMENSION(partial_out_size),
+                               G2G::fortran_vars.atoms);
+  //
+  // Fock: ouptut is partial Fock elements
+  //
+  // The partial Fock matrix is partitioned by term type, so the second
+  // (partial) dimension needs to be as big as largest count of a single term
+  // type
+  partial_fock_dev.resize(dens_values.size(), 1);  // max_partial_size);
 
-    partial_energies_dev.resize(energies_size,1);
+  partial_energies_dev.resize(energies_size, 1);
 
-    cudaAssertNoError("OSIntegral::alloc_output");
+  cudaAssertNoError("OSIntegral::alloc_output");
 
-    return true;
+  return true;
 }
 
-template<class scalar_type>
-void OSIntegral<scalar_type>::get_fock_output( double& Es, G2G::FortranMatrix<double>& fock_out )
-{
-    uint energies_size = 0;
-    for (uint i = 0; i < NUM_TERM_TYPES; i++) {
-      energies_size += divUp(dens_counts[i],QMMM_REDUCE_BLOCK_SIZE);
-    }
+template <class scalar_type>
+void OSIntegral<scalar_type>::get_fock_output(
+    double& Es, G2G::FortranMatrix<double>& fock_out) {
+  uint energies_size = 0;
+  for (uint i = 0; i < NUM_TERM_TYPES; i++) {
+    energies_size += divUp(dens_counts[i], QMMM_REDUCE_BLOCK_SIZE);
+  }
 
-    //
-    // Download reduced Fock matrix and partially reduced energies
-    // The Fock matrix has been reduced to the first row of the output, so we only want that much of the device array
-    //
-    G2G::HostMatrix<double> cpu_fock(partial_fock_dev);
-    //cudaMemcpy(cpu_fock.data,partial_fock_dev.data,cpu_fock.bytes(),cudaMemcpyDeviceToHost);
-    G2G::HostMatrix<double> cpu_partial_energies(partial_energies_dev);
+  //
+  // Download reduced Fock matrix and partially reduced energies
+  // The Fock matrix has been reduced to the first row of the output, so we only
+  // want that much of the device array
+  //
+  G2G::HostMatrix<double> cpu_fock(partial_fock_dev);
+  // cudaMemcpy(cpu_fock.data,partial_fock_dev.data,cpu_fock.bytes(),cudaMemcpyDeviceToHost);
+  G2G::HostMatrix<double> cpu_partial_energies(partial_energies_dev);
 
-    //
-    // Send Fock elements back to RMM(M11) and do final reduction of e-nuc energies into Es
-    //
-    for (uint t = 0; t < NUM_TERM_TYPES; t++) {
-      for (uint i = dens_offsets[t]; i < dens_offsets[t] + dens_counts[t]; i++) {
-        uint dens_ind = local2globaldens[i];
-        fock_out(dens_ind) += cpu_fock(i);
-      }
+  //
+  // Send Fock elements back to RMM(M11) and do final reduction of e-nuc
+  // energies into Es
+  //
+  for (uint t = 0; t < NUM_TERM_TYPES; t++) {
+    for (uint i = dens_offsets[t]; i < dens_offsets[t] + dens_counts[t]; i++) {
+      uint dens_ind = local2globaldens[i];
+      fock_out(dens_ind) += cpu_fock(i);
     }
-    for (uint i = 0; i < energies_size; i++) {
-      Es += cpu_partial_energies(i);
-    }
+  }
+  for (uint i = 0; i < energies_size; i++) {
+    Es += cpu_partial_energies(i);
+  }
 
-    cudaAssertNoError("OSIntegral::get_fock_output");
+  cudaAssertNoError("OSIntegral::get_fock_output");
 }
 
-template<class scalar_type>
-void OSIntegral<scalar_type>::get_gradient_output(double* qm_forces, uint partial_out_size)
-{
-    G2G::HostMatrix<G2G::vec_type<scalar_type,3> > cpu_partial_qm_forces(partial_qm_forces_dev);
+template <class scalar_type>
+void OSIntegral<scalar_type>::get_gradient_output(double* qm_forces,
+                                                  uint partial_out_size) {
+  G2G::HostMatrix<G2G::vec_type<scalar_type, 3> > cpu_partial_qm_forces(
+      partial_qm_forces_dev);
 
-    //
-    // Accumulate partial output
-    //
-    // TODO: need to think about how to accumulate individual force terms
-    // Currently, we reduce on a per-block basis in the kernel, then accumulate the block results here on the host
-    //
-    // The energy partial results are being reduced on-device and that works very well, could probably do that for forces too
-    //
-    for (uint i = 0; i < G2G::fortran_vars.atoms; i++) {
-      for (uint j = 0; j < partial_out_size; j++) {
-        qm_forces[i + 0 * G2G::fortran_vars.atoms] += cpu_partial_qm_forces(j,i).x;
-        qm_forces[i + 1 * G2G::fortran_vars.atoms] += cpu_partial_qm_forces(j,i).y;
-        qm_forces[i + 2 * G2G::fortran_vars.atoms] += cpu_partial_qm_forces(j,i).z;
-      }
+  //
+  // Accumulate partial output
+  //
+  // TODO: need to think about how to accumulate individual force terms
+  // Currently, we reduce on a per-block basis in the kernel, then accumulate
+  // the block results here on the host
+  //
+  // The energy partial results are being reduced on-device and that works very
+  // well, could probably do that for forces too
+  //
+  for (uint i = 0; i < G2G::fortran_vars.atoms; i++) {
+    for (uint j = 0; j < partial_out_size; j++) {
+      qm_forces[i + 0 * G2G::fortran_vars.atoms] +=
+          cpu_partial_qm_forces(j, i).x;
+      qm_forces[i + 1 * G2G::fortran_vars.atoms] +=
+          cpu_partial_qm_forces(j, i).y;
+      qm_forces[i + 2 * G2G::fortran_vars.atoms] +=
+          cpu_partial_qm_forces(j, i).z;
     }
+  }
 
-    cudaAssertNoError("OSIntegral::get_gradient_output");
+  cudaAssertNoError("OSIntegral::get_gradient_output");
 }
 
 #if AINT_MP && !FULL_DOUBLE
@@ -303,4 +342,4 @@ template class OSIntegral<float>;
 template class OSIntegral<double>;
 #endif
 
-}
+}  // namespace AINT

--- a/g2g/analytic_integral/cuda/qmmm.cu
+++ b/g2g/analytic_integral/cuda/qmmm.cu
@@ -13,17 +13,15 @@
 #include "../aint_init.h"
 #include "../aint_common.h"
 
-namespace G2G
-{
+namespace G2G {
 #include "gpu_vars/g2g_gpu_variables.h"
 }
 
 using std::cout;
-using std::vector;
 using std::endl;
+using std::vector;
 
-namespace AINT
-{
+namespace AINT {
 
 #include "gpu_vars/os_gpu_variables.h"
 #include "gpu_vars/qmmm_gpu_variables.h"
@@ -36,275 +34,406 @@ namespace AINT
 // Send the MM atom positions and charges to the device
 //
 template <class scalar_type>
-bool QMMMIntegral<scalar_type>::load_clatoms( void )
-{
+bool QMMMIntegral<scalar_type>::load_clatoms(void) {
+  cudaMemcpyToSymbol(gpu_clatoms, &integral_vars.clatoms,
+                     sizeof(integral_vars.clatoms), 0, cudaMemcpyHostToDevice);
 
-    cudaMemcpyToSymbol(gpu_clatoms, &integral_vars.clatoms, sizeof(integral_vars.clatoms), 0, cudaMemcpyHostToDevice);
+  G2G::HostMatrix<G2G::vec_type<scalar_type, 3>> clatom_pos_cpu(
+      integral_vars.clatoms, 1);
+  G2G::HostMatrix<scalar_type> clatom_chg_cpu(integral_vars.clatoms, 1);
+  for (uint i = 0; i < integral_vars.clatoms; i++) {
+    clatom_pos_cpu(i) =
+        G2G::vec_type<scalar_type, 3>(integral_vars.clatom_positions(i).x,
+                                      integral_vars.clatom_positions(i).y,
+                                      integral_vars.clatom_positions(i).z);
+    clatom_chg_cpu(i) = integral_vars.clatom_charges(i);
+  }
+  //    size_t gpu_size = clatom_pos_cpu.bytes() + clatom_chg_cpu.bytes();
+  //    float mb_size = (float)gpu_size / 1048576.0f;
+  //    cout << "QM/MM input size: " << mb_size << " MB" << endl;
 
-    G2G::HostMatrix<G2G::vec_type<scalar_type,3> > clatom_pos_cpu(integral_vars.clatoms,1);
-    G2G::HostMatrix<scalar_type> clatom_chg_cpu(integral_vars.clatoms,1);
-    for (uint i = 0; i < integral_vars.clatoms; i++) {
-      clatom_pos_cpu(i) = G2G::vec_type<scalar_type,3>(integral_vars.clatom_positions(i).x,integral_vars.clatom_positions(i).y,integral_vars.clatom_positions(i).z);
-      clatom_chg_cpu(i) = integral_vars.clatom_charges(i);
-    }
-//    size_t gpu_size = clatom_pos_cpu.bytes() + clatom_chg_cpu.bytes();
-//    float mb_size = (float)gpu_size / 1048576.0f;
-//    cout << "QM/MM input size: " << mb_size << " MB" << endl;
+  clatom_pos_dev = clatom_pos_cpu;
+  clatom_chg_dev = clatom_chg_cpu;
 
-    clatom_pos_dev = clatom_pos_cpu;
-    clatom_chg_dev = clatom_chg_cpu;
+  cudaAssertNoError("QMMMIntegral::load_clatoms");
 
-    cudaAssertNoError("QMMMIntegral::load_clatoms");
-
-    return true;
+  return true;
 }
 
 //
 // Allocate output arrays on device
 //
 template <class scalar_type>
-bool QMMMIntegral<scalar_type>::alloc_output( void )
-{
-    // Currently, each block in the kernel reduces its output, so the output arrays have length (# block)
-    uint partial_out_size = 0;
-    // Output arrays (probably) don't need to be padded for alignment as only one (or three) threads per block write to them
-    for (uint i = 0; i < NUM_TERM_TYPES; i++) {
-      uint this_count = divUp(os_int.term_type_counts[i],QMMM_BLOCK_SIZE);
-      partial_out_size += this_count;
-    }
-//    size_t gpu_size = COALESCED_DIMENSION(partial_out_size) * integral_vars.clatoms * 3 * sizeof(scalar_type);
-//    float mb_size = (float)gpu_size / 1048576.0f;
-//    cout << "QM/MM output size: " << mb_size << " MB" << endl;
+bool QMMMIntegral<scalar_type>::alloc_output(void) {
+  // Currently, each block in the kernel reduces its output, so the output
+  // arrays have length (# block)
+  uint partial_out_size = 0;
+  // Output arrays (probably) don't need to be padded for alignment as only one
+  // (or three) threads per block write to them
+  for (uint i = 0; i < NUM_TERM_TYPES; i++) {
+    uint this_count = divUp(os_int.term_type_counts[i], QMMM_BLOCK_SIZE);
+    partial_out_size += this_count;
+  }
+  //    size_t gpu_size = COALESCED_DIMENSION(partial_out_size) *
+  //    integral_vars.clatoms * 3 * sizeof(scalar_type); float mb_size =
+  //    (float)gpu_size / 1048576.0f; cout << "QM/MM output size: " << mb_size
+  //    << " MB" << endl;
 
-    // Forces: output is partial forces
-    partial_mm_forces_dev.resize(COALESCED_DIMENSION(partial_out_size), integral_vars.clatoms);
+  // Forces: output is partial forces
+  partial_mm_forces_dev.resize(COALESCED_DIMENSION(partial_out_size),
+                               integral_vars.clatoms);
 
-    cudaAssertNoError("QMMMIntegral::alloc_output");
+  cudaAssertNoError("QMMMIntegral::alloc_output");
 
-    return true;
+  return true;
 }
 
 template <class scalar_type>
-void QMMMIntegral<scalar_type>::clear( void )
-{
-    clatom_pos_dev.deallocate();
-    clatom_chg_dev.deallocate();
+void QMMMIntegral<scalar_type>::clear(void) {
+  clatom_pos_dev.deallocate();
+  clatom_chg_dev.deallocate();
 
-    partial_mm_forces_dev.deallocate();
+  partial_mm_forces_dev.deallocate();
 
-    cudaAssertNoError("QMMMIntegral::clear");
+  cudaAssertNoError("QMMMIntegral::clear");
 }
 
 template <class scalar_type>
-void QMMMIntegral<scalar_type>::calc_fock( double& Es, bool do_cl, bool do_qm )
-{
-    os_int.reload_density();
+void QMMMIntegral<scalar_type>::calc_fock(double& Es, bool do_cl, bool do_qm) {
+  os_int.reload_density();
 
-    uint partial_out_size = 0, max_partial_size = 0;
-    for (uint i = 0; i < NUM_TERM_TYPES; i++) {
-      uint this_count = divUp(os_int.term_type_counts[i],QMMM_BLOCK_SIZE);
-      if (this_count > max_partial_size) max_partial_size = this_count;
-      partial_out_size += this_count;
-    }
+  uint partial_out_size = 0, max_partial_size = 0;
+  for (uint i = 0; i < NUM_TERM_TYPES; i++) {
+    uint this_count = divUp(os_int.term_type_counts[i], QMMM_BLOCK_SIZE);
+    if (this_count > max_partial_size) max_partial_size = this_count;
+    partial_out_size += this_count;
+  }
 
-    {
-      dim3 threads(os_int.dens_values.size());
-      dim3 blockSize(QMMM_BLOCK_SIZE);
-      dim3 gridSize = divUp(threads,blockSize);
-      // Zero the partial Fock matrix on the GPU
-      zero_fock<double><<<gridSize,blockSize>>>(os_int.partial_fock_dev.data,os_int.dens_values.size(),1);;
-    }
+  {
+    dim3 threads(os_int.dens_values.size());
+    dim3 blockSize(QMMM_BLOCK_SIZE);
+    dim3 gridSize = divUp(threads, blockSize);
+    // Zero the partial Fock matrix on the GPU
+    zero_fock<double><<<gridSize, blockSize>>>(os_int.partial_fock_dev.data,
+                                               os_int.dens_values.size(), 1);
+    ;
+  }
 
-    //
-    // The STR table for F(m,U) calculation is being accessed via texture fetches
-    //
-    cudaBindTextureToArray(str_tex,gammaArray);
+  //
+  // The STR table for F(m,U) calculation is being accessed via texture fetches
+  //
+  cudaBindTextureToArray(str_tex, gammaArray);
 
-#define qmmm_fock_parameters \
-  os_int.term_type_counts[i], os_int.factor_ac_dev.data, os_int.nuc_dev.data, os_int.func_code_dev.data+offset,os_int.local_dens_dev.data+offset, \
-  os_int.partial_fock_dev.data+fock_offset, os_int.dens_values.size(),clatom_pos_dev.data,clatom_chg_dev.data
-    // Each term type is calculated asynchronously
-    cudaStream_t stream[NUM_TERM_TYPES];
-    for (uint i = 0; i < NUM_TERM_TYPES; i++) {
-      cudaStreamCreate(&stream[i]);
-    }
-    //
-    // Begin launching kernels (one for each type of term, 0 = s-s, 1 = p-s, etc)
-    //
-    for (uint i = 0; i < NUM_TERM_TYPES; i++)
-    {
-      uint offset = os_int.term_type_offsets[i];
-      uint fock_offset = os_int.dens_offsets[i];
-      dim3 threads = os_int.term_type_counts[i];
-      dim3 blockSize(QMMM_BLOCK_SIZE);
-      dim3 gridSize = divUp(threads, blockSize);
-      if (do_cl) {
-        if (do_qm) {
-          switch (i) {
-            case 0: gpu_qmmm_fock<scalar_type,0,true,true><<<gridSize,blockSize,0,stream[i]>>>( qmmm_fock_parameters ); break;
-            case 1: gpu_qmmm_fock<scalar_type,1,true,true><<<gridSize,blockSize,0,stream[i]>>>( qmmm_fock_parameters ); break;
-            case 2: gpu_qmmm_fock<scalar_type,2,true,true><<<gridSize,blockSize,0,stream[i]>>>( qmmm_fock_parameters ); break;
-            case 3: gpu_qmmm_fock<scalar_type,3,true,true><<<gridSize,blockSize,0,stream[i]>>>( qmmm_fock_parameters ); break;
-            case 4: gpu_qmmm_fock<scalar_type,4,true,true><<<gridSize,blockSize,0,stream[i]>>>( qmmm_fock_parameters ); break;
-            case 5: gpu_qmmm_fock<scalar_type,5,true,true><<<gridSize,blockSize,0,stream[i]>>>( qmmm_fock_parameters ); break;
-          }
-        } else {
-          switch (i) {
-            case 0: gpu_qmmm_fock<scalar_type,0,true,false><<<gridSize,blockSize,0,stream[i]>>>( qmmm_fock_parameters ); break;
-            case 1: gpu_qmmm_fock<scalar_type,1,true,false><<<gridSize,blockSize,0,stream[i]>>>( qmmm_fock_parameters ); break;
-            case 2: gpu_qmmm_fock<scalar_type,2,true,false><<<gridSize,blockSize,0,stream[i]>>>( qmmm_fock_parameters ); break;
-            case 3: gpu_qmmm_fock<scalar_type,3,true,false><<<gridSize,blockSize,0,stream[i]>>>( qmmm_fock_parameters ); break;
-            case 4: gpu_qmmm_fock<scalar_type,4,true,false><<<gridSize,blockSize,0,stream[i]>>>( qmmm_fock_parameters ); break;
-            case 5: gpu_qmmm_fock<scalar_type,5,true,false><<<gridSize,blockSize,0,stream[i]>>>( qmmm_fock_parameters ); break;
-          }
+#define qmmm_fock_parameters                                                   \
+  os_int.term_type_counts[i], os_int.factor_ac_dev.data, os_int.nuc_dev.data,  \
+      os_int.func_code_dev.data + offset, os_int.local_dens_dev.data + offset, \
+      os_int.partial_fock_dev.data + fock_offset, os_int.dens_values.size(),   \
+      clatom_pos_dev.data, clatom_chg_dev.data
+  // Each term type is calculated asynchronously
+  cudaStream_t stream[NUM_TERM_TYPES];
+  for (uint i = 0; i < NUM_TERM_TYPES; i++) {
+    cudaStreamCreate(&stream[i]);
+  }
+  //
+  // Begin launching kernels (one for each type of term, 0 = s-s, 1 = p-s, etc)
+  //
+  for (uint i = 0; i < NUM_TERM_TYPES; i++) {
+    uint offset = os_int.term_type_offsets[i];
+    uint fock_offset = os_int.dens_offsets[i];
+    dim3 threads = os_int.term_type_counts[i];
+    dim3 blockSize(QMMM_BLOCK_SIZE);
+    dim3 gridSize = divUp(threads, blockSize);
+    if (do_cl) {
+      if (do_qm) {
+        switch (i) {
+          case 0:
+            gpu_qmmm_fock<scalar_type, 0, true, true>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_fock_parameters);
+            break;
+          case 1:
+            gpu_qmmm_fock<scalar_type, 1, true, true>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_fock_parameters);
+            break;
+          case 2:
+            gpu_qmmm_fock<scalar_type, 2, true, true>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_fock_parameters);
+            break;
+          case 3:
+            gpu_qmmm_fock<scalar_type, 3, true, true>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_fock_parameters);
+            break;
+          case 4:
+            gpu_qmmm_fock<scalar_type, 4, true, true>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_fock_parameters);
+            break;
+          case 5:
+            gpu_qmmm_fock<scalar_type, 5, true, true>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_fock_parameters);
+            break;
         }
       } else {
-        if (do_qm) {
-          switch (i) {
-            case 0: gpu_qmmm_fock<scalar_type,0,false,true><<<gridSize,blockSize,0,stream[i]>>>( qmmm_fock_parameters ); break;
-            case 1: gpu_qmmm_fock<scalar_type,1,false,true><<<gridSize,blockSize,0,stream[i]>>>( qmmm_fock_parameters ); break;
-            case 2: gpu_qmmm_fock<scalar_type,2,false,true><<<gridSize,blockSize,0,stream[i]>>>( qmmm_fock_parameters ); break;
-            case 3: gpu_qmmm_fock<scalar_type,3,false,true><<<gridSize,blockSize,0,stream[i]>>>( qmmm_fock_parameters ); break;
-            case 4: gpu_qmmm_fock<scalar_type,4,false,true><<<gridSize,blockSize,0,stream[i]>>>( qmmm_fock_parameters ); break;
-            case 5: gpu_qmmm_fock<scalar_type,5,false,true><<<gridSize,blockSize,0,stream[i]>>>( qmmm_fock_parameters ); break;
-          }
-        } else {
+        switch (i) {
+          case 0:
+            gpu_qmmm_fock<scalar_type, 0, true, false>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_fock_parameters);
+            break;
+          case 1:
+            gpu_qmmm_fock<scalar_type, 1, true, false>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_fock_parameters);
+            break;
+          case 2:
+            gpu_qmmm_fock<scalar_type, 2, true, false>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_fock_parameters);
+            break;
+          case 3:
+            gpu_qmmm_fock<scalar_type, 3, true, false>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_fock_parameters);
+            break;
+          case 4:
+            gpu_qmmm_fock<scalar_type, 4, true, false>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_fock_parameters);
+            break;
+          case 5:
+            gpu_qmmm_fock<scalar_type, 5, true, false>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_fock_parameters);
+            break;
         }
       }
-
-      //
-      // Reduce the partial Fock terms for a particular term type as soon as that kernel is done; also calculate partial energies for that type
-      //
-      dim3 reduceThreads = os_int.dens_counts[i];
-      dim3 reduceBlockSize(QMMM_REDUCE_BLOCK_SIZE);
-      dim3 reduceGridSize = divUp(reduceThreads,reduceBlockSize);
-      gpu_fock_reduce<scalar_type><<<reduceGridSize,reduceBlockSize,0,stream[i]>>>( os_int.partial_fock_dev.data+fock_offset,os_int.dens_values_dev.data+fock_offset,
-                                                                                    os_int.partial_energies_dev.data+os_int.energies_offsets[i],
-                                                                                    os_int.dens_values.size(),max_partial_size,os_int.dens_counts[i] );
-    }
-    cudaDeviceSynchronize();
-    for (uint i = 0; i < NUM_TERM_TYPES; i++) {
-      cudaStreamDestroy(stream[i]);
-    }
-
-    cudaUnbindTexture(str_tex);
-
-    os_int.get_fock_output(Es,integral_vars.rmm_1e_output);
-
-    cudaAssertNoError("QMMMIntegral::calc_fock");
-}
-
-template<class scalar_type>
-void QMMMIntegral<scalar_type>::calc_gradient(double* qm_forces, double* mm_forces, bool do_cl, bool do_qm)
-{
-    os_int.reload_density();
-
-    uint partial_out_size = 0, max_partial_size = 0;
-    for (uint i = 0; i < NUM_TERM_TYPES; i++) {
-      uint this_count = divUp(os_int.term_type_counts[i],QMMM_BLOCK_SIZE);
-      if (this_count > max_partial_size) max_partial_size = this_count;
-      partial_out_size += this_count;
-    }
-    {
-        dim3 threads(COALESCED_DIMENSION(partial_out_size),G2G::fortran_vars.atoms);
-        dim3 blockSize(32,4);
-        dim3 gridSize = divUp(threads,blockSize);
-        zero_forces<scalar_type><<<gridSize,blockSize>>>(os_int.partial_qm_forces_dev.data,COALESCED_DIMENSION(partial_out_size),G2G::fortran_vars.atoms);
-    }
-
-    //
-    // The STR table for F(m,U) calculation is being accessed via texture fetches
-    //
-    cudaBindTextureToArray(str_tex,gammaArray);
-
-#define qmmm_forces_parameters \
-  os_int.term_type_counts[i], os_int.factor_ac_dev.data, os_int.nuc_dev.data, os_int.dens_values_dev.data+dens_offset, os_int.func_code_dev.data+offset,os_int.local_dens_dev.data+offset, \
-  partial_mm_forces_dev.data+force_offset, os_int.partial_qm_forces_dev.data+force_offset, COALESCED_DIMENSION(partial_out_size),clatom_pos_dev.data,clatom_chg_dev.data
-    // Each term type is calculated asynchronously
-    cudaStream_t stream[NUM_TERM_TYPES];
-    for (uint i = 0; i < NUM_TERM_TYPES; i++) {
-      cudaStreamCreate(&stream[i]);
-    }
-    //
-    // Begin launching kernels (one for each type of term, 0 = s-s, 1 = p-s, etc)
-    //
-    for (uint i = 0; i < NUM_TERM_TYPES; i++)
-    {
-      uint offset = os_int.term_type_offsets[i];
-      uint dens_offset = os_int.dens_offsets[i];
-      uint force_offset = os_int.out_offsets[i];
-      dim3 threads = os_int.term_type_counts[i];
-      dim3 blockSize(QMMM_BLOCK_SIZE);
-      dim3 gridSize = divUp(threads, blockSize);
-      if (do_cl) {
-        if (do_qm) {
-          switch (i) {
-            case 0: gpu_qmmm_forces<scalar_type,0,true,true><<<gridSize,blockSize,0,stream[i]>>>( qmmm_forces_parameters ); break;
-            case 1: gpu_qmmm_forces<scalar_type,1,true,true><<<gridSize,blockSize,0,stream[i]>>>( qmmm_forces_parameters ); break;
-            case 2: gpu_qmmm_forces<scalar_type,2,true,true><<<gridSize,blockSize,0,stream[i]>>>( qmmm_forces_parameters ); break;
-            case 3: gpu_qmmm_forces<scalar_type,3,true,true><<<gridSize,blockSize,0,stream[i]>>>( qmmm_forces_parameters ); break;
-            case 4: gpu_qmmm_forces<scalar_type,4,true,true><<<gridSize,blockSize,0,stream[i]>>>( qmmm_forces_parameters ); break;
-            case 5: gpu_qmmm_forces<scalar_type,5,true,true><<<gridSize,blockSize,0,stream[i]>>>( qmmm_forces_parameters ); break;
-          }
-        } else {
-          switch (i) {
-            case 0: gpu_qmmm_forces<scalar_type,0,true,false><<<gridSize,blockSize,0,stream[i]>>>( qmmm_forces_parameters ); break;
-            case 1: gpu_qmmm_forces<scalar_type,1,true,false><<<gridSize,blockSize,0,stream[i]>>>( qmmm_forces_parameters ); break;
-            case 2: gpu_qmmm_forces<scalar_type,2,true,false><<<gridSize,blockSize,0,stream[i]>>>( qmmm_forces_parameters ); break;
-            case 3: gpu_qmmm_forces<scalar_type,3,true,false><<<gridSize,blockSize,0,stream[i]>>>( qmmm_forces_parameters ); break;
-            case 4: gpu_qmmm_forces<scalar_type,4,true,false><<<gridSize,blockSize,0,stream[i]>>>( qmmm_forces_parameters ); break;
-            case 5: gpu_qmmm_forces<scalar_type,5,true,false><<<gridSize,blockSize,0,stream[i]>>>( qmmm_forces_parameters ); break;
-          }
+    } else {
+      if (do_qm) {
+        switch (i) {
+          case 0:
+            gpu_qmmm_fock<scalar_type, 0, false, true>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_fock_parameters);
+            break;
+          case 1:
+            gpu_qmmm_fock<scalar_type, 1, false, true>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_fock_parameters);
+            break;
+          case 2:
+            gpu_qmmm_fock<scalar_type, 2, false, true>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_fock_parameters);
+            break;
+          case 3:
+            gpu_qmmm_fock<scalar_type, 3, false, true>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_fock_parameters);
+            break;
+          case 4:
+            gpu_qmmm_fock<scalar_type, 4, false, true>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_fock_parameters);
+            break;
+          case 5:
+            gpu_qmmm_fock<scalar_type, 5, false, true>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_fock_parameters);
+            break;
         }
       } else {
-        if (do_qm) {
-          switch (i) {
-            case 0: gpu_qmmm_forces<scalar_type,0,false,true><<<gridSize,blockSize,0,stream[i]>>>( qmmm_forces_parameters ); break;
-            case 1: gpu_qmmm_forces<scalar_type,1,false,true><<<gridSize,blockSize,0,stream[i]>>>( qmmm_forces_parameters ); break;
-            case 2: gpu_qmmm_forces<scalar_type,2,false,true><<<gridSize,blockSize,0,stream[i]>>>( qmmm_forces_parameters ); break;
-            case 3: gpu_qmmm_forces<scalar_type,3,false,true><<<gridSize,blockSize,0,stream[i]>>>( qmmm_forces_parameters ); break;
-            case 4: gpu_qmmm_forces<scalar_type,4,false,true><<<gridSize,blockSize,0,stream[i]>>>( qmmm_forces_parameters ); break;
-            case 5: gpu_qmmm_forces<scalar_type,5,false,true><<<gridSize,blockSize,0,stream[i]>>>( qmmm_forces_parameters ); break;
-          }
-        } else { // This should never be launched
-        }
       }
     }
-    cudaDeviceSynchronize();
-    for (uint i = 0; i < NUM_TERM_TYPES; i++) {
-      cudaStreamDestroy(stream[i]);
-    }
 
-    cudaUnbindTexture(str_tex);
+    //
+    // Reduce the partial Fock terms for a particular term type as soon as that
+    // kernel is done; also calculate partial energies for that type
+    //
+    dim3 reduceThreads = os_int.dens_counts[i];
+    dim3 reduceBlockSize(QMMM_REDUCE_BLOCK_SIZE);
+    dim3 reduceGridSize = divUp(reduceThreads, reduceBlockSize);
+    gpu_fock_reduce<scalar_type>
+        <<<reduceGridSize, reduceBlockSize, 0, stream[i]>>>(
+            os_int.partial_fock_dev.data + fock_offset,
+            os_int.dens_values_dev.data + fock_offset,
+            os_int.partial_energies_dev.data + os_int.energies_offsets[i],
+            os_int.dens_values.size(), max_partial_size, os_int.dens_counts[i]);
+  }
+  cudaDeviceSynchronize();
+  for (uint i = 0; i < NUM_TERM_TYPES; i++) {
+    cudaStreamDestroy(stream[i]);
+  }
 
-    os_int.get_gradient_output(qm_forces,partial_out_size);
-    if (integral_vars.clatoms > 0) get_gradient_output(mm_forces,partial_out_size);
+  cudaUnbindTexture(str_tex);
 
-    cudaAssertNoError("QMMMIntegral::calc_gradient");
+  os_int.get_fock_output(Es, integral_vars.rmm_1e_output);
+
+  cudaAssertNoError("QMMMIntegral::calc_fock");
 }
 
-template<class scalar_type>
-void QMMMIntegral<scalar_type>::get_gradient_output(double* mm_forces, uint partial_out_size)
-{
-    G2G::HostMatrix<G2G::vec_type<scalar_type,3> > cpu_partial_mm_forces(partial_mm_forces_dev);
+template <class scalar_type>
+void QMMMIntegral<scalar_type>::calc_gradient(double* qm_forces,
+                                              double* mm_forces, bool do_cl,
+                                              bool do_qm) {
+  os_int.reload_density();
 
-    //
-    // Accumulate partial output
-    //
-    // TODO: need to think about how to accumulate individual force terms
-    // Currently, we reduce on a per-block basis in the kernel, then accumulate the block results here on the host
-    //
-    // The energy partial results are being reduced on-device and that works very well, could probably do that for forces too
-    //
-    for (uint i = 0; i < integral_vars.clatoms; i++) {
-      for (uint j = 0; j < partial_out_size; j++) {
-        mm_forces[i + 0 * integral_vars.clatoms] += cpu_partial_mm_forces(j,i).x;
-        mm_forces[i + 1 * integral_vars.clatoms] += cpu_partial_mm_forces(j,i).y;
-        mm_forces[i + 2 * integral_vars.clatoms] += cpu_partial_mm_forces(j,i).z;
+  uint partial_out_size = 0, max_partial_size = 0;
+  for (uint i = 0; i < NUM_TERM_TYPES; i++) {
+    uint this_count = divUp(os_int.term_type_counts[i], QMMM_BLOCK_SIZE);
+    if (this_count > max_partial_size) max_partial_size = this_count;
+    partial_out_size += this_count;
+  }
+  {
+    dim3 threads(COALESCED_DIMENSION(partial_out_size),
+                 G2G::fortran_vars.atoms);
+    dim3 blockSize(32, 4);
+    dim3 gridSize = divUp(threads, blockSize);
+    zero_forces<scalar_type><<<gridSize, blockSize>>>(
+        os_int.partial_qm_forces_dev.data,
+        COALESCED_DIMENSION(partial_out_size), G2G::fortran_vars.atoms);
+  }
+
+  //
+  // The STR table for F(m,U) calculation is being accessed via texture fetches
+  //
+  cudaBindTextureToArray(str_tex, gammaArray);
+
+#define qmmm_forces_parameters                                                 \
+  os_int.term_type_counts[i], os_int.factor_ac_dev.data, os_int.nuc_dev.data,  \
+      os_int.dens_values_dev.data + dens_offset,                               \
+      os_int.func_code_dev.data + offset, os_int.local_dens_dev.data + offset, \
+      partial_mm_forces_dev.data + force_offset,                               \
+      os_int.partial_qm_forces_dev.data + force_offset,                        \
+      COALESCED_DIMENSION(partial_out_size), clatom_pos_dev.data,              \
+      clatom_chg_dev.data
+  // Each term type is calculated asynchronously
+  cudaStream_t stream[NUM_TERM_TYPES];
+  for (uint i = 0; i < NUM_TERM_TYPES; i++) {
+    cudaStreamCreate(&stream[i]);
+  }
+  //
+  // Begin launching kernels (one for each type of term, 0 = s-s, 1 = p-s, etc)
+  //
+  for (uint i = 0; i < NUM_TERM_TYPES; i++) {
+    uint offset = os_int.term_type_offsets[i];
+    uint dens_offset = os_int.dens_offsets[i];
+    uint force_offset = os_int.out_offsets[i];
+    dim3 threads = os_int.term_type_counts[i];
+    dim3 blockSize(QMMM_BLOCK_SIZE);
+    dim3 gridSize = divUp(threads, blockSize);
+    if (do_cl) {
+      if (do_qm) {
+        switch (i) {
+          case 0:
+            gpu_qmmm_forces<scalar_type, 0, true, true>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_forces_parameters);
+            break;
+          case 1:
+            gpu_qmmm_forces<scalar_type, 1, true, true>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_forces_parameters);
+            break;
+          case 2:
+            gpu_qmmm_forces<scalar_type, 2, true, true>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_forces_parameters);
+            break;
+          case 3:
+            gpu_qmmm_forces<scalar_type, 3, true, true>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_forces_parameters);
+            break;
+          case 4:
+            gpu_qmmm_forces<scalar_type, 4, true, true>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_forces_parameters);
+            break;
+          case 5:
+            gpu_qmmm_forces<scalar_type, 5, true, true>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_forces_parameters);
+            break;
+        }
+      } else {
+        switch (i) {
+          case 0:
+            gpu_qmmm_forces<scalar_type, 0, true, false>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_forces_parameters);
+            break;
+          case 1:
+            gpu_qmmm_forces<scalar_type, 1, true, false>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_forces_parameters);
+            break;
+          case 2:
+            gpu_qmmm_forces<scalar_type, 2, true, false>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_forces_parameters);
+            break;
+          case 3:
+            gpu_qmmm_forces<scalar_type, 3, true, false>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_forces_parameters);
+            break;
+          case 4:
+            gpu_qmmm_forces<scalar_type, 4, true, false>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_forces_parameters);
+            break;
+          case 5:
+            gpu_qmmm_forces<scalar_type, 5, true, false>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_forces_parameters);
+            break;
+        }
+      }
+    } else {
+      if (do_qm) {
+        switch (i) {
+          case 0:
+            gpu_qmmm_forces<scalar_type, 0, false, true>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_forces_parameters);
+            break;
+          case 1:
+            gpu_qmmm_forces<scalar_type, 1, false, true>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_forces_parameters);
+            break;
+          case 2:
+            gpu_qmmm_forces<scalar_type, 2, false, true>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_forces_parameters);
+            break;
+          case 3:
+            gpu_qmmm_forces<scalar_type, 3, false, true>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_forces_parameters);
+            break;
+          case 4:
+            gpu_qmmm_forces<scalar_type, 4, false, true>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_forces_parameters);
+            break;
+          case 5:
+            gpu_qmmm_forces<scalar_type, 5, false, true>
+                <<<gridSize, blockSize, 0, stream[i]>>>(qmmm_forces_parameters);
+            break;
+        }
+      } else {  // This should never be launched
       }
     }
+  }
+  cudaDeviceSynchronize();
+  for (uint i = 0; i < NUM_TERM_TYPES; i++) {
+    cudaStreamDestroy(stream[i]);
+  }
 
-    cudaAssertNoError("QMMMIntegral::get_gradient_output");
+  cudaUnbindTexture(str_tex);
+
+  os_int.get_gradient_output(qm_forces, partial_out_size);
+  if (integral_vars.clatoms > 0)
+    get_gradient_output(mm_forces, partial_out_size);
+
+  cudaAssertNoError("QMMMIntegral::calc_gradient");
+}
+
+template <class scalar_type>
+void QMMMIntegral<scalar_type>::get_gradient_output(double* mm_forces,
+                                                    uint partial_out_size) {
+  G2G::HostMatrix<G2G::vec_type<scalar_type, 3>> cpu_partial_mm_forces(
+      partial_mm_forces_dev);
+
+  //
+  // Accumulate partial output
+  //
+  // TODO: need to think about how to accumulate individual force terms
+  // Currently, we reduce on a per-block basis in the kernel, then accumulate
+  // the block results here on the host
+  //
+  // The energy partial results are being reduced on-device and that works very
+  // well, could probably do that for forces too
+  //
+  for (uint i = 0; i < integral_vars.clatoms; i++) {
+    for (uint j = 0; j < partial_out_size; j++) {
+      mm_forces[i + 0 * integral_vars.clatoms] += cpu_partial_mm_forces(j, i).x;
+      mm_forces[i + 1 * integral_vars.clatoms] += cpu_partial_mm_forces(j, i).y;
+      mm_forces[i + 2 * integral_vars.clatoms] += cpu_partial_mm_forces(j, i).z;
+    }
+  }
+
+  cudaAssertNoError("QMMMIntegral::get_gradient_output");
 }
 
 #if AINT_MP && !FULL_DOUBLE
@@ -313,4 +442,4 @@ template class QMMMIntegral<float>;
 template class QMMMIntegral<double>;
 #endif
 
-}
+}  // namespace AINT

--- a/g2g/analytic_integral/os_cutoff.cpp
+++ b/g2g/analytic_integral/os_cutoff.cpp
@@ -13,8 +13,8 @@
 #include "os_integral.h"
 
 using std::cout;
-using std::vector;
 using std::endl;
+using std::vector;
 
 namespace AINT {
 
@@ -67,7 +67,7 @@ void OSIntegral<scalar_type>::new_cutoff(void) {
   this->dens_offsets[0] = 0;
   uint tmp_dens_ind = 0;
 
-  if (p_start == m) {         // When there are only s functions.
+  if (p_start == m) {  // When there are only s functions.
     NUM_TERM_TYPES = 1;
   } else if (d_start == m) {  // When there are only s and p functions.
     NUM_TERM_TYPES = 3;
@@ -173,10 +173,9 @@ void OSIntegral<scalar_type>::new_cutoff(void) {
               num_dens_terms++;
               this->dens_counts[current_term_type]++;
 
-              uint dens_ind =
-                  (i + i_orbital) +
-                  (2 * G2G::fortran_vars.m - ((j + j_orbital) + 1)) *
-                      (j + j_orbital) / 2;
+              uint dens_ind = (i + i_orbital) + (2 * G2G::fortran_vars.m -
+                                                 ((j + j_orbital) + 1)) *
+                                                    (j + j_orbital) / 2;
               this->dens_values.push_back(
                   G2G::fortran_vars.rmm_input_ndens1.data[dens_ind]);
               this->local2globaldens.push_back(dens_ind);
@@ -188,21 +187,33 @@ void OSIntegral<scalar_type>::new_cutoff(void) {
     }
     // Pad the input arrays so the next term type has an aligned offset
     if (term_type_counts[current_term_type] > 0) {
-      for (j = 0; j < QMMM_BLOCK_SIZE - (term_type_counts[current_term_type] % QMMM_BLOCK_SIZE); j++) {
-        this->func_code.push_back(func_code[term_type_offsets[current_term_type]]);  
+      for (j = 0; j < QMMM_BLOCK_SIZE - (term_type_counts[current_term_type] %
+                                         QMMM_BLOCK_SIZE);
+           j++) {
+        this->func_code.push_back(
+            func_code[term_type_offsets[current_term_type]]);
         // Use the first code from this term type
-        this->local_dens.push_back(local_dens[term_type_offsets[current_term_type]]);
+        this->local_dens.push_back(
+            local_dens[term_type_offsets[current_term_type]]);
       }
-      for (j = 0; j < QMMM_BLOCK_SIZE - (dens_counts[current_term_type] % QMMM_BLOCK_SIZE); j++) {
-        this->dens_values.push_back(dens_values[dens_offsets[current_term_type]]);
-        this->local2globaldens.push_back(local2globaldens[dens_offsets[current_term_type]]);
+      for (j = 0; j < QMMM_BLOCK_SIZE -
+                          (dens_counts[current_term_type] % QMMM_BLOCK_SIZE);
+           j++) {
+        this->dens_values.push_back(
+            dens_values[dens_offsets[current_term_type]]);
+        this->local2globaldens.push_back(
+            local2globaldens[dens_offsets[current_term_type]]);
       }
     } else {
-      for (j = 0; j < QMMM_BLOCK_SIZE - (dens_counts[current_term_type] % QMMM_BLOCK_SIZE); j++) {
+      for (j = 0; j < QMMM_BLOCK_SIZE -
+                          (dens_counts[current_term_type] % QMMM_BLOCK_SIZE);
+           j++) {
         this->func_code.push_back(0);
         this->local_dens.push_back(0);
       }
-      for (j = 0; j < QMMM_BLOCK_SIZE - (dens_counts[current_term_type] % QMMM_BLOCK_SIZE); j++) {
+      for (j = 0; j < QMMM_BLOCK_SIZE -
+                          (dens_counts[current_term_type] % QMMM_BLOCK_SIZE);
+           j++) {
         this->dens_values.push_back(0.0f);
         this->local2globaldens.push_back(0);
       }
@@ -235,4 +246,4 @@ template class OSIntegral<float>;
 #else
 template class OSIntegral<double>;
 #endif
-}
+}  // namespace AINT

--- a/g2g/analytic_integral/os_integral.h
+++ b/g2g/analytic_integral/os_integral.h
@@ -79,6 +79,6 @@ class OSIntegral {
   void clear(void);
   void deinit(void);
 };
-}
+}  // namespace AINT
 
 #endif

--- a/g2g/analytic_integral/qmmm_integral.h
+++ b/g2g/analytic_integral/qmmm_integral.h
@@ -54,6 +54,6 @@ class QMMMIntegral {
 
   void clear(void);
 };
-}
+}  // namespace AINT
 
 #endif

--- a/g2g/analytic_integral/qmmm_nuc.cpp
+++ b/g2g/analytic_integral/qmmm_nuc.cpp
@@ -12,8 +12,8 @@
 #include "qmmm_integral.h"
 
 using std::cout;
-using std::vector;
 using std::endl;
+using std::vector;
 
 namespace AINT {
 
@@ -29,7 +29,7 @@ void QMMMIntegral<scalar_type>::calc_nuc_gradient(double* qm_forces,
       dist = sqrt(dist);
 
       double prefactor = -integral_vars.clatom_charges(j) *
-                          integral_vars.atom_Z(i) / pow(dist, 3.0);
+                         integral_vars.atom_Z(i) / pow(dist, 3.0);
       qm_forces[i + 0 * G2G::fortran_vars.atoms] += prefactor * diff.x;
       qm_forces[i + 1 * G2G::fortran_vars.atoms] += prefactor * diff.y;
       qm_forces[i + 2 * G2G::fortran_vars.atoms] += prefactor * diff.z;
@@ -51,8 +51,8 @@ void QMMMIntegral<scalar_type>::calc_nuc_energy(double& Ens) {
       double dist = diff.x * diff.x + diff.y * diff.y + diff.z * diff.z;
       dist = sqrt(dist);
 
-      double E = integral_vars.clatom_charges(j) *
-                 integral_vars.atom_Z(i) / dist;
+      double E =
+          integral_vars.clatom_charges(j) * integral_vars.atom_Z(i) / dist;
       Ens += E;
     }
   }
@@ -63,4 +63,4 @@ template class QMMMIntegral<float>;
 #else
 template class QMMMIntegral<double>;
 #endif
-}
+}  // namespace AINT

--- a/g2g/cioverlap/cioverlap.cpp
+++ b/g2g/cioverlap/cioverlap.cpp
@@ -1,5 +1,6 @@
 /*
-    Copyright (C) 2008 Jiri Pittner <jiri.pittner@jh-inst.cas.cz> or <jiri@pittnerovi.com>
+    Copyright (C) 2008 Jiri Pittner <jiri.pittner@jh-inst.cas.cz> or
+   <jiri@pittnerovi.com>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,12 +16,11 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 /*
  ORIGINAL
- this program computes overlaps of arbitrary wave functions expressed in Slater determinants or GUGA CSFs
- UHF version now available
- NO particular order of determinants is assumed - all dets are listed in Slaterfile and CI coefficients
+ this program computes overlaps of arbitrary wave functions expressed in Slater
+ determinants or GUGA CSFs UHF version now available NO particular order of
+ determinants is assumed - all dets are listed in Slaterfile and CI coefficients
  in matching order are in the input
 */
 
@@ -46,7 +46,7 @@
 
 #include "options.h"
 
-//LA
+// LA
 #include "vec.h"
 #include "mat.h"
 #include "smat.h"
@@ -63,1119 +63,1217 @@
 #include <cstdlib>
 #include <cmath>
 
-template<class MAT>
-struct twooverlaps
-	{
-	NRMat<typename LA_traits<MAT>::elementtype> alpha;
-	NRMat<typename LA_traits<MAT>::elementtype> beta;
-	int rowparity; //parity of permutation to get rows in alpha,beta order
-	int colparity; //parity of permutation to get columns in alpha,beta order
-	};
+template <class MAT>
+struct twooverlaps {
+  NRMat<typename LA_traits<MAT>::elementtype> alpha;
+  NRMat<typename LA_traits<MAT>::elementtype> beta;
+  int rowparity;  // parity of permutation to get rows in alpha,beta order
+  int colparity;  // parity of permutation to get columns in alpha,beta order
+};
 
-template<class MAT, class INDEX>
-const twooverlaps<MAT>  slatersubmatrices(const MAT (&a)[2], const int nelec, const INDEX rows, const INDEX cols, const int ncore, const int nactive, const bool inversedorbitals)
-{
-twooverlaps<MAT> r;
+template <class MAT, class INDEX>
+const twooverlaps<MAT> slatersubmatrices(const MAT (&a)[2], const int nelec,
+                                         const INDEX rows, const INDEX cols,
+                                         const int ncore, const int nactive,
+                                         const bool inversedorbitals) {
+  twooverlaps<MAT> r;
 
-const int ncoreshift=0; //even with frozen core, the numbering of MOs is NOT shifted
+  const int ncoreshift =
+      0;  // even with frozen core, the numbering of MOs is NOT shifted
 
-int nalpha=0;
-int nbeta=0;
-for(int j=0; j<nelec; ++j) if(rows[j]<0) ++nbeta; else ++nalpha;
+  int nalpha = 0;
+  int nbeta = 0;
+  for (int j = 0; j < nelec; ++j)
+    if (rows[j] < 0)
+      ++nbeta;
+    else
+      ++nalpha;
 
-r.alpha.resize(ncore+nalpha,ncore+nalpha);
-r.beta.resize(ncore+nbeta,ncore+nbeta);
-r.alpha.clear();
-r.beta.clear();
+  r.alpha.resize(ncore + nalpha, ncore + nalpha);
+  r.beta.resize(ncore + nbeta, ncore + nbeta);
+  r.alpha.clear();
+  r.beta.clear();
 
-//count the number of betas all alphas must transpose with when moved to the left in conservative order
-r.rowparity=ncore*(ncore-1)/2; 
-r.colparity=ncore*(ncore-1)/2;
-int rowbeta=ncore;
-int colbeta=ncore; 
-for(int j=0; j<nelec; ++j) 
-	{
-	if(rows[j]<0) ++rowbeta; else r.rowparity += rowbeta;
-	if(cols[j]<0) ++colbeta; else r.colparity += colbeta;
-	}
+  // count the number of betas all alphas must transpose with when moved to the
+  // left in conservative order
+  r.rowparity = ncore * (ncore - 1) / 2;
+  r.colparity = ncore * (ncore - 1) / 2;
+  int rowbeta = ncore;
+  int colbeta = ncore;
+  for (int j = 0; j < nelec; ++j) {
+    if (rows[j] < 0)
+      ++rowbeta;
+    else
+      r.rowparity += rowbeta;
+    if (cols[j] < 0)
+      ++colbeta;
+    else
+      r.colparity += colbeta;
+  }
 
+  // core-core block
+  for (int i = 0; i < ncore; ++i)
+    for (int j = 0; j < ncore; ++j) {
+      r.alpha(i, j) = a[0](i, j);
+      r.beta(i, j) = a[1](i, j);
+    }
 
-//core-core block
-for(int i=0; i<ncore; ++i)
-        for(int j=0; j<ncore; ++j)
-                {
-                r.alpha(i,j) = a[0](i,j);
-                r.beta(i,j) = a[1](i,j);
-                }
+  // core-active and active-core
+  for (int i = 0; i < ncore; ++i) {
+    int jac = 0;
+    int jbc = 0;
+    int jar = 0;
+    int jbr = 0;
+    for (int j = 0; j < nelec; ++j) {
+      if (inversedorbitals) {
+        if (cols[j] < 0)
+          r.beta(i, ncore + jbc++) =
+              a[1](i, nactive - abs(cols[j]) + ncoreshift);
+        else
+          r.alpha(i, ncore + jac++) =
+              a[0](i, nactive - abs(cols[j]) + ncoreshift);
 
-//core-active and active-core
-for(int i=0; i<ncore; ++i)
-	{
-	int jac=0;
-	int jbc=0;
-	int jar=0;
-	int jbr=0;
-        for(int j=0; j<nelec; ++j)
-		{
-		if(inversedorbitals)
-                        {
-                        if(cols[j]<0) r.beta(i,ncore+ jbc++) = a[1](i,nactive-abs(cols[j])+ncoreshift);
-                        else          r.alpha(i,ncore+ jac++) = a[0](i,nactive-abs(cols[j])+ncoreshift);
+        if (rows[j] < 0)
+          r.beta(ncore + jbr++, i) =
+              a[1](nactive - abs(rows[j]) + ncoreshift, i);
+        else
+          r.alpha(ncore + jar++, i) =
+              a[0](nactive - abs(rows[j]) + ncoreshift, i);
+      } else {
+        if (cols[j] < 0)
+          r.beta(i, ncore + jbc++) = a[1](i, abs(cols[j]) + ncoreshift - 1);
+        else
+          r.alpha(i, ncore + jac++) = a[0](i, abs(cols[j]) + ncoreshift - 1);
 
-                        if(rows[j]<0) r.beta(ncore+ jbr++,i) = a[1](nactive-abs(rows[j])+ncoreshift,i);
-                        else          r.alpha(ncore+ jar++,i) = a[0](nactive-abs(rows[j])+ncoreshift,i);
-                        }
-                else
-                        {
-			if(cols[j]<0) r.beta(i,ncore+ jbc++) = a[1](i,abs(cols[j])+ncoreshift-1); 
-			else	      r.alpha(i,ncore+ jac++) = a[0](i,abs(cols[j])+ncoreshift-1); 
+        if (rows[j] < 0)
+          r.beta(ncore + jbr++, i) = a[1](abs(rows[j]) + ncoreshift - 1, i);
+        else
+          r.alpha(ncore + jar++, i) = a[0](abs(rows[j]) + ncoreshift - 1, i);
+      }
+    }
+  }
 
-			if(rows[j]<0) r.beta(ncore+ jbr++,i) = a[1](abs(rows[j])+ncoreshift-1,i);
-			else	      r.alpha(ncore+ jar++,i) = a[0](abs(rows[j])+ncoreshift-1,i);
-                        }
-		
-		}
-	}
+  // active-active block
+  if (inversedorbitals) {
+    int ia = 0;
+    int ib = 0;
+    for (int i = 0; i < nelec; ++i) {
+      int ja = 0;
+      int jb = 0;
+      for (int j = 0; j < nelec; ++j) {
+        // cout <<"here2\n";
+        if (rows[i] < 0 && cols[j] < 0)
+          r.beta(ncore + ib, ncore + jb) =
+              a[1](nactive - abs(rows[i]) + ncoreshift,
+                   nactive - abs(cols[j]) + ncoreshift);
+        if (rows[i] > 0 && cols[j] > 0)
+          r.alpha(ncore + ia, ncore + ja) =
+              a[0](nactive - abs(rows[i]) + ncoreshift,
+                   nactive - abs(cols[j]) + ncoreshift);
+        if (cols[j] < 0)
+          ++jb;
+        else
+          ++ja;
+      }
+      if (rows[i] < 0)
+        ++ib;
+      else
+        ++ia;
+    }
+  } else {
+    int ia = 0;
+    int ib = 0;
+    for (int i = 0; i < nelec; ++i) {
+      int ja = 0;
+      int jb = 0;
+      for (int j = 0; j < nelec; ++j) {
+        if (rows[i] < 0 && cols[j] < 0)
+          r.beta(ncore + ib, ncore + jb) = a[1](abs(rows[i]) + ncoreshift - 1,
+                                                abs(cols[j]) + ncoreshift - 1);
+        if (rows[i] > 0 && cols[j] > 0)
+          r.alpha(ncore + ia, ncore + ja) = a[0](abs(rows[i]) + ncoreshift - 1,
+                                                 abs(cols[j]) + ncoreshift - 1);
+        if (cols[j] < 0)
+          ++jb;
+        else
+          ++ja;
+      }
+      if (rows[i] < 0)
+        ++ib;
+      else
+        ++ia;
+    }
+  }
 
-
-//active-active block
-if(inversedorbitals)
-{
-int ia=0; int ib=0;
-for(int i=0; i<nelec; ++i)
-        {
-        int ja=0; int jb=0;
-        for(int j=0; j<nelec; ++j)
-                {
-		//cout <<"here2\n";
-                if(rows[i]<0 && cols[j]<0) r.beta(ncore+ib,ncore+jb) = a[1](nactive-abs(rows[i])+ncoreshift,nactive-abs(cols[j])+ncoreshift);
-                if(rows[i]>0 && cols[j]>0) r.alpha(ncore+ia,ncore+ja) = a[0](nactive-abs(rows[i])+ncoreshift,nactive-abs(cols[j])+ncoreshift);
-                if(cols[j]<0) ++jb; else ++ja;
-                }
-        if(rows[i]<0) ++ib; else ++ia;
-        }
+  return r;
 }
-else
-{
-int ia=0; int ib=0;
-for(int i=0; i<nelec; ++i)
-	{
-	int ja=0; int jb=0;
-        for(int j=0; j<nelec; ++j)
-		{
-		
-		if(rows[i]<0 && cols[j]<0) r.beta(ncore+ib,ncore+jb) = a[1](abs(rows[i])+ncoreshift-1,abs(cols[j])+ncoreshift-1);
-		if(rows[i]>0 && cols[j]>0) r.alpha(ncore+ia,ncore+ja) = a[0](abs(rows[i])+ncoreshift-1,abs(cols[j])+ncoreshift-1);
-		if(cols[j]<0) ++jb; else ++ja;
-		}
-	if(rows[i]<0) ++ib; else ++ia;
-	}
-}
-
-return r;
-}
-	
 
 #if defined(oldversion) || defined(DEBUG3)
-template<class MAT, class INDEX>
-const NRMat<typename LA_traits<MAT>::elementtype> slatersubmatrix(const MAT (&a)[2], const int nelec, const INDEX rows, const INDEX cols, const int ncore, const int nactive, const bool inversedorbitals)
-{
-const int ncoreshift=0; //even with frozen core, the numbering of MOs is NOT shifted
+template <class MAT, class INDEX>
+const NRMat<typename LA_traits<MAT>::elementtype> slatersubmatrix(
+    const MAT (&a)[2], const int nelec, const INDEX rows, const INDEX cols,
+    const int ncore, const int nactive, const bool inversedorbitals) {
+  const int ncoreshift =
+      0;  // even with frozen core, the numbering of MOs is NOT shifted
 
-int ncore2=2*ncore;
-NRMat<typename LA_traits<MAT>::elementtype> r(nelec+ncore2,nelec+ncore2);
+  int ncore2 = 2 * ncore;
+  NRMat<typename LA_traits<MAT>::elementtype> r(nelec + ncore2, nelec + ncore2);
 
-//core-core block
-for(int i=0; i<ncore2; ++i)
-	for(int j=0; j<ncore2; ++j)
-		{
-		r(i,j) = (i^j)&1 ? 0 : a[i&1](i/2,j/2);
-		}
+  // core-core block
+  for (int i = 0; i < ncore2; ++i)
+    for (int j = 0; j < ncore2; ++j) {
+      r(i, j) = (i ^ j) & 1 ? 0 : a[i & 1](i / 2, j / 2);
+    }
 
-//core-active and active-core
-for(int i=0; i<ncore2; ++i)
-	for(int j=0; j<nelec; ++j)
-		{
-		int si= i&1? -1:1;
-		if(inversedorbitals)
-			{
-			r(i,ncore2+j) = si*cols[j]<0 ? 0. : a[i&1](i/2,nactive-abs(cols[j])+ncoreshift);
-                        r(ncore2+j,i) = si*rows[j]<0 ? 0. : a[i&1](nactive-abs(rows[j])+ncoreshift,i/2);
-			}
-		else
-			{
-			r(i,ncore2+j) = si*cols[j]<0 ? 0. : a[i&1](i/2,abs(cols[j])+ncoreshift-1);
-			r(ncore2+j,i) = si*rows[j]<0 ? 0. : a[i&1](abs(rows[j])+ncoreshift-1,i/2);
-			}
-		}
+  // core-active and active-core
+  for (int i = 0; i < ncore2; ++i)
+    for (int j = 0; j < nelec; ++j) {
+      int si = i & 1 ? -1 : 1;
+      if (inversedorbitals) {
+        r(i, ncore2 + j) =
+            si * cols[j] < 0
+                ? 0.
+                : a[i & 1](i / 2, nactive - abs(cols[j]) + ncoreshift);
+        r(ncore2 + j, i) =
+            si * rows[j] < 0
+                ? 0.
+                : a[i & 1](nactive - abs(rows[j]) + ncoreshift, i / 2);
+      } else {
+        r(i, ncore2 + j) = si * cols[j] < 0
+                               ? 0.
+                               : a[i & 1](i / 2, abs(cols[j]) + ncoreshift - 1);
+        r(ncore2 + j, i) = si * rows[j] < 0
+                               ? 0.
+                               : a[i & 1](abs(rows[j]) + ncoreshift - 1, i / 2);
+      }
+    }
 
-//active-active block
-if(inversedorbitals)
-for(int i=0; i<nelec; ++i)
-        for(int j=0; j<nelec; ++j)
-                r(ncore2+i,ncore2+j) = rows[i]*cols[j]<0?0.:a[rows[i]<0?1:0](nactive-abs(rows[i])+ncoreshift,nactive-abs(cols[j])+ncoreshift);
-else
-for(int i=0; i<nelec; ++i)
-        for(int j=0; j<nelec; ++j)
-                r(ncore2+i,ncore2+j) = rows[i]*cols[j]<0?0.:a[rows[i]<0?1:0](abs(rows[i])+ncoreshift-1,abs(cols[j])+ncoreshift-1);
-return r;
+  // active-active block
+  if (inversedorbitals)
+    for (int i = 0; i < nelec; ++i)
+      for (int j = 0; j < nelec; ++j)
+        r(ncore2 + i, ncore2 + j) =
+            rows[i] * cols[j] < 0
+                ? 0.
+                : a[rows[i] < 0 ? 1 : 0](nactive - abs(rows[i]) + ncoreshift,
+                                         nactive - abs(cols[j]) + ncoreshift);
+  else
+    for (int i = 0; i < nelec; ++i)
+      for (int j = 0; j < nelec; ++j)
+        r(ncore2 + i, ncore2 + j) =
+            rows[i] * cols[j] < 0
+                ? 0.
+                : a[rows[i] < 0 ? 1 : 0](abs(rows[i]) + ncoreshift - 1,
+                                         abs(cols[j]) + ncoreshift - 1);
+  return r;
 }
 #endif
 
+struct part_eliminated {
+  NRMat<REAL> submat;
+  NRSMat<REAL> coeffs;
+  REAL det;
+};
 
-struct part_eliminated
-	{
-	NRMat<REAL> submat;
-	NRSMat<REAL> coeffs;
-	REAL det;
-	};
+static part_eliminated *precompa = NULL, *precompb = NULL;
 
-static part_eliminated *precompa=NULL, *precompb=NULL;
+void prepare_elimination(part_eliminated **precomp, const NRMat<REAL> &a,
+                         int inactive) {
+  *precomp = new part_eliminated;
+  (*precomp)->submat = a.submatrix(0, inactive - 1, 0, inactive - 1);
+  (*precomp)->coeffs.resize(inactive);
+  (*precomp)->coeffs.clear();
 
-void prepare_elimination(part_eliminated **precomp, const  NRMat<REAL> &a, int inactive)
-{
- *precomp  = new part_eliminated;
-(*precomp)->submat = a.submatrix(0,inactive-1,0,inactive-1);
-(*precomp)->coeffs.resize(inactive); 
-(*precomp)->coeffs.clear();
+  // cout <<"Constant part of overlap matrices\n"<<(*precomp)->submat;
 
-//cout <<"Constant part of overlap matrices\n"<<(*precomp)->submat;
+  // no pivoting necessary, assumed inactive orbitals do not change character
+  // and diagonal elements are about 0.99
+  for (int i = 0; i < inactive - 1; ++i) {
+    REAL p = (*precomp)->submat(i, i);
+    for (int j = i + 1; j < inactive; ++j) {
+      REAL q = -(*precomp)->submat(j, i) / p;
+      (*precomp)->coeffs(i, j) = q;
+      xaxpy(inactive, q, (*precomp)->submat[i], 1, (*precomp)->submat[j], 1);
+    }
+  }
+  REAL d = 1.;
+  for (int i = 0; i < inactive; ++i) d *= (*precomp)->submat(i, i);
+  (*precomp)->det = d;
 
-//no pivoting necessary, assumed inactive orbitals do not change character and diagonal elements are about 0.99
-for(int i=0; i<inactive-1; ++i)
-	{
-	REAL p=(*precomp)->submat(i,i);
-	for(int j=i+1; j<inactive; ++j)
-		{
-		REAL q= -(*precomp)->submat(j,i)/p;
-		(*precomp)->coeffs(i,j) = q;
-		xaxpy(inactive,q,(*precomp)->submat[i],1,(*precomp)->submat[j],1);
-		}
-	}
-REAL d=1.;
-for(int i=0; i<inactive; ++i) d *= (*precomp)->submat(i,i);
-(*precomp)->det=d;
-
-//cout <<"Pre-eliminated ovelap submatrix\n"<<(*precomp)->submat;
-cout.flush();
-//cout <<"Elimination coefficients\n"<<(*precomp)->coeffs;
-cout.flush();
+  // cout <<"Pre-eliminated ovelap submatrix\n"<<(*precomp)->submat;
+  cout.flush();
+  // cout <<"Elimination coefficients\n"<<(*precomp)->coeffs;
+  cout.flush();
 }
 
+REAL finish_elimination(const part_eliminated *precomp, NRMat<REAL> &a,
+                        int inactive) {
+  // store in the matrix the precomputed part
+  a.storesubmatrix(0, 0, precomp->submat);
 
-REAL finish_elimination(const part_eliminated *precomp,  NRMat<REAL> &a, int inactive)
-{
-//store in the matrix the precomputed part
-a.storesubmatrix(0,0,precomp->submat);
+  // perform the precomputed linear combinations on the right columns
+  for (int i = 0; i < inactive - 1; ++i)
+    for (int j = i + 1; j < inactive; ++j)
+      xaxpy(a.ncols() - inactive, precomp->coeffs(i, j), a[i] + inactive, 1,
+            a[j] + inactive, 1);
 
-//perform the precomputed linear combinations on the right columns
-for(int i=0; i<inactive-1; ++i)
-        for(int j=i+1; j<inactive; ++j)
-                xaxpy(a.ncols()-inactive,precomp->coeffs(i,j),a[i]+inactive,1,a[j]+inactive,1);
+  // finish elimination
+  // should a pivoting be done for accuracy (in principle an orbital swap could
+  // lead to division by a near-zero) ?
+  for (int i = 0; i < a.nrows() - 1; ++i) {
+    REAL p = a(i, i);
+    int jlow = i + 1;
+    if (inactive > jlow) jlow = inactive;
+    for (int j = jlow; j < a.nrows(); ++j) {
+      REAL q = -a(j, i) / p;
+      xaxpy(a.ncols(), q, a[i], 1, a[j], 1);
+    }
+  }
 
-
-//finish elimination
-//should a pivoting be done for accuracy (in principle an orbital swap could lead to division by a near-zero) ?
-for(int i=0; i<a.nrows()-1; ++i)
-	{
-	REAL p=a(i,i);
-	int jlow= i+1;
-	if(inactive > jlow) jlow= inactive;
-        for(int j=jlow; j<a.nrows(); ++j)
-		{
-		REAL q= -a(j,i)/p;
-                xaxpy(a.ncols(),q,a[i],1,a[j],1);
-		}
-	}
-
-//compute determinant
-REAL d=precomp->det;
-for(int i=inactive; i<a.nrows(); ++i) d *= a(i,i);
-return d;
+  // compute determinant
+  REAL d = precomp->det;
+  for (int i = inactive; i < a.nrows(); ++i) d *= a(i, i);
+  return d;
 }
-
-
 
 void perform_overlap(lexindex i, lexindex j, unsigned long *skipcount,
-	bool (&needpermute)[2],int nelec,const slaterbasis &slaters, const NRVec<int> (&bra2ketperm)[2],
-	bool permuteslvectors, const NRVec<SPMatindex> &slperm,REAL screeningthr, 
-	const NRMat<REAL> &brasl,const NRMat<REAL> &ketsl,const NRMat<REAL> (&Smo)[2],int ncore,int mo,
-	bool inversedorbitals,unsigned long *computedcount,SparseMat<REAL> &Ssl, int inactive,
-	NRMat<int> *screening_mask)
-{
-if(screening_mask)
-	{
-	if((*screening_mask).nrows() != brasl.ncols() || (*screening_mask).ncols() != ketsl.ncols()) laerror("error in screening_mask dimensions");
-	}
-			lexindex k;
-			if(needpermute[0]||needpermute[1]) //only general need in principle
-				{
-				bool waspermuted=false;
-				slaterdet permuted(nelec);
-				for(int e=0; e<nelec; ++e) 
-					{
-					spinorbindex ee=slaters(j,e);
-					permuted[e]=bra2ketperm[ee<0?1:0][abs(ee)];
-					if(ee<0) permuted[e]= -permuted[e];
-					if(permuted[e]!=ee) waspermuted=true;
-					}
-				
-				if(waspermuted)
-					{
-					permuted.sort();
-					k=permuted.find(slaters,slaterorder); 
+                     bool (&needpermute)[2], int nelec,
+                     const slaterbasis &slaters,
+                     const NRVec<int> (&bra2ketperm)[2], bool permuteslvectors,
+                     const NRVec<SPMatindex> &slperm, REAL screeningthr,
+                     const NRMat<REAL> &brasl, const NRMat<REAL> &ketsl,
+                     const NRMat<REAL> (&Smo)[2], int ncore, int mo,
+                     bool inversedorbitals, unsigned long *computedcount,
+                     SparseMat<REAL> &Ssl, int inactive,
+                     NRMat<int> *screening_mask) {
+  if (screening_mask) {
+    if ((*screening_mask).nrows() != brasl.ncols() ||
+        (*screening_mask).ncols() != ketsl.ncols())
+      laerror("error in screening_mask dimensions");
+  }
+  lexindex k;
+  if (needpermute[0] || needpermute[1])  // only general need in principle
+  {
+    bool waspermuted = false;
+    slaterdet permuted(nelec);
+    for (int e = 0; e < nelec; ++e) {
+      spinorbindex ee = slaters(j, e);
+      permuted[e] = bra2ketperm[ee < 0 ? 1 : 0][abs(ee)];
+      if (ee < 0) permuted[e] = -permuted[e];
+      if (permuted[e] != ee) waspermuted = true;
+    }
+
+    if (waspermuted) {
+      permuted.sort();
+      k = permuted.find(slaters, slaterorder);
 #ifdef DEBUG
-					//cout << "original determinant "<<slaters.row(j)<<endl;
-					//cout << "permuted determinant "<<j<<" "<<k<<" : "<<permuted<<endl;
-					//cout <<" ci size = "<<slaters.nrows()<<endl;
+      // cout << "original determinant "<<slaters.row(j)<<endl;
+      // cout << "permuted determinant "<<j<<" "<<k<<" : "<<permuted<<endl;
+      // cout <<" ci size = "<<slaters.nrows()<<endl;
 #endif
-					if(k == (lexindex)-1) 
-						{
+      if (k == (lexindex)-1) {
 #ifdef DEBUG
-						//cout <<"WARNING: permuted slater determinant outside CI, computed overlap will be inaccurate\n";
+        // cout <<"WARNING: permuted slater determinant outside CI, computed
+        // overlap will be inaccurate\n";
 #endif
-						++ (*skipcount);
-						return;
-						}
-					}
-				else
-					k=j;
-				}
-			else
-				k=j;
+        ++(*skipcount);
+        return;
+      }
+    } else
+      k = j;
+  } else
+    k = j;
 
-			lexindex itrue = permuteslvectors ? slperm[i] : i ;
-			lexindex ktrue = permuteslvectors ? slperm[k] : k ;
+  lexindex itrue = permuteslvectors ? slperm[i] : i;
+  lexindex ktrue = permuteslvectors ? slperm[k] : k;
 
-			//implement screening
-			if(screeningthr>0)
-				{
-				REAL s=0.;
-				for(int a=0; a<brasl.ncols(); ++a) 
-					for(int b=0; b<ketsl.ncols(); ++b) 
-					    {
-					    if(!screening_mask || (*screening_mask)(a,b) )
-						{
-						s += abs(brasl[itrue][a] * ketsl[ktrue][b]);
-						}
-					    }
-				if(s<screeningthr)
-					{
-					++ (*skipcount);
-					return;
-					}
-				}
+  // implement screening
+  if (screeningthr > 0) {
+    REAL s = 0.;
+    for (int a = 0; a < brasl.ncols(); ++a)
+      for (int b = 0; b < ketsl.ncols(); ++b) {
+        if (!screening_mask || (*screening_mask)(a, b)) {
+          s += abs(brasl[itrue][a] * ketsl[ktrue][b]);
+        }
+      }
+    if (s < screeningthr) {
+      ++(*skipcount);
+      return;
+    }
+  }
 
-
-{
-
+  {
 #ifdef oldversion
-NRMat<REAL> overlaps=slatersubmatrix(Smo,nelec,slaters[i],slaters[k],ncore,mo,inversedorbitals);
-REAL dd=determinant_destroy(overlaps);
+    NRMat<REAL> overlaps = slatersubmatrix(Smo, nelec, slaters[i], slaters[k],
+                                           ncore, mo, inversedorbitals);
+    REAL dd = determinant_destroy(overlaps);
 #else
 #ifdef DEBUG3
-NRMat<REAL> overlaps=slatersubmatrix(Smo,nelec,slaters[i],slaters[k],ncore,mo,inversedorbitals);
+    NRMat<REAL> overlaps = slatersubmatrix(Smo, nelec, slaters[i], slaters[k],
+                                           ncore, mo, inversedorbitals);
 #ifdef DEBUG2
-if(i==0 && k==13)
-{
-//cout <<"Ssl "<<i<<" "<<k<<" (j="<<j<<") : " <<itrue<<" "<<ktrue<<" = "<<endl;
-//cout <<"Overlap submatrix original algorithm " <<overlaps<<endl;
-}
+    if (i == 0 && k == 13) {
+      // cout <<"Ssl "<<i<<" "<<k<<" (j="<<j<<") : " <<itrue<<" "<<ktrue<<" =
+      // "<<endl; cout <<"Overlap submatrix original algorithm "
+      // <<overlaps<<endl;
+    }
 #endif
-REAL ddorig=determinant_destroy(overlaps);
-//cout <<"original_result = "<<ddorig<<endl;
+    REAL ddorig = determinant_destroy(overlaps);
+// cout <<"original_result = "<<ddorig<<endl;
 #endif
 
-
-twooverlaps<NRMat<REAL> > overlaps2 = slatersubmatrices(Smo,nelec,slaters[i],slaters[k],ncore,mo,inversedorbitals);
+    twooverlaps<NRMat<REAL> > overlaps2 = slatersubmatrices(
+        Smo, nelec, slaters[i], slaters[k], ncore, mo, inversedorbitals);
 
 #ifdef DEBUG2
-if(i==0 && k==13)
-{
-//cout <<"Ssl "<<i<<" "<<k<<" (j="<<j<<") : " <<itrue<<" "<<ktrue<<" = "<<endl;
-//cout <<"i= ";for(int ii=0;ii<nelec;++ii) cout <<slaters[i][ii]<<" "; cout <<endl;
-//cout <<"k= ";for(int ii=0;ii<nelec;++ii) cout <<slaters[k][ii]<<" "; cout <<endl;
-//cout <<"Overlap submatrices alpha, beta:\n"<<overlaps2.alpha<<endl<<overlaps2.beta<<endl;
-}
+    if (i == 0 && k == 13) {
+      // cout <<"Ssl "<<i<<" "<<k<<" (j="<<j<<") : " <<itrue<<" "<<ktrue<<" =
+      // "<<endl; cout <<"i= ";for(int ii=0;ii<nelec;++ii) cout
+      // <<slaters[i][ii]<<" "; cout <<endl; cout <<"k= ";for(int
+      // ii=0;ii<nelec;++ii) cout <<slaters[k][ii]<<" "; cout <<endl; cout
+      // <<"Overlap submatrices alpha,
+      // beta:\n"<<overlaps2.alpha<<endl<<overlaps2.beta<<endl;
+    }
 #endif
-REAL da,db;
-if(inactive>1) //simplified computation from a precomputed intermediate for efficiency
-	{
-	if(!precompa) prepare_elimination(&precompa,overlaps2.alpha,inactive);
-	if(!precompb) prepare_elimination(&precompb,overlaps2.beta,inactive);
-	da = finish_elimination(precompa,overlaps2.alpha,inactive);
-	db = finish_elimination(precompb,overlaps2.beta,inactive);
-	}
-else //full determinant computation
-	{
-	da=determinant_destroy(overlaps2.alpha);
-	db=determinant_destroy(overlaps2.beta);
-	}
+    REAL da, db;
+    if (inactive > 1)  // simplified computation from a precomputed intermediate
+                       // for efficiency
+    {
+      if (!precompa) prepare_elimination(&precompa, overlaps2.alpha, inactive);
+      if (!precompb) prepare_elimination(&precompb, overlaps2.beta, inactive);
+      da = finish_elimination(precompa, overlaps2.alpha, inactive);
+      db = finish_elimination(precompb, overlaps2.beta, inactive);
+    } else  // full determinant computation
+    {
+      da = determinant_destroy(overlaps2.alpha);
+      db = determinant_destroy(overlaps2.beta);
+    }
 
-REAL dd=da*db; if((overlaps2.rowparity+overlaps2.colparity)&1) dd= -dd;
+    REAL dd = da * db;
+    if ((overlaps2.rowparity + overlaps2.colparity) & 1) dd = -dd;
 #ifdef DEBUG
-//cout <<"da db rowparity colparity = "<<da<<" "<<db<<" "<<overlaps2.rowparity<<" "<<overlaps2.colparity<<endl;
-//cout <<"full_result = "<<dd<<endl;
+// cout <<"da db rowparity colparity = "<<da<<" "<<db<<"
+// "<<overlaps2.rowparity<<" "<<overlaps2.colparity<<endl; cout <<"full_result =
+// "<<dd<<endl;
 #ifdef DEBUG3
-if(fabs(ddorig-dd) > 1e-13) //cout <<"INTERNAL ERROR\n";
+    if (fabs(ddorig - dd) > 1e-13)  // cout <<"INTERNAL ERROR\n";
 #endif
 #endif
-#endif //oldversion
-++ *computedcount;
-Ssl.add(itrue,ktrue,dd);
-}
+#endif  // oldversion
+    ++*computedcount;
+    Ssl.add(itrue, ktrue, dd);
+  }
 }
 
-
-//suitable for small cis, we do not care much about memory needs, just try not to really waste
-//all paths go to this routine
+// suitable for small cis, we do not care much about memory needs, just try not
+// to really waste all paths go to this routine
 
 NRMat<REAL> CIoverlap_slater(
-	bool uhf,
-	const NRMat<REAL> &brasl, //slaterCIsize x n
-	const NRMat<REAL> &ketsl, //slaterCIsize x m
-	const NRMat<REAL> &Sraw, //2*AO x 2*AO (generated by artificial doubled geometry input)
-	const NRMat<REAL> (&braLCAO)[2], //AO x MO
-        const NRMat<REAL> (&ketLCAO)[2], //AO x MO
-	int slaterfile, //file descriptor for slater basis 
-	int excitlistfile, //file descriptor for list of not neglected excitations
-        const int nelec,
-        const int mo, //active MOs
-        const int ncore=0,
-        const int ndiscarded=0,
-	bool make_excitlist=true,
-	const int truncation=4, //neglect overlap of Slater dets differing in more than ... spinorbitals (take into account arbitrary MO swapping)
-	const bool inversedorbitals=true, //lowest MOs are at the top of DRT when true
-	const int slaterorder=1,
-        const bool reorderslbasis=true, //the slater basis was not sorted before
-	const int slaterpermfile=-1, //file handle for permutation of slater overlap matrix (slater CI vectors will remain same, slater basis is permuted)
-	REAL screeningthr=0,
-	NRMat<int> *activerange=NULL,
-	int inactive=0, //for performance improving precompute a constant part of the determinants 
-	NRMat<int> *screening_mask = NULL
-	) 
-{
+    bool uhf,
+    const NRMat<REAL> &brasl,  // slaterCIsize x n
+    const NRMat<REAL> &ketsl,  // slaterCIsize x m
+    const NRMat<REAL>
+        &Sraw,  // 2*AO x 2*AO (generated by artificial doubled geometry input)
+    const NRMat<REAL> (&braLCAO)[2],  // AO x MO
+    const NRMat<REAL> (&ketLCAO)[2],  // AO x MO
+    int slaterfile,                   // file descriptor for slater basis
+    int excitlistfile,  // file descriptor for list of not neglected excitations
+    const int nelec,
+    const int mo,  // active MOs
+    const int ncore = 0, const int ndiscarded = 0, bool make_excitlist = true,
+    const int truncation =
+        4,  // neglect overlap of Slater dets differing in more than ...
+            // spinorbitals (take into account arbitrary MO swapping)
+    const bool inversedorbitals =
+        true,  // lowest MOs are at the top of DRT when true
+    const int slaterorder = 1,
+    const bool reorderslbasis = true,  // the slater basis was not sorted before
+    const int slaterpermfile =
+        -1,  // file handle for permutation of slater overlap matrix (slater CI
+             // vectors will remain same, slater basis is permuted)
+    REAL screeningthr = 0, NRMat<int> *activerange = NULL,
+    int inactive = 0,  // for performance improving precompute a constant part
+                       // of the determinants
+    NRMat<int> *screening_mask = NULL) {
+  int motot = mo + ncore + ndiscarded;
+  // cout <<"Number of frozen+active+discarded MOs = "<<motot<<endl;
+  int ao = braLCAO[0].nrows();
+  if (ao != braLCAO[1].nrows() || ao != ketLCAO[0].nrows() ||
+      ao != ketLCAO[1].nrows())
+    laerror("inconsistent row dimension of LCAO matrices");
+  if (braLCAO[0].ncols() != braLCAO[1].ncols() ||
+      braLCAO[0].ncols() != ketLCAO[0].ncols() ||
+      braLCAO[0].ncols() != ketLCAO[1].ncols())
+    laerror("inconsistent column dimension of LCAO matrices");
 
-int motot=mo+ncore+ndiscarded;
-//cout <<"Number of frozen+active+discarded MOs = "<<motot<<endl;
-int ao=braLCAO[0].nrows();
-if(ao!= braLCAO[1].nrows() || ao!= ketLCAO[0].nrows() ||  ao!= ketLCAO[1].nrows()) laerror("inconsistent row dimension of LCAO matrices");
-if(braLCAO[0].ncols() != braLCAO[1].ncols() || braLCAO[0].ncols() != ketLCAO[0].ncols() ||  braLCAO[0].ncols() != ketLCAO[1].ncols() ) laerror("inconsistent column dimension of LCAO matrices");
+  lexindex sl = (lexindex)brasl.nrows();
 
-lexindex sl=(lexindex)brasl.nrows();
+  if (activerange) {
+    if ((*activerange)(0, 0) <= 0 || (*activerange)(0, 1) <= 0 ||
+        (*activerange)(1, 0) <= 0 || (*activerange)(1, 1) <= 0 ||
+        (*activerange)(0, 0) > mo || (*activerange)(0, 1) > mo ||
+        (*activerange)(1, 0) > mo || (*activerange)(1, 1) > mo)
+      laerror("illegal active orbital range specified");
+  }
 
+  // consistency checks
+  if (ao != ketLCAO[0].nrows() || ao != ketLCAO[1].nrows() ||
+      ao != braLCAO[0].nrows() || ao != braLCAO[1].nrows() ||
+      2 * ao != Sraw.nrows() || motot != braLCAO[0].ncols() ||
+      motot != ketLCAO[0].ncols() || motot != braLCAO[1].ncols() ||
+      motot != ketLCAO[1].ncols() || sl != (lexindex)ketsl.nrows()) {
+    //      cout <<"ao " <<ao <<" ketLCAO[0].nrows() "<<ketLCAO[0].nrows()<<
+    //      endl; cout <<"ao " <<ao <<" ketLCAO[1].nrows()
+    //      "<<ketLCAO[1].nrows()<< endl; cout <<"ao " <<ao <<"
+    //      braLCAO[0].nrows() "<<braLCAO[0].nrows()<< endl; cout <<"ao " <<ao
+    //      <<" braLCAO[1].nrows() "<<braLCAO[1].nrows()<< endl; cout <<"2*ao
+    //      "<<2*ao<<" Sraw.nrows() "<<Sraw.nrows()<<endl; cout <<"motot
+    //      "<<motot<<" braLCAO[0].ncols() "<<braLCAO[0].ncols()<<"
+    //      ketLCAO[0].ncols() "<<ketLCAO[0].ncols()<<endl; cout <<"motot
+    //      "<<motot<<" braLCAO[1].ncols() "<<braLCAO[1].ncols()<<"
+    //      ketLCAO[1].ncols() "<<ketLCAO[1].ncols()<<endl; cout <<"sl "<<sl<<"
+    //      ketsl.nrows() "<<ketsl.nrows()<<endl; laerror("inconsistent
+    //      dimensions in CIoverlap");
+  }
 
-if(activerange)
-	{
-	if((*activerange)(0,0)<=0||(*activerange)(0,1)<=0||(*activerange)(1,0)<=0||(*activerange)(1,1)<=0||
-		(*activerange)(0,0)>mo||(*activerange)(0,1)>mo||(*activerange)(1,0)>mo||(*activerange)(1,1)>mo) laerror("illegal active orbital range specified");
-	}
-
-//consistency checks
-if(ao!=ketLCAO[0].nrows()
-|| ao!=ketLCAO[1].nrows()
-|| ao!=braLCAO[0].nrows()
-|| ao!=braLCAO[1].nrows()
-|| 2*ao!=Sraw.nrows()
-|| motot!=braLCAO[0].ncols()
-|| motot!=ketLCAO[0].ncols()
-|| motot!=braLCAO[1].ncols()
-|| motot!=ketLCAO[1].ncols()
-|| sl!=(lexindex)ketsl.nrows()
-  ) 
-	{
-//      cout <<"ao " <<ao <<" ketLCAO[0].nrows() "<<ketLCAO[0].nrows()<< endl;
-//      cout <<"ao " <<ao <<" ketLCAO[1].nrows() "<<ketLCAO[1].nrows()<< endl;
-//      cout <<"ao " <<ao <<" braLCAO[0].nrows() "<<braLCAO[0].nrows()<< endl;
-//      cout <<"ao " <<ao <<" braLCAO[1].nrows() "<<braLCAO[1].nrows()<< endl;
-//      cout <<"2*ao "<<2*ao<<" Sraw.nrows() "<<Sraw.nrows()<<endl;
-//      cout <<"motot "<<motot<<" braLCAO[0].ncols() "<<braLCAO[0].ncols()<<" ketLCAO[0].ncols() "<<ketLCAO[0].ncols()<<endl;
-//      cout <<"motot "<<motot<<" braLCAO[1].ncols() "<<braLCAO[1].ncols()<<" ketLCAO[1].ncols() "<<ketLCAO[1].ncols()<<endl;
-//      cout <<"sl "<<sl<<" ketsl.nrows() "<<ketsl.nrows()<<endl;
-//      laerror("inconsistent dimensions in CIoverlap");
-	}
-
-//calculate one-particle overlaps in the MO basis
-NRMat<REAL> Smo[2];
-Smo[0].resize(motot,motot);
-Smo[1].resize(motot,motot);
-{
-NRMat<REAL> Sao12=Sraw.submatrix(0,ao-1,ao,2*ao-1);
-//cout <<"test Sao12\n"<<Sao12;
-NRMat<REAL> tmp;
-for(int spin=0; spin<2; ++spin)
-	{
-	tmp=Sao12*ketLCAO[spin];
-	Smo[spin].gemm(0.,braLCAO[spin],'t',tmp,'n',1.); 
-	}
-}
-
-/* 
-ORIGINAL
-for test symmetrize Smo and test symmetry of Ssl
-Smo[0]= (Smo[0]+Smo[0].transpose())*.5;
-Smo[1]= (Smo[1]+Smo[1].transpose())*.5;
-*/
-
-//for(int spin=0; spin<2; ++spin) cout <<"test Smo["<<spin<<"]\n"<<Smo[spin];
-
-/* NO PASA POR AQUI
-//#define UNIT_SMO
-#ifdef UNIT_SMO
-//try to put here a fake diagonal Smo 
-for(int spin=0; spin<2; ++spin)
-			{
-			for(int kk=0; kk<Smo[spin].nrows(); ++kk)
-				for(int ll=0; ll<Smo[spin].ncols(); ++ll)
-					{							
-					if(kk!=ll) Smo[spin](kk,ll)=0; else
-						{
-						if(Smo[spin](kk,ll)<0) Smo[spin](kk,ll)= -1; else Smo[spin](kk,ll)=1;
-						}
-					}
-			}
-			cout <<"Adjusted Smo["<<spin<<"]\n"<<Smo[spin];
-#endif
-*/
-
-
-/*
-  find out largest overlap mapping between bra and ket MOs for later need
-  this should preferably be based not on Smo but on overlap of Loewdin-normalized LCAO at the two geometries
-  thus it will yield identity for rotated-translated molecule
-*/
-bool needpermute[2];
-needpermute[0]=false;
-needpermute[1]=false;
-NRVec<int> bra2ketperm[2];
-NRVec<int> bra2ket[2];
-bra2ket[0].resize(motot);
-bra2ket[1].resize(motot);
-{
-NRMat<REAL> Sao11=realsqrt(Sraw.submatrix(0,ao-1,0,ao-1));
-NRMat<REAL> Sao22=realsqrt(Sraw.submatrix(ao,2*ao-1,ao,2*ao-1));
-for(int spin=0; spin<2; ++spin)
-{
-NRMat<REAL> braL = Sao11 * braLCAO[spin];
-NRMat<REAL> ketL = Sao22 * ketLCAO[spin];
-NRMat<REAL> Sloewdin(motot,motot);
-Sloewdin.gemm(0.,braL,'t',ketL,'n',1.);
-//cout <<"test Sloewdin["<<spin<<"]\n"<<Sloewdin;
-
-NRVec<int> counts(motot);
-NRVec<int> mophase(motot);
-counts=0;
-mophase=0;
-for(int i=0; i<motot; ++i)
-	{
-	int jmaxforbid = -1;
-	findmax:
-	int jmax= -1;
-	int pmax= 1;
-	REAL smax= -1.;
-	for(int j=0; j<motot; ++j)
-		if(abs(Sloewdin(i,j)) > smax && j != jmaxforbid)
-			{
-			jmax=j;
-			smax=abs(Sloewdin(i,j));
-			pmax = Sloewdin(i,j)>0. ?1 : -1;
-			}
-	bra2ket[spin][i]=jmax;
-	mophase[i] = pmax;
-	if(counts[jmax] && jmaxforbid== -1) //this already had a big overlap and we were not in the second search already
-		{
-		//find second biggest one
-		jmaxforbid=jmax;
-		goto findmax;
-		}
-	else counts[jmax]++;
-	}
-
-//cout <<"test bra2ket["<<spin<<"], counts, mophase\n"<<bra2ket[spin]<<counts<<mophase;
-for(int i=0; i<motot; ++i) if(counts[i]!=1) 
-	{
-	//cout << "cannot determine MO permutation, orbital rotations do not represent simple orbital swaps\n";
-	for(int j=0; j<motot; ++j) bra2ket[spin][j]=j;
-	goto skippermute;
-	}
-
-//cout <<"Smo["<<spin<<"] (permuted) diagonal elements\n";
-//for(int i=0; i<motot; ++i) cout << i<<" : "<<Smo[spin](i,bra2ket[spin][i])<<endl;
-
-for(int i=ncore; i<motot-ndiscarded; ++i) if(bra2ket[spin][i]!=i) 
-	{
-	needpermute[spin]=true;
-	//if(bra2ket[spin][i]<ncore||bra2ket[spin][i]>=motot-ndiscarded) {cout <<"Warning: MO swap outside of active space occured for spin "<<spin<<"\n";}
-	}
-
-skippermute:
-
-//adjust the bra2ket permutation to the CI-active orbitals
-bra2ketperm[spin].resize(mo+1); //index from 1 over active
-	{
-	bra2ketperm[spin][0]= -1; //dummy
-	if(inversedorbitals) for(int i=0; i<mo; ++i) 
-			{
-			bra2ketperm[spin][i+1]=mo-(bra2ket[spin][ncore+mo-i-1]-ncore); 
-			}
-	else for(int i=0; i<mo; ++i) bra2ketperm[spin][i+1]=bra2ket[spin][ncore+i]-ncore+1;
-	}
-//cout <<"bra2ketperm["<<spin<<"] "<<bra2ketperm[spin]<<endl;
-//cout <<"needpermute["<<spin<<"] "<<needpermute[spin]<<endl;
-
-}//spin
-}//local scope
-
-//cout <<"application of the permutation has been switched off, since typically the determinants from permuted orbitals are outside of the CI space anyway\n";
-needpermute[0]=false;
-needpermute[1]=false;
-
-//read the slater basis into memory
-//cout << "Slater basis dimensions are "<<sl<<" "<<nelec<<endl;
-//cout <<"(total number of electrons including the ones in frozen orbitals is "<<nelec+2*ncore<<")"<<endl;
-slaterbasis slaters(sl,nelec);
-bool permuteslvectors=false;
-{
-struct stat buf;
-if(! fstat(slaterpermfile,&buf)) if(buf.st_size>0) permuteslvectors=true;
-}
-if(reorderslbasis && !permuteslvectors) //was not reordered previously
-	{
-	//read the input basis
-	lseek(slaterfile,0,SEEK_SET);
-	slaters.get(slaterfile,false);
-	//check that the whole slaterfile has been exhausted by the read to prevent mismatch in the number of electrons
-	{
-	unsigned char dummy;
-	int r = read(slaterfile,&dummy,1);
-	if (r>0) laerror("slaterfile is larger than expected, check the number of electrons in cioverlap input");
-	if (r<0) laerror("unexpected error when testing slaterfile eof");
-	}
-	//check for illegal content (orbital number 0)	
-	if(slaters.checkzero()) laerror("malformed slaterfile encountered, perhaps cipc/mcpc was compiled without --assume byterecl");
-	//sort
-	NRVec<SPMatindex> slperm(sl);
-	for(lexindex i=0; i<sl; ++i) slperm[i]=i;
-	slsort_sldetbase=&slaters;
-        slsort_permbase=&slperm[0];
-        slsort_nelectrons=nelec;
-        genqsort(0,(int)sl-1,slaterorder>0 ? slsort_slbascmp : slsort_slbascmp2 ,slsort_slbasswap);
-	//save the new basis
-        lseek(slaterfile,0,SEEK_SET);
-        for(lexindex i=0; i<sl; ++i)
-                if(slsort_nelectrons*(int)sizeof(spinorbindex) != write(slaterfile, slaters[slperm[i]] ,slsort_nelectrons*sizeof(spinorbindex))) laerror("write error in CIoverlap_slater");
-
-	//save the permutation, to be used in contraction with CI coefficients
-	lseek(slaterpermfile,0,SEEK_SET);
-        slperm.put(slaterpermfile,true);
-	permuteslvectors=true;
-	}
-lseek(slaterfile,0,SEEK_SET);
-slaters.get(slaterfile,false);
-{
-unsigned char dummy;
-int r = read(slaterfile,&dummy,1);
-if (r>0) laerror("slaterfile is larger than expected, check the number of electrons in cioverlap input");
-if (r<0) laerror("unexpected error when testing slaterfile eof");
-}
-
-//check for illegal content (orbital number 0)
-if(slaters.checkzero()) laerror("malformed slaterfile encountered, perhaps cipc was compiled without --assume byterecl");
-
-/* NO PASA POR AQUI
-#ifdef DEBUG
-cout <<"slater basis "<<slaters<<endl;
-#endif
-*/
-
-//precompute and store in a file a list giving all determinants to consider from given one in the Ssl computation
-//Note: symmetry of non-neglected Ssl entries is not in general present, if the bra2ket permutation has cycles longer than two
-
-if(truncation<0) 
-	{
-	//cout <<"Omitting excitlistfile generation\n";
-	make_excitlist=false;
-	}
-
-if(make_excitlist)
-	{
-	clock_t t0=clock();
-	//cout <<"Generating excitation list for CI size " <<sl<<endl;
-	lseek(excitlistfile,0,SEEK_SET);
-	lexindex maxlen=0;
-	if(sizeof(lexindex)!=write(excitlistfile,&maxlen,sizeof(lexindex))) laerror("write error");
-	NRVec<lexindex> allowedlist(sl);
-	NRVec<unsigned char> n_act_elec((unsigned char)0,sl);
-	if(activerange) //count electrons in active orbitals for each determinant
-	    for(lexindex i=0; i<sl; ++i)
-		{
-		for(int e=0; e<nelec; ++e) 
-			{
-			int imo=slaters[i][e];
-			if(imo>0 && imo>=(*activerange)(0,0) && imo<=(*activerange)(0,1)
-				|| imo<0 && imo>=(*activerange)(1,0) && imo<=(*activerange)(1,1)) ++n_act_elec[i];
-			}
-		}
-	for(lexindex i=0; i<sl; ++i) //prepare the list for each slater det.
-		{
-		NRVec<char> notocc_i(2*(mo+ncore)+1);  //is in principle a bitvector but the "unpacked form" should be more efficient
-		for(int o=0; o<2*(mo+ncore)+1; ++o) notocc_i[o]=1;
-		for(int e=0; e<nelec; ++e) notocc_i[mo+ncore+slaters[i][e]]=0;
-		//setup an active space, where a difference in occupation does not count
-		//not to degrade performance it is also handeled via notocc_i flags
-		if(activerange) 
-			{
-			for(int o=(*activerange)(0,0); o<=(*activerange)(0,1); ++o) notocc_i[mo+ncore+o]=0;
-			for(int o=(*activerange)(1,0); o<=(*activerange)(1,1); ++o) notocc_i[mo+ncore+o]=0;
-			}
-		//
-		allowedlist[0]=i;
-		lexindex ntot=1;
-        	for(lexindex j=i+1; j<sl; ++j) 
-			{
-			//if(slater_excitation(nelec,slaters[i],slaters[j],false,mo)>truncation) goto skipthis ;
-			//replaced by more optimized code
-			int include_it = truncation;
-			int activediff = (int)n_act_elec[j] - (int)n_act_elec[i];
-			spinorbindex *sj = slaters[j];
-			if(abs(activediff) > truncation) goto skipthis;
-			if(activediff>0) include_it -= activediff; //account for electrons excited into active orbitals
-			if(include_it<0) goto skipthis;
-			for(int e=0; e<nelec; ++e)
-				{
-				if(notocc_i[mo+ncore+sj[e]]) --include_it;
-				if(include_it<0) goto skipthis;
-				}	
-			allowedlist[ntot++]=j;
-			skipthis:;
-			}
-		//cout <<"For "<<i<< " "<<ntot <<endl;
-		//write the list for i-th slater
-		if(ntot>maxlen) maxlen=ntot;
-		if(sizeof(lexindex)!=write(excitlistfile,&ntot,sizeof(lexindex))) laerror("write error");
-		if((lexindex)ntot*sizeof(lexindex)!=(lexindex)write(excitlistfile,&allowedlist[0],ntot*sizeof(lexindex))) laerror("write error");
-		}
-	lseek(excitlistfile,0,SEEK_SET);
-	if(sizeof(lexindex)!=write(excitlistfile,&maxlen,sizeof(lexindex))) laerror("write error");
-	//cout <<"make_excitlist cpu time "<<(1.*clock()-t0)/CLOCKS_PER_SEC<<endl;
-	}
-
-
-//prepare many-particle overlap matrix in the Slater basis
-NRVec<SPMatindex> slperm;
-if(permuteslvectors)
-	{
-	lseek(slaterpermfile,0,SEEK_SET);
-	slperm.get(slaterpermfile,true);
-	if(sl!= (lexindex)slperm.size()) laerror("inconsistent slaterpermfile");
-	}
-
-SparseMat<REAL> Ssl(sl,sl);
-unsigned long skipcount=0;
-unsigned long computedcount=0;
-clock_t t0=clock();
-if(truncation>=0) lseek(excitlistfile,0,SEEK_SET);
-lexindex maxlen=0;
-if(truncation>=0)
-	{
-	if(sizeof(lexindex)!=read(excitlistfile,&maxlen,sizeof(lexindex))) laerror("excitlist read error 1");
-	if(maxlen==0) laerror("unfinished excitlistfile encountered");
-	}
-else
-	maxlen=1;
-NRVec<lexindex> excitlist(maxlen);
-//cout<<"Number of determinants in the wavefunctions = "<<sl<<endl;
-//cout<<"Done 0%\n"; cout.flush();
-int percent=0;
-for(lexindex i=0; i<sl; ++i)
-	{
-/* NO PASA POR AQUI
-#ifdef DEBUG
-//cout<< "Processing determinant "<<i<<endl;
-#endif
-*/
-	if((i*100)/sl > percent)
-		{
-		percent = (i*100)/sl;
-		//cout<<" "<<percent<<"%"; cout.flush();
-		}
-	lexindex ntot;
-	if(truncation>=0)
-		{
-		if(sizeof(lexindex)!=read(excitlistfile,&ntot,sizeof(lexindex))) laerror("excitlist read error 2");
-		if(ntot*sizeof(lexindex)!=(lexindex)read(excitlistfile,&excitlist[0],ntot*sizeof(lexindex))) laerror("excitlist read error 3");
-		}
-	for(lexindex jj= (truncation>=0? 0 : i) ; jj<(truncation>=0? ntot :sl); ++jj)	
-			{
-			lexindex jjx;
-			jjx = truncation>=0 ? excitlist[jj] : jj;
-/* NO PASA POR AQUI
-#ifdef DEBUG
-//cout<< "Processing its peer "<<jj<<" "<<jjx<<endl;
-#endif
-*/ 
-			perform_overlap(i,jjx,&skipcount,needpermute,nelec,slaters,bra2ketperm,permuteslvectors,slperm,screeningthr,brasl,ketsl,Smo,ncore,mo,inversedorbitals,&computedcount,Ssl,inactive,screening_mask);
-			if(i!=jjx) perform_overlap(jjx,i,&skipcount,needpermute,nelec,slaters,bra2ketperm,permuteslvectors,slperm,screeningthr,brasl,ketsl,Smo,ncore,mo,inversedorbitals,&computedcount,Ssl,inactive,screening_mask);
-			}
-	}
-//cout<< " 100%\noverlap calculation CPU time "<<(1.*clock()-t0)/CLOCKS_PER_SEC<<endl;
-//cout.flush();
-slaters.resize(0,0);// free memory
-
-/* NO PASA POR AQUI
-#ifdef DEBUG
-NRMat<REAL>Ssltest(Ssl);
-for(lexindex i=0; i<sl; ++i) 
-    {
-	cout <<"for "<<i<<endl;
-	for(lexindex j=0; j<sl; ++j)
-	{
-	if(abs(Ssltest(i,j))>.01) cout <<"Ssl "<<i<<" "<<j<<" = "<<Ssltest(i,j)<<endl;
-	//cout <<"Ssl asymetry "<<i<<" "<<j<<" "<<Ssltest(i,j)-Ssltest(j,i) <<" from "<<Ssltest(i,j)<<endl;
-	}
-	cout <<endl;
+  // calculate one-particle overlaps in the MO basis
+  NRMat<REAL> Smo[2];
+  Smo[0].resize(motot, motot);
+  Smo[1].resize(motot, motot);
+  {
+    NRMat<REAL> Sao12 = Sraw.submatrix(0, ao - 1, ao, 2 * ao - 1);
+    // cout <<"test Sao12\n"<<Sao12;
+    NRMat<REAL> tmp;
+    for (int spin = 0; spin < 2; ++spin) {
+      tmp = Sao12 * ketLCAO[spin];
+      Smo[spin].gemm(0., braLCAO[spin], 't', tmp, 'n', 1.);
     }
-cout <<"Ssl diagonal elements\n";
-for(lexindex i=0; i<sl; ++i) cout <<"det "<<i<<": "<<Ssltest(i,i)<<endl;
-#endif
-*/
+  }
 
-//cout <<"Number of computed overlap determinant pairs = "<<computedcount<<endl;
-//if(screeningthr>0) cout <<"Number of skipped determinant pairs at screening threshold "<<screeningthr<<" = "<<skipcount<<endl;
+  /*
+  ORIGINAL
+  for test symmetrize Smo and test symmetry of Ssl
+  Smo[0]= (Smo[0]+Smo[0].transpose())*.5;
+  Smo[1]= (Smo[1]+Smo[1].transpose())*.5;
+  */
 
+  // for(int spin=0; spin<2; ++spin) cout <<"test Smo["<<spin<<"]\n"<<Smo[spin];
 
-//contract bras and kets with the overlaps in Slater basis 
-NRMat<REAL> tmp=Ssl*ketsl;
-Ssl.resize(0,0);//free memory
-NRMat<REAL> result(brasl.ncols(),ketsl.ncols());
-result.gemm(0.,brasl,'t',tmp,'n',1.);
+  /* NO PASA POR AQUI
+  //#define UNIT_SMO
+  #ifdef UNIT_SMO
+  //try to put here a fake diagonal Smo
+  for(int spin=0; spin<2; ++spin)
+                          {
+                          for(int kk=0; kk<Smo[spin].nrows(); ++kk)
+                                  for(int ll=0; ll<Smo[spin].ncols(); ++ll)
+                                          {
+                                          if(kk!=ll) Smo[spin](kk,ll)=0; else
+                                                  {
+                                                  if(Smo[spin](kk,ll)<0)
+  Smo[spin](kk,ll)= -1; else Smo[spin](kk,ll)=1;
+                                                  }
+                                          }
+                          }
+                          cout <<"Adjusted Smo["<<spin<<"]\n"<<Smo[spin];
+  #endif
+  */
 
-//zero out inaccurate elements according to screening_mask
-if(screening_mask)
-	{
-	int i,j;
-	for(i=0; i<result.nrows(); ++i) for(j=0; j<result.ncols(); ++j)
-		{
-		if((*screening_mask)(i,j) == 0) result(i,j)=0;
-		}
-	}
+  /*
+    find out largest overlap mapping between bra and ket MOs for later need
+    this should preferably be based not on Smo but on overlap of
+    Loewdin-normalized LCAO at the two geometries thus it will yield identity
+    for rotated-translated molecule
+  */
+  bool needpermute[2];
+  needpermute[0] = false;
+  needpermute[1] = false;
+  NRVec<int> bra2ketperm[2];
+  NRVec<int> bra2ket[2];
+  bra2ket[0].resize(motot);
+  bra2ket[1].resize(motot);
+  {
+    NRMat<REAL> Sao11 = realsqrt(Sraw.submatrix(0, ao - 1, 0, ao - 1));
+    NRMat<REAL> Sao22 =
+        realsqrt(Sraw.submatrix(ao, 2 * ao - 1, ao, 2 * ao - 1));
+    for (int spin = 0; spin < 2; ++spin) {
+      NRMat<REAL> braL = Sao11 * braLCAO[spin];
+      NRMat<REAL> ketL = Sao22 * ketLCAO[spin];
+      NRMat<REAL> Sloewdin(motot, motot);
+      Sloewdin.gemm(0., braL, 't', ketL, 'n', 1.);
+      // cout <<"test Sloewdin["<<spin<<"]\n"<<Sloewdin;
 
-return result;
-}
-
-
-//NRMat<int> *read_screening_mask(char *screening_mask_file,int nbras, int nkets)
-NRMat<int> *read_screening_mask(int* kcoup,int nbras, int nkets)
-{
-   int dim=min(nbras,nkets);
-   //cout << nbras << " " << nkets << " " << dim << endl;
-   NRMat<int> *r = new NRMat<int>(0,nbras,nkets);
-   for(int ii=0; ii<dim; ++ii) 
-      for(int jj=0; jj<dim; ++jj) {
-         //cout << kcoup[ii*dim+jj] << endl ;
-         (*r)[ii][jj]=kcoup[ii*dim+jj];
+      NRVec<int> counts(motot);
+      NRVec<int> mophase(motot);
+      counts = 0;
+      mophase = 0;
+      for (int i = 0; i < motot; ++i) {
+        int jmaxforbid = -1;
+      findmax:
+        int jmax = -1;
+        int pmax = 1;
+        REAL smax = -1.;
+        for (int j = 0; j < motot; ++j)
+          if (abs(Sloewdin(i, j)) > smax && j != jmaxforbid) {
+            jmax = j;
+            smax = abs(Sloewdin(i, j));
+            pmax = Sloewdin(i, j) > 0. ? 1 : -1;
+          }
+        bra2ket[spin][i] = jmax;
+        mophase[i] = pmax;
+        if (counts[jmax] &&
+            jmaxforbid == -1)  // this already had a big overlap and we were not
+                               // in the second search already
+        {
+          // find second biggest one
+          jmaxforbid = jmax;
+          goto findmax;
+        } else
+          counts[jmax]++;
       }
-/*
-if(!screening_mask_file) return NULL;
-NRMat<int> *r = new NRMat<int>(0,nbras,nkets);
-FILE *f = fopen(screening_mask_file,"r");
-if(!f) laerror("cannot read screening_mask_file");
-char line[1024];
-fgets(line, 1024,f);
-int x1,x2,x3,x4;
-while(4==fscanf(f,"%d %d %d %d",&x1,&x2,&x3,&x4))
-	{
-	(*r)(x2-1,x4-1)=1;
-	(*r)(x4-1,x2-1)=1;
-	}
-fclose(f);
-for(int i=0; i<min(nbras,nkets); ++i) (*r)[i][i]=1;
-*/
 
-//cout <<"Screening mask\n"<< *r<<endl;
+      // cout <<"test bra2ket["<<spin<<"], counts,
+      // mophase\n"<<bra2ket[spin]<<counts<<mophase;
+      for (int i = 0; i < motot; ++i)
+        if (counts[i] != 1) {
+          // cout << "cannot determine MO permutation, orbital rotations do not
+          // represent simple orbital swaps\n";
+          for (int j = 0; j < motot; ++j) bra2ket[spin][j] = j;
+          goto skippermute;
+        }
 
-return r;
+      // cout <<"Smo["<<spin<<"] (permuted) diagonal elements\n";
+      // for(int i=0; i<motot; ++i) cout << i<<" :
+      // "<<Smo[spin](i,bra2ket[spin][i])<<endl;
+
+      for (int i = ncore; i < motot - ndiscarded; ++i)
+        if (bra2ket[spin][i] != i) {
+          needpermute[spin] = true;
+          // if(bra2ket[spin][i]<ncore||bra2ket[spin][i]>=motot-ndiscarded)
+          // {cout <<"Warning: MO swap outside of active space occured for spin
+          // "<<spin<<"\n";}
+        }
+
+    skippermute:
+
+      // adjust the bra2ket permutation to the CI-active orbitals
+      bra2ketperm[spin].resize(mo + 1);  // index from 1 over active
+      {
+        bra2ketperm[spin][0] = -1;  // dummy
+        if (inversedorbitals)
+          for (int i = 0; i < mo; ++i) {
+            bra2ketperm[spin][i + 1] =
+                mo - (bra2ket[spin][ncore + mo - i - 1] - ncore);
+          }
+        else
+          for (int i = 0; i < mo; ++i)
+            bra2ketperm[spin][i + 1] = bra2ket[spin][ncore + i] - ncore + 1;
+      }
+      // cout <<"bra2ketperm["<<spin<<"] "<<bra2ketperm[spin]<<endl;
+      // cout <<"needpermute["<<spin<<"] "<<needpermute[spin]<<endl;
+
+    }  // spin
+  }    // local scope
+
+  // cout <<"application of the permutation has been switched off, since
+  // typically the determinants from permuted orbitals are outside of the CI
+  // space anyway\n";
+  needpermute[0] = false;
+  needpermute[1] = false;
+
+  // read the slater basis into memory
+  // cout << "Slater basis dimensions are "<<sl<<" "<<nelec<<endl;
+  // cout <<"(total number of electrons including the ones in frozen orbitals is
+  // "<<nelec+2*ncore<<")"<<endl;
+  slaterbasis slaters(sl, nelec);
+  bool permuteslvectors = false;
+  {
+    struct stat buf;
+    if (!fstat(slaterpermfile, &buf))
+      if (buf.st_size > 0) permuteslvectors = true;
+  }
+  if (reorderslbasis && !permuteslvectors)  // was not reordered previously
+  {
+    // read the input basis
+    lseek(slaterfile, 0, SEEK_SET);
+    slaters.get(slaterfile, false);
+    // check that the whole slaterfile has been exhausted by the read to prevent
+    // mismatch in the number of electrons
+    {
+      unsigned char dummy;
+      int r = read(slaterfile, &dummy, 1);
+      if (r > 0)
+        laerror(
+            "slaterfile is larger than expected, check the number of electrons "
+            "in cioverlap input");
+      if (r < 0) laerror("unexpected error when testing slaterfile eof");
+    }
+    // check for illegal content (orbital number 0)
+    if (slaters.checkzero())
+      laerror(
+          "malformed slaterfile encountered, perhaps cipc/mcpc was compiled "
+          "without --assume byterecl");
+    // sort
+    NRVec<SPMatindex> slperm(sl);
+    for (lexindex i = 0; i < sl; ++i) slperm[i] = i;
+    slsort_sldetbase = &slaters;
+    slsort_permbase = &slperm[0];
+    slsort_nelectrons = nelec;
+    genqsort(0, (int)sl - 1,
+             slaterorder > 0 ? slsort_slbascmp : slsort_slbascmp2,
+             slsort_slbasswap);
+    // save the new basis
+    lseek(slaterfile, 0, SEEK_SET);
+    for (lexindex i = 0; i < sl; ++i)
+      if (slsort_nelectrons * (int)sizeof(spinorbindex) !=
+          write(slaterfile, slaters[slperm[i]],
+                slsort_nelectrons * sizeof(spinorbindex)))
+        laerror("write error in CIoverlap_slater");
+
+    // save the permutation, to be used in contraction with CI coefficients
+    lseek(slaterpermfile, 0, SEEK_SET);
+    slperm.put(slaterpermfile, true);
+    permuteslvectors = true;
+  }
+  lseek(slaterfile, 0, SEEK_SET);
+  slaters.get(slaterfile, false);
+  {
+    unsigned char dummy;
+    int r = read(slaterfile, &dummy, 1);
+    if (r > 0)
+      laerror(
+          "slaterfile is larger than expected, check the number of electrons "
+          "in cioverlap input");
+    if (r < 0) laerror("unexpected error when testing slaterfile eof");
+  }
+
+  // check for illegal content (orbital number 0)
+  if (slaters.checkzero())
+    laerror(
+        "malformed slaterfile encountered, perhaps cipc was compiled without "
+        "--assume byterecl");
+
+  /* NO PASA POR AQUI
+  #ifdef DEBUG
+  cout <<"slater basis "<<slaters<<endl;
+  #endif
+  */
+
+  // precompute and store in a file a list giving all determinants to consider
+  // from given one in the Ssl computation Note: symmetry of non-neglected Ssl
+  // entries is not in general present, if the bra2ket permutation has cycles
+  // longer than two
+
+  if (truncation < 0) {
+    // cout <<"Omitting excitlistfile generation\n";
+    make_excitlist = false;
+  }
+
+  if (make_excitlist) {
+    clock_t t0 = clock();
+    // cout <<"Generating excitation list for CI size " <<sl<<endl;
+    lseek(excitlistfile, 0, SEEK_SET);
+    lexindex maxlen = 0;
+    if (sizeof(lexindex) != write(excitlistfile, &maxlen, sizeof(lexindex)))
+      laerror("write error");
+    NRVec<lexindex> allowedlist(sl);
+    NRVec<unsigned char> n_act_elec((unsigned char)0, sl);
+    if (activerange)  // count electrons in active orbitals for each determinant
+      for (lexindex i = 0; i < sl; ++i) {
+        for (int e = 0; e < nelec; ++e) {
+          int imo = slaters[i][e];
+          if (imo > 0 && imo >= (*activerange)(0, 0) &&
+                  imo <= (*activerange)(0, 1) ||
+              imo < 0 && imo >= (*activerange)(1, 0) &&
+                  imo <= (*activerange)(1, 1))
+            ++n_act_elec[i];
+        }
+      }
+    for (lexindex i = 0; i < sl; ++i)  // prepare the list for each slater det.
+    {
+      NRVec<char> notocc_i(2 * (mo + ncore) +
+                           1);  // is in principle a bitvector but the "unpacked
+                                // form" should be more efficient
+      for (int o = 0; o < 2 * (mo + ncore) + 1; ++o) notocc_i[o] = 1;
+      for (int e = 0; e < nelec; ++e) notocc_i[mo + ncore + slaters[i][e]] = 0;
+      // setup an active space, where a difference in occupation does not count
+      // not to degrade performance it is also handeled via notocc_i flags
+      if (activerange) {
+        for (int o = (*activerange)(0, 0); o <= (*activerange)(0, 1); ++o)
+          notocc_i[mo + ncore + o] = 0;
+        for (int o = (*activerange)(1, 0); o <= (*activerange)(1, 1); ++o)
+          notocc_i[mo + ncore + o] = 0;
+      }
+      //
+      allowedlist[0] = i;
+      lexindex ntot = 1;
+      for (lexindex j = i + 1; j < sl; ++j) {
+        // if(slater_excitation(nelec,slaters[i],slaters[j],false,mo)>truncation)
+        // goto skipthis ; replaced by more optimized code
+        int include_it = truncation;
+        int activediff = (int)n_act_elec[j] - (int)n_act_elec[i];
+        spinorbindex *sj = slaters[j];
+        if (abs(activediff) > truncation) goto skipthis;
+        if (activediff > 0)
+          include_it -=
+              activediff;  // account for electrons excited into active orbitals
+        if (include_it < 0) goto skipthis;
+        for (int e = 0; e < nelec; ++e) {
+          if (notocc_i[mo + ncore + sj[e]]) --include_it;
+          if (include_it < 0) goto skipthis;
+        }
+        allowedlist[ntot++] = j;
+      skipthis:;
+      }
+      // cout <<"For "<<i<< " "<<ntot <<endl;
+      // write the list for i-th slater
+      if (ntot > maxlen) maxlen = ntot;
+      if (sizeof(lexindex) != write(excitlistfile, &ntot, sizeof(lexindex)))
+        laerror("write error");
+      if ((lexindex)ntot * sizeof(lexindex) !=
+          (lexindex)write(excitlistfile, &allowedlist[0],
+                          ntot * sizeof(lexindex)))
+        laerror("write error");
+    }
+    lseek(excitlistfile, 0, SEEK_SET);
+    if (sizeof(lexindex) != write(excitlistfile, &maxlen, sizeof(lexindex)))
+      laerror("write error");
+    // cout <<"make_excitlist cpu time "<<(1.*clock()-t0)/CLOCKS_PER_SEC<<endl;
+  }
+
+  // prepare many-particle overlap matrix in the Slater basis
+  NRVec<SPMatindex> slperm;
+  if (permuteslvectors) {
+    lseek(slaterpermfile, 0, SEEK_SET);
+    slperm.get(slaterpermfile, true);
+    if (sl != (lexindex)slperm.size()) laerror("inconsistent slaterpermfile");
+  }
+
+  SparseMat<REAL> Ssl(sl, sl);
+  unsigned long skipcount = 0;
+  unsigned long computedcount = 0;
+  clock_t t0 = clock();
+  if (truncation >= 0) lseek(excitlistfile, 0, SEEK_SET);
+  lexindex maxlen = 0;
+  if (truncation >= 0) {
+    if (sizeof(lexindex) != read(excitlistfile, &maxlen, sizeof(lexindex)))
+      laerror("excitlist read error 1");
+    if (maxlen == 0) laerror("unfinished excitlistfile encountered");
+  } else
+    maxlen = 1;
+  NRVec<lexindex> excitlist(maxlen);
+  // cout<<"Number of determinants in the wavefunctions = "<<sl<<endl;
+  // cout<<"Done 0%\n"; cout.flush();
+  int percent = 0;
+  for (lexindex i = 0; i < sl; ++i) {
+    /* NO PASA POR AQUI
+    #ifdef DEBUG
+    //cout<< "Processing determinant "<<i<<endl;
+    #endif
+    */
+    if ((i * 100) / sl > percent) {
+      percent = (i * 100) / sl;
+      // cout<<" "<<percent<<"%"; cout.flush();
+    }
+    lexindex ntot;
+    if (truncation >= 0) {
+      if (sizeof(lexindex) != read(excitlistfile, &ntot, sizeof(lexindex)))
+        laerror("excitlist read error 2");
+      if (ntot * sizeof(lexindex) !=
+          (lexindex)read(excitlistfile, &excitlist[0], ntot * sizeof(lexindex)))
+        laerror("excitlist read error 3");
+    }
+    for (lexindex jj = (truncation >= 0 ? 0 : i);
+         jj < (truncation >= 0 ? ntot : sl); ++jj) {
+      lexindex jjx;
+      jjx = truncation >= 0 ? excitlist[jj] : jj;
+      /* NO PASA POR AQUI
+      #ifdef DEBUG
+      //cout<< "Processing its peer "<<jj<<" "<<jjx<<endl;
+      #endif
+      */
+      perform_overlap(i, jjx, &skipcount, needpermute, nelec, slaters,
+                      bra2ketperm, permuteslvectors, slperm, screeningthr,
+                      brasl, ketsl, Smo, ncore, mo, inversedorbitals,
+                      &computedcount, Ssl, inactive, screening_mask);
+      if (i != jjx)
+        perform_overlap(jjx, i, &skipcount, needpermute, nelec, slaters,
+                        bra2ketperm, permuteslvectors, slperm, screeningthr,
+                        brasl, ketsl, Smo, ncore, mo, inversedorbitals,
+                        &computedcount, Ssl, inactive, screening_mask);
+    }
+  }
+  // cout<< " 100%\noverlap calculation CPU time
+  // "<<(1.*clock()-t0)/CLOCKS_PER_SEC<<endl; cout.flush();
+  slaters.resize(0, 0);  // free memory
+
+  /* NO PASA POR AQUI
+  #ifdef DEBUG
+  NRMat<REAL>Ssltest(Ssl);
+  for(lexindex i=0; i<sl; ++i)
+      {
+          cout <<"for "<<i<<endl;
+          for(lexindex j=0; j<sl; ++j)
+          {
+          if(abs(Ssltest(i,j))>.01) cout <<"Ssl "<<i<<" "<<j<<" =
+  "<<Ssltest(i,j)<<endl;
+          //cout <<"Ssl asymetry "<<i<<" "<<j<<" "<<Ssltest(i,j)-Ssltest(j,i)
+  <<" from "<<Ssltest(i,j)<<endl;
+          }
+          cout <<endl;
+      }
+  cout <<"Ssl diagonal elements\n";
+  for(lexindex i=0; i<sl; ++i) cout <<"det "<<i<<": "<<Ssltest(i,i)<<endl;
+  #endif
+  */
+
+  // cout <<"Number of computed overlap determinant pairs =
+  // "<<computedcount<<endl; if(screeningthr>0) cout <<"Number of skipped
+  // determinant pairs at screening threshold "<<screeningthr<<" =
+  // "<<skipcount<<endl;
+
+  // contract bras and kets with the overlaps in Slater basis
+  NRMat<REAL> tmp = Ssl * ketsl;
+  Ssl.resize(0, 0);  // free memory
+  NRMat<REAL> result(brasl.ncols(), ketsl.ncols());
+  result.gemm(0., brasl, 't', tmp, 'n', 1.);
+
+  // zero out inaccurate elements according to screening_mask
+  if (screening_mask) {
+    int i, j;
+    for (i = 0; i < result.nrows(); ++i)
+      for (j = 0; j < result.ncols(); ++j) {
+        if ((*screening_mask)(i, j) == 0) result(i, j) = 0;
+      }
+  }
+
+  return result;
 }
 
+// NRMat<int> *read_screening_mask(char *screening_mask_file,int nbras, int
+// nkets)
+NRMat<int> *read_screening_mask(int *kcoup, int nbras, int nkets) {
+  int dim = min(nbras, nkets);
+  // cout << nbras << " " << nkets << " " << dim << endl;
+  NRMat<int> *r = new NRMat<int>(0, nbras, nkets);
+  for (int ii = 0; ii < dim; ++ii)
+    for (int jj = 0; jj < dim; ++jj) {
+      // cout << kcoup[ii*dim+jj] << endl ;
+      (*r)[ii][jj] = kcoup[ii * dim + jj];
+    }
+  /*
+  if(!screening_mask_file) return NULL;
+  NRMat<int> *r = new NRMat<int>(0,nbras,nkets);
+  FILE *f = fopen(screening_mask_file,"r");
+  if(!f) laerror("cannot read screening_mask_file");
+  char line[1024];
+  fgets(line, 1024,f);
+  int x1,x2,x3,x4;
+  while(4==fscanf(f,"%d %d %d %d",&x1,&x2,&x3,&x4))
+          {
+          (*r)(x2-1,x4-1)=1;
+          (*r)(x4-1,x2-1)=1;
+          }
+  fclose(f);
+  for(int i=0; i<min(nbras,nkets); ++i) (*r)[i][i]=1;
+  */
+
+  // cout <<"Screening mask\n"<< *r<<endl;
+
+  return r;
+}
 
 NRMat<REAL> CIoverlap(
-	bool uhf,
-	const NRMat<REAL> &bras, //CIsize x n
-	const NRMat<REAL> &kets, //CIsize x m
-	const NRMat<REAL> &Sraw, //2*AO x 2*AO (generated by artificial doubled geometry input)
-	const NRMat<REAL> (&braLCAO)[2], //AO x MO
-	const NRMat<REAL> (&ketLCAO)[2], //AO x MO
-	const drt &d,
-	int slaterfile, //file descriptor for slater basis 
-	int citrfile, //file descriptor for CItrafo matrix
-	int excitlistfile, //file descriptor for list of not neglected excitations
-        const int ncore=0,
-        const int ndiscarded=0,
-	bool generate_trafo=true,
-	bool make_excitlist=true,
-	const int truncation=4, //neglect overlap of Slater dets differing in more than ... spinorbitals (take into account arbitrary MO swapping)
-	const bool inversedorbitals=true, //lowest MOs are at the top of DRT when true
-	const bool inverselex=false,
-	const int slaterorder=1,
-	REAL screeningthr=0,
-	NRMat<int> *activerange=NULL,
-	int inactive=0,
-	NRMat<int> *screening_mask = NULL
-	) 
-{
-//generate and save, or read from files Slater basis and transformation matrix
-//this computation can be done only once and remains constant
-lexindex ci=d.cisize();
-NRMat<REAL> brasl, ketsl;
-SparseMat<REAL> citrafo;
-if(generate_trafo)
-	{
-	citrafo=CItrafo(slaterfile,d,slaterorder,inverselex);
-	citrafo.put(citrfile,true);
-	}
-else
-	{
-	lseek(citrfile,0,SEEK_SET);
-	citrafo.get(citrfile,true);
-	if((lexindex)citrafo.ncols()!=ci) laerror("inconsistent dimension of citrafo");
-	}
+    bool uhf,
+    const NRMat<REAL> &bras,  // CIsize x n
+    const NRMat<REAL> &kets,  // CIsize x m
+    const NRMat<REAL>
+        &Sraw,  // 2*AO x 2*AO (generated by artificial doubled geometry input)
+    const NRMat<REAL> (&braLCAO)[2],  // AO x MO
+    const NRMat<REAL> (&ketLCAO)[2],  // AO x MO
+    const drt &d,
+    int slaterfile,     // file descriptor for slater basis
+    int citrfile,       // file descriptor for CItrafo matrix
+    int excitlistfile,  // file descriptor for list of not neglected excitations
+    const int ncore = 0, const int ndiscarded = 0, bool generate_trafo = true,
+    bool make_excitlist = true,
+    const int truncation =
+        4,  // neglect overlap of Slater dets differing in more than ...
+            // spinorbitals (take into account arbitrary MO swapping)
+    const bool inversedorbitals =
+        true,  // lowest MOs are at the top of DRT when true
+    const bool inverselex = false, const int slaterorder = 1,
+    REAL screeningthr = 0, NRMat<int> *activerange = NULL, int inactive = 0,
+    NRMat<int> *screening_mask = NULL) {
+  // generate and save, or read from files Slater basis and transformation
+  // matrix this computation can be done only once and remains constant
+  lexindex ci = d.cisize();
+  NRMat<REAL> brasl, ketsl;
+  SparseMat<REAL> citrafo;
+  if (generate_trafo) {
+    citrafo = CItrafo(slaterfile, d, slaterorder, inverselex);
+    citrafo.put(citrfile, true);
+  } else {
+    lseek(citrfile, 0, SEEK_SET);
+    citrafo.get(citrfile, true);
+    if ((lexindex)citrafo.ncols() != ci)
+      laerror("inconsistent dimension of citrafo");
+  }
 
-//transform CI vectors to the Slater basis
-brasl=citrafo*bras;
-ketsl=citrafo*kets;
-citrafo.resize(0,0); //free memory
+  // transform CI vectors to the Slater basis
+  brasl = citrafo * bras;
+  ketsl = citrafo * kets;
+  citrafo.resize(0, 0);  // free memory
 
-return CIoverlap_slater(uhf,brasl,ketsl,Sraw,braLCAO,ketLCAO,slaterfile,excitlistfile,d.electrons(),d.orbnum(),ncore,ndiscarded,make_excitlist,truncation,inversedorbitals,slaterorder,false,-1,screeningthr,activerange,inactive,screening_mask);
+  return CIoverlap_slater(uhf, brasl, ketsl, Sraw, braLCAO, ketLCAO, slaterfile,
+                          excitlistfile, d.electrons(), d.orbnum(), ncore,
+                          ndiscarded, make_excitlist, truncation,
+                          inversedorbitals, slaterorder, false, -1,
+                          screeningthr, activerange, inactive, screening_mask);
 }
 
-NRMat<REAL> docislateroverlap(int M, int NCO, int Nvirt, int nstates, int ndets, double* wfunc, 
-                              double* wfunc_old,double* coef, double* coef_old, double* Sbig, 
-                              bool uhf, REAL screeningthr, int excitrank, 
-                              NRMat<int> *activerange=NULL,int inactive=0, int* kcoup = NULL)
-{
+NRMat<REAL> docislateroverlap(int M, int NCO, int Nvirt, int nstates, int ndets,
+                              double *wfunc, double *wfunc_old, double *coef,
+                              double *coef_old, double *Sbig, bool uhf,
+                              REAL screeningthr, int excitrank,
+                              NRMat<int> *activerange = NULL, int inactive = 0,
+                              int *kcoup = NULL) {
+  /*
+    NOTE: ncore are only such core orbitals which are not included in slaterfile
+    NOTE: slaterfile numbering is expected to start from ncore+1
+    NOTE  inactive orbitals by -i option are NOT counted as core here, they are
+    only approximation to make computation faster NOTE: discarded orbitals have
+    to be included so that all dimensions fit NOTE: nelec should NOT include the
+    2*ncore frozen electrons
+  */
 
-/*
-  NOTE: ncore are only such core orbitals which are not included in slaterfile
-  NOTE: slaterfile numbering is expected to start from ncore+1
-  NOTE  inactive orbitals by -i option are NOT counted as core here, they are only approximation to make computation faster
-  NOTE: discarded orbitals have to be included so that all dimensions fit
-  NOTE: nelec should NOT include the 2*ncore frozen electrons
-*/
+  int nbas, ncore, ndisc, nactive, nelec;
+  ncore = 0;
+  ndisc = 0;
+  nbas = M, nelec = NCO * 2;
 
-int nbas,ncore,ndisc,nactive,nelec;
-ncore=0; ndisc=0; 
-nbas=M,
-nelec=NCO*2;
+  nactive = nbas - ncore - ndisc;
+  // cout << "Number of frozen core orbitals (not in slaterfile) =
+  // "<<ncore<<endl; cout << "Number of discarded virtual orbitals =
+  // "<<ndisc<<endl; cout << "Number of not frozen electrons = " <<nelec<<endl;
 
-nactive=nbas-ncore-ndisc;
-//cout << "Number of frozen core orbitals (not in slaterfile) = "<<ncore<<endl;
-//cout << "Number of discarded virtual orbitals = "<<ndisc<<endl;
-//cout << "Number of not frozen electrons = " <<nelec<<endl;
+  if (inactive * 2 >= nelec)
+    laerror("more inactive doubly occ orbitals than nelec/2");
 
-if(inactive*2>=nelec) laerror("more inactive doubly occ orbitals than nelec/2");
+  bool include_occ = 1, number_occ = 1;
+  int nocc[2], nvirt[2], inactive_occ = 0, inactive_virt = 0;
+  nocc[0] = nocc[1] = NCO;
+  nvirt[0] = nvirt[1] = Nvirt;
 
-bool include_occ=1, number_occ=1;
-int nocc[2], nvirt[2], inactive_occ=0, inactive_virt=0;
-nocc[0]=nocc[1]=NCO; nvirt[0]=nvirt[1]=Nvirt;
+  // Ver como hacer para que lo guarde en memoria TODO
+  do_cis_slater(uhf, ncore, nocc, nvirt, inactive_occ, inactive_virt,
+                include_occ, number_occ);  // crea el archivo slaterfile
+  int slaterfile = open("slaterfile", O_RDWR | O_LARGEFILE,
+                        0777);  // abre el fichero anterior
+  if (slaterfile < 0) {
+    perror("cannot open slaterfile");
+    laerror("IO error");
+  }
 
-// Ver como hacer para que lo guarde en memoria TODO
-do_cis_slater(uhf,ncore,nocc,nvirt,inactive_occ,inactive_virt,include_occ,number_occ); // crea el archivo slaterfile
-int slaterfile=open("slaterfile",O_RDWR|O_LARGEFILE,0777); // abre el fichero anterior
-if(slaterfile<0) {perror("cannot open slaterfile");laerror("IO error");}
+  // Esto crea archivos temporales: TODO
+  int excitlistfile =
+      open("excitlistfile", O_CREAT | O_LARGEFILE | O_RDWR, 0777);
+  if (excitlistfile < 0) {
+    perror("cannot open excitlistfile");
+    laerror("IO error");
+  }
 
-// Esto crea archivos temporales: TODO
-int excitlistfile=open("excitlistfile",O_CREAT|O_LARGEFILE|O_RDWR,0777);
-if(excitlistfile<0) {perror("cannot open excitlistfile");laerror("IO error");}
+  int slaterpermfile =
+      open("slaterpermfile", O_CREAT | O_RDWR | O_LARGEFILE, 0777);
+  if (slaterpermfile < 0) {
+    perror("cannot open slaterpermfile");
+    laerror("IO error");
+  }
+  /////////////////////////////////////
 
-int slaterpermfile=open("slaterpermfile",O_CREAT|O_RDWR|O_LARGEFILE,0777);
-if(slaterpermfile<0) {perror("cannot open slaterpermfile");laerror("IO error");}
-/////////////////////////////////////
+  NRMat<REAL> bras, kets;
+  bras.resize(ndets, nstates);
+  kets.resize(ndets, nstates);
+  for (int ii = 0; ii < nstates; ii++)
+    for (int jj = 0; jj < ndets; jj++) {
+      bras(jj, ii) = wfunc[ii * ndets + jj];
+      kets(jj, ii) = wfunc_old[ii * ndets + jj];
+    }
 
+  // TODO: vectores de excitaciones y fundamental
+  /*
+  int f;
+  f=open("eivectors1",O_RDONLY|O_LARGEFILE); if(f<0) {perror("cannot open
+  eivectors1");laerror("IO error");} bras.get(f,true,true); close(f);
+  f=open("eivectors2",O_RDONLY|O_LARGEFILE); if(f<0) {perror("cannot open
+  eivectors2");laerror("IO error");} kets.get(f,true,true); close(f);
+  */
 
-NRMat<REAL> bras,kets;
-bras.resize(ndets,nstates);
-kets.resize(ndets,nstates);
-for (int ii=0; ii<nstates; ii++)
-   for (int jj=0; jj<ndets; jj++) {
-        bras(jj,ii) = wfunc[ii*ndets+jj];
-        kets(jj,ii) = wfunc_old[ii*ndets+jj];
-   }
+  //#ifdef DEBUG
+  // cout <<"test eivectors1 (bras) "<<bras<<endl;
+  // cout <<"test eivectors2 (kets) "<<kets<<endl;
+  //#else
 
-// TODO: vectores de excitaciones y fundamental 
-/*
-int f;
-f=open("eivectors1",O_RDONLY|O_LARGEFILE); if(f<0) {perror("cannot open eivectors1");laerror("IO error");}
-bras.get(f,true,true);
-close(f);
-f=open("eivectors2",O_RDONLY|O_LARGEFILE); if(f<0) {perror("cannot open eivectors2");laerror("IO error");}
-kets.get(f,true,true);
-close(f);
-*/
+  // TODO: Esto es por checke, no se necesita en la cuenta - REMOVER
+  /*
+  cout <<"Dominant contributions to bras\n";
+  for(int k=0; k<bras.ncols(); ++k)
+          {
+          cout <<"bra state "<<k<<":\n";
+          for(lexindex l=0; l<bras.nrows(); ++l)
+                  if(abs(bras(l,k))>0.1) cout <<"det "<<l<<" "<<bras(l,k)<<endl;
+          }
+  cout <<"Dominant contributions to kets\n";
+  for(int k=0; k<kets.ncols(); ++k)
+          {
+          cout <<"ket state "<<k<<":\n";
+          for(lexindex l=0; l<kets.nrows(); ++l)
+                  if(abs(kets(l,k))>0.1) cout <<"det "<<l<<" "<<kets(l,k)<<endl;
+          }
+  */
+  //#endif
 
-//#ifdef DEBUG
-//cout <<"test eivectors1 (bras) "<<bras<<endl;
-//cout <<"test eivectors2 (kets) "<<kets<<endl;
-//#else
+  NRMat<int> *screening_mask =
+      read_screening_mask(kcoup, bras.ncols(), kets.ncols());
 
-// TODO: Esto es por checke, no se necesita en la cuenta - REMOVER
-/*
-cout <<"Dominant contributions to bras\n";
-for(int k=0; k<bras.ncols(); ++k)
-	{
-	cout <<"bra state "<<k<<":\n";
-	for(lexindex l=0; l<bras.nrows(); ++l)
-		if(abs(bras(l,k))>0.1) cout <<"det "<<l<<" "<<bras(l,k)<<endl;
-	}
-cout <<"Dominant contributions to kets\n";
-for(int k=0; k<kets.ncols(); ++k)
-        {
-        cout <<"ket state "<<k<<":\n";
-        for(lexindex l=0; l<kets.nrows(); ++l)
-                if(abs(kets(l,k))>0.1) cout <<"det "<<l<<" "<<kets(l,k)<<endl;
+  // cout <<"Coefficient-overlap bra-ket:\n";
+  // cout << bras.transpose() * kets;
+
+  NRMat<REAL> Sraw;
+  /*
+         |  [t,t] | [t,t-dt]  |
+  Sraw = |--------|-----------|
+         |[t-dt,t]|[t-dt,t-dt]|
+  */
+  int dim = nbas * 2;
+  Sraw.resize(dim, dim);
+  for (int ii = 0; ii < dim; ii++)
+    for (int jj = 0; jj < dim; jj++) {
+      Sraw(ii, jj) = Sbig[ii * dim + jj];
+    }
+  // cout << " caca 1 " << endl;
+
+  // SCF coeffiencts, bra=new, ket=old
+  NRMat<REAL> braLCAO[2], ketLCAO[2];
+  braLCAO[0].resize(nbas, nbas);
+  braLCAO[1].resize(nbas, nbas);
+  ketLCAO[0].resize(nbas, nbas);
+  ketLCAO[1].resize(nbas, nbas);
+  for (int ii = 0; ii < nbas; ii++)
+    for (int jj = 0; jj < nbas; jj++) {
+      braLCAO[0](ii, jj) = braLCAO[1](ii, jj) = coef[jj * nbas + ii];
+      ketLCAO[0](ii, jj) = ketLCAO[1](ii, jj) = coef_old[jj * nbas + ii];
+    }
+  // cout << " caca 2 " << endl;
+
+  bool make_excitlist = true;
+  {
+    struct stat64 buf;
+    if (fstat64(excitlistfile, &buf)) laerror("cannot stat excitlistfile");
+    if (buf.st_size > 0) make_excitlist = false;
+  }
+
+  NRMat<REAL> SCI = CIoverlap_slater(
+      uhf, bras, kets, Sraw, braLCAO, ketLCAO, slaterfile, excitlistfile, nelec,
+      nactive, ncore, ndisc, make_excitlist, excitrank, inverseorb, slaterorder,
+      false /*we do not need lexical order now*/, slaterpermfile, screeningthr,
+      activerange, inactive, screening_mask);
+
+  close(slaterfile);
+  close(slaterpermfile);
+  close(excitlistfile);
+
+  return SCI;
+}
+
+void cioverlap(double *wfunc, double *wfunc_old, double *coef, double *coef_old,
+               double *Sbig, double *sigma, int *kind_coupling, double *phases,
+               double *phases_old, int &M, int &NCO, int &Nvirt, int &nstates,
+               int &ndets) {
+  clock_t clock0 = clock();
+
+  cout.setf(ios::fixed);
+  cout.precision(12);
+
+  // TRUE = 1; FALSE = 0;
+  bool uhf = 0;
+  // char *screening_mask_file=NULL;
+  // screening_mask_file="transmomin";
+  bool alignrows = 1;
+  bool useoldphase = 1;
+  bool aligncolumns = 0;
+  REAL screeningthr = 5e-4;
+  int excitrank = -1;
+  int inactive = 0;
+  NRMat<int> *activerange = NULL;
+
+  // cout << "Number of (not frozen) inactive orbitals = "<<inactive<<endl;
+  // cout << "Excitation rank threshold = "<<excitrank<<endl;
+  // cout << "Screening threshold = "<<screeningthr<<endl;
+
+  NRMat<REAL> SCI;
+
+  SCI = docislateroverlap(M, NCO, Nvirt, nstates, ndets, wfunc, wfunc_old, coef,
+                          coef_old, Sbig, uhf, screeningthr, excitrank,
+                          activerange, inactive, kind_coupling);
+  // cout << "CI overlap before alignment\n";
+  // cout << SCI;
+
+  SCI.copyonwrite();
+  if (aligncolumns) SCI.transposeme();
+  if (alignrows || aligncolumns) {
+    // NRVec<REAL> phases;
+    // phases.resize(SCI.nrows());
+
+    // apply old phases if available
+    if (useoldphase) {
+      // int f=open("phases.old",O_RDONLY);
+      // if(f>=0)
+      {
+        // phases.get(f,true,false);
+        // close(f);
+        // cout <<"Old phases:\n"<<phases<<endl;
+        // if(phases.size() != SCI.ncols() || phases.size() != SCI.nrows())
+        // laerror("size mismatch in phases.old");
+        for (int j = 0; j < SCI.ncols(); ++j)
+          for (int i = 0; i < SCI.nrows(); ++i) SCI(i, j) *= phases_old[j];
+        // cout <<"CI overlap patched by old phases\n"<< (aligncolumns?
+        // SCI.transpose():SCI);
+      }
+    }
+    for (int i = 0; i < SCI.nrows(); ++i) {
+      REAL maxoverlap = -1;
+      int maxoverlapindex = -1;
+      for (int j = 0; j < SCI.ncols(); ++j)
+        if (abs(SCI(i, j)) > maxoverlap) {
+          maxoverlapindex = j;
+          maxoverlap = abs(SCI(i, j));
         }
-*/
-//#endif
 
-NRMat<int> *screening_mask = read_screening_mask(kcoup,bras.ncols(), kets.ncols());
+      // if(i!=maxoverlapindex) cout <<"Note: state character exchanged: "<<i<<"
+      // -> "<<maxoverlapindex<<endl;
 
-//cout <<"Coefficient-overlap bra-ket:\n";
-//cout << bras.transpose() * kets;
+      if (SCI(i, i) < 0) {
+        phases[i] = -1;
+        for (int j = 0; j < SCI.ncols(); ++j) SCI(i, j) *= -1;
+      } else
+        phases[i] = 1;
+    }
+    // int p=open("phases",O_WRONLY|O_CREAT,0777);
+    // if(p<0) laerror("cannot write-open phases");
+    // phases.put(p,true);
+    // close(p);
+    // cout <<"Phases aligned:\n"<<phases<<endl;
+  }
 
-NRMat<REAL> Sraw;
-/*
-       |  [t,t] | [t,t-dt]  |   
-Sraw = |--------|-----------|
-       |[t-dt,t]|[t-dt,t-dt]|
-*/
-int dim=nbas*2;
-Sraw.resize(dim,dim);
-for (int ii=0; ii<dim; ii++)
-   for (int jj=0; jj<dim; jj++) {
-        Sraw(ii,jj) = Sbig[ii*dim+jj];
-   }
-//cout << " caca 1 " << endl;
+  if (aligncolumns) SCI.transposeme();
 
-// SCF coeffiencts, bra=new, ket=old
-NRMat<REAL> braLCAO[2],ketLCAO[2];
-braLCAO[0].resize(nbas,nbas); braLCAO[1].resize(nbas,nbas);
-ketLCAO[0].resize(nbas,nbas); ketLCAO[1].resize(nbas,nbas);
-for (int ii=0; ii<nbas; ii++)
-   for (int jj=0; jj<nbas; jj++) {
-        braLCAO[0](ii,jj)=braLCAO[1](ii,jj)=coef[jj*nbas+ii];
-        ketLCAO[0](ii,jj)=ketLCAO[1](ii,jj)=coef_old[jj*nbas+ii];
-   }
-//cout << " caca 2 " << endl;
+  // cout << "CPU time "<< (clock()-clock0)/CLOCKS_PER_SEC<<endl;
 
-bool make_excitlist=true;
-{
-struct stat64 buf;
-if(fstat64(excitlistfile,&buf)) laerror("cannot stat excitlistfile");
-if(buf.st_size>0) make_excitlist=false;
-}
+  // cout << "CI overlap matrix\n";
+  // cout << SCI;
 
-
-NRMat<REAL> SCI = CIoverlap_slater(uhf, bras, kets, Sraw, braLCAO, ketLCAO, slaterfile, excitlistfile, nelec, nactive, ncore, ndisc, make_excitlist, excitrank,inverseorb,slaterorder,false /*we do not need lexical order now*/,slaterpermfile,screeningthr,activerange,inactive,screening_mask);
-
-close(slaterfile);
-close(slaterpermfile);
-close(excitlistfile);
-
-return SCI;
-}
-
-void cioverlap(double* wfunc, double* wfunc_old,
-        double* coef, double* coef_old, double* Sbig, double* sigma,
-        int* kind_coupling,double* phases, double* phases_old, int& M, int& NCO, int& Nvirt, int& nstates,
-        int& ndets)
-{
-clock_t clock0 = clock();
-
-cout.setf(ios::fixed);
-    cout.precision(12);
-
-
-// TRUE = 1; FALSE = 0;
-bool uhf=0;
-//char *screening_mask_file=NULL;
-//screening_mask_file="transmomin";
-bool alignrows=1;
-bool useoldphase=1;
-bool aligncolumns=0;
-REAL screeningthr=5e-4; 
-int excitrank=-1;
-int inactive=0;
-NRMat<int> *activerange=NULL;
-
-//cout << "Number of (not frozen) inactive orbitals = "<<inactive<<endl;
-//cout << "Excitation rank threshold = "<<excitrank<<endl;
-//cout << "Screening threshold = "<<screeningthr<<endl;
-
-NRMat<REAL> SCI;
-
-SCI = docislateroverlap(M,NCO,Nvirt,nstates,ndets,wfunc,wfunc_old,coef,coef_old,Sbig,
-                        uhf,screeningthr,excitrank,activerange,inactive,kind_coupling);
-//cout << "CI overlap before alignment\n";
-//cout << SCI;
-
-SCI.copyonwrite();
-if(aligncolumns) SCI.transposeme();
-if(alignrows||aligncolumns)
-	{
-	//NRVec<REAL> phases;
-	//phases.resize(SCI.nrows());
-
-//apply old phases if available 
-if(useoldphase)
-{
-//int f=open("phases.old",O_RDONLY); 
-//if(f>=0)
-	{
-	//phases.get(f,true,false);
-	//close(f);
-	//cout <<"Old phases:\n"<<phases<<endl;
-	//if(phases.size() != SCI.ncols() || phases.size() != SCI.nrows()) laerror("size mismatch in phases.old");
-	for(int j=0; j<SCI.ncols(); ++j) for(int i=0; i<SCI.nrows(); ++i) SCI(i,j) *= phases_old[j];
-	//cout <<"CI overlap patched by old phases\n"<< (aligncolumns? SCI.transpose():SCI);
-	}
-
-}
-	for(int i=0; i<SCI.nrows(); ++i)
-		{
-		REAL maxoverlap = -1;
-		int maxoverlapindex = -1;
-		for(int j=0; j<SCI.ncols(); ++j) if(abs(SCI(i,j)) > maxoverlap) 
-			{
-			maxoverlapindex=j;
-			maxoverlap=abs(SCI(i,j));
-			}
-
-		//if(i!=maxoverlapindex) cout <<"Note: state character exchanged: "<<i<<" -> "<<maxoverlapindex<<endl;
-	
-		if(SCI(i,i)<0)
-			{	
-	 		phases[i]= -1;
-			for(int j=0; j<SCI.ncols(); ++j) SCI(i,j) *= -1;
-			}
-		else
-			phases[i]= 1;
-		}
-	//int p=open("phases",O_WRONLY|O_CREAT,0777);
-	//if(p<0) laerror("cannot write-open phases");
-	//phases.put(p,true);
-	//close(p);
-	//cout <<"Phases aligned:\n"<<phases<<endl;
-	}
-
-if(aligncolumns) SCI.transposeme();
-
-//cout << "CPU time "<< (clock()-clock0)/CLOCKS_PER_SEC<<endl;
-
-//cout << "CI overlap matrix\n";
-//cout << SCI;
-
-// Put sigma in pointer
-for ( int ii=0; ii<nstates; ii++ )
-   for( int jj=0; jj<nstates; jj++ )
-      sigma[ii*nstates+jj] = SCI(ii,jj);
-
+  // Put sigma in pointer
+  for (int ii = 0; ii < nstates; ii++)
+    for (int jj = 0; jj < nstates; jj++) sigma[ii * nstates + jj] = SCI(ii, jj);
 }

--- a/g2g/cioverlap/cioverlap_fake.cpp
+++ b/g2g/cioverlap/cioverlap_fake.cpp
@@ -1,15 +1,13 @@
 #include <iostream>
 #include <stdlib.h>
 
-
 using namespace std;
-extern "C" void g2g_cioverlap_(double* wfunc, double* wfunc_old,
-        double* coef, double* coef_old, double* Sbig, double* sigma,
-        int* kind_coupling, double* phases, double* phases_old,  
-        int& M, int& NCO, int& Nvirt, int& nstates, int& ndets)
-{
-   cout << " In order to run TSH dynamics, you have to compile LIO " ;
-   cout << "with tsh=1 option" << endl;
-   exit(-1);
+extern "C" void g2g_cioverlap_(double* wfunc, double* wfunc_old, double* coef,
+                               double* coef_old, double* Sbig, double* sigma,
+                               int* kind_coupling, double* phases,
+                               double* phases_old, int& M, int& NCO, int& Nvirt,
+                               int& nstates, int& ndets) {
+  cout << " In order to run TSH dynamics, you have to compile LIO ";
+  cout << "with tsh=1 option" << endl;
+  exit(-1);
 }
-

--- a/g2g/cioverlap/cis_slatergen.h
+++ b/g2g/cioverlap/cis_slatergen.h
@@ -1,107 +1,115 @@
-void do_cis_slater(bool uhf, int ncore0, int (&nocc0)[2], int (&nvirt0)[2], int inactive_occ, int inactive_virt, bool include_occ = 1, bool number_occ = 1)
-{
-//cout << "Is this UHF run? "<<uhf<<endl;
-//cout <<"core occa occb virta virtb freeze disc "<<ncore0<<" "<<nocc0[0]<<" "<<nocc0[1]<<" "<<nvirt0[0]<<" "<<nvirt0[1]<<" "<<inactive_occ<<" "<<inactive_virt<<endl;
+void do_cis_slater(bool uhf, int ncore0, int (&nocc0)[2], int (&nvirt0)[2],
+                   int inactive_occ, int inactive_virt, bool include_occ = 1,
+                   bool number_occ = 1) {
+  // cout << "Is this UHF run? "<<uhf<<endl;
+  // cout <<"core occa occb virta virtb freeze disc "<<ncore0<<" "<<nocc0[0]<<"
+  // "<<nocc0[1]<<" "<<nvirt0[0]<<" "<<nvirt0[1]<<" "<<inactive_occ<<"
+  // "<<inactive_virt<<endl;
 
-int ncore = ncore0+inactive_occ;
-int nocc[2]; 
-nocc[0] = nocc0[0]-inactive_occ;
-nocc[1] = nocc0[1]-inactive_occ;
-int nvirt[2];
-nvirt[0] = nvirt0[0]-inactive_virt;
-nvirt[1] = nvirt0[1]-inactive_virt;
+  int ncore = ncore0 + inactive_occ;
+  int nocc[2];
+  nocc[0] = nocc0[0] - inactive_occ;
+  nocc[1] = nocc0[1] - inactive_occ;
+  int nvirt[2];
+  nvirt[0] = nvirt0[0] - inactive_virt;
+  nvirt[1] = nvirt0[1] - inactive_virt;
 
-//cout <<"nocc_eff = "<<nocc[0] <<" "<<nocc[1]<<endl;
-//cout <<"virt_eff = "<<nvirt[0] <<" "<<nvirt[1]<<endl;
+  // cout <<"nocc_eff = "<<nocc[0] <<" "<<nocc[1]<<endl;
+  // cout <<"virt_eff = "<<nvirt[0] <<" "<<nvirt[1]<<endl;
 
+  slaterdet tmp((include_occ ? 2 * ncore : 0) + nocc[0] +
+                nocc[1]);  // general uhf
 
-slaterdet tmp((include_occ?2*ncore:0)+nocc[0]+nocc[1]); //general uhf
+  int slaterfile = open("slaterfile", O_WRONLY | O_CREAT | O_LARGEFILE, 0777);
+  if (slaterfile < 0) {
+    perror("cannot open");
+    laerror("IO error");
+  }
 
-int slaterfile=open("slaterfile",O_WRONLY|O_CREAT|O_LARGEFILE,0777); if(slaterfile<0) {perror("cannot open");laerror("IO error");}
+  if (include_occ)
+    for (int iocc = 1; iocc <= ncore;
+         ++iocc)  // generate fixed core occupation alternating alpha and beta
+    {
+      tmp[2 * iocc - 2] = iocc;
+      tmp[2 * iocc - 1] = -iocc;
+    }
 
-if(include_occ)
-    for(int iocc=1; iocc<=ncore; ++iocc) //generate fixed core occupation alternating alpha and beta
-        {
-        tmp[2*iocc-2] = iocc; 
-        tmp[2*iocc-1] = -iocc;
+  int shiftcore = include_occ ? ncore : 0;
+  int numcore = number_occ ? ncore : 0;
+
+  // fermi vacuum determinant
+
+  NRVec<int> positions[2];
+  if (uhf) {
+    positions[0].resize(nocc[0]);
+    positions[1].resize(nocc[1]);
+  }
+
+  int noccmin = nocc[0];
+  if (nocc[1] < noccmin) noccmin = nocc[1];
+  int noccmax = nocc[0];
+  if (nocc[1] > noccmax) noccmax = nocc[1];
+  // generate part with alternating alpha and beta
+  for (int iocc = 1; iocc <= noccmin; ++iocc) {
+    int pos = 2 * shiftcore + 2 * iocc - 2;
+    tmp[2 * shiftcore + 2 * iocc - 2] = iocc + numcore;
+    tmp[pos + 1] = -iocc - numcore;
+    if (uhf) {
+      positions[0][iocc - 1] = pos;
+      positions[1][iocc - 1] = pos + 1;
+    }
+  }
+  // and add extra alpha or beta orbitals
+  if (nocc[0] != nocc[1]) {
+    int spin = nocc[0] > nocc[1] ? 1 : -1;
+    for (int iocc = noccmin + 1; iocc <= noccmax; ++iocc) {
+      int pos = 2 * shiftcore + 2 * noccmin + iocc - noccmin - 1;
+      tmp[pos] = spin * (iocc + numcore);
+      if (uhf) positions[spin == 1 ? 0 : 1][iocc - 1] = pos;
+    }
+  }
+
+  // store the vacuum
+  tmp.put(slaterfile, false);
+
+  // now generate all possible excitations
+
+  // order of indices will be occ,virt
+  // notice that we make replacement in place - parity of permutation to bring a
+  // given spinorb in front and after excitation to bring it back compensates
+
+  if (uhf) {
+    for (int spin = 0; spin <= 1;
+         ++spin)  // first all alpha, then all beta excitations
+    {
+      for (int iocc = 1; iocc <= nocc[spin]; ++iocc)
+        for (int ivirt = nocc[spin] + 1; ivirt <= nocc[spin] + nvirt[spin];
+             ++ivirt) {
+          // use stored positions to make replacements
+          int pos = positions[spin][iocc - 1];
+          int original = tmp[pos];
+          tmp[pos] = (spin ? -1 : 1) * (ivirt + numcore);
+          tmp.put(slaterfile, false);
+          tmp[pos] = original;
         }
+    }
+  } else  // not uhf ... keep original order of determinants for full backward
+          // compatibility
+  {
+    for (int iocc = 1; iocc <= nocc[0]; ++iocc)
+      for (int ivirt = nocc[0] + 1; ivirt <= nocc[0] + nvirt[0]; ++ivirt) {
+        tmp[2 * shiftcore + 2 * iocc - 2] = ivirt + numcore;
+        tmp.put(slaterfile, false);  // alpha excitation
+        tmp[2 * shiftcore + 2 * iocc - 2] = iocc + numcore;
 
+        tmp[2 * shiftcore + 2 * iocc - 1] = -ivirt - numcore;
+        tmp.put(slaterfile, false);  // beta excitation
+        tmp[2 * shiftcore + 2 * iocc - 1] = -iocc - numcore;
+      }
+  }
 
-int shiftcore = include_occ? ncore:0;
-int numcore = number_occ?ncore:0;
+  // cout <<"Number of determinants generated =
+  // "<<1+nocc[0]*nvirt[0]+nocc[1]*nvirt[1]<<endl;
 
-//fermi vacuum determinant
-
-NRVec<int> positions[2];
-if(uhf)
-	{
-	positions[0].resize(nocc[0]);
-	positions[1].resize(nocc[1]);
-	}
-
-int noccmin=nocc[0]; if(nocc[1]<noccmin) noccmin=nocc[1];
-int noccmax=nocc[0]; if(nocc[1]>noccmax) noccmax=nocc[1];
-//generate part with alternating alpha and beta
-for(int iocc=1; iocc<=noccmin; ++iocc)  
-	{
-	int pos=2*shiftcore + 2*iocc-2;
-	tmp[2*shiftcore + 2*iocc-2] = iocc + numcore;
-	tmp[pos+1] = -iocc -numcore;
-	if(uhf) {positions[0][iocc-1] = pos; positions[1][iocc-1] = pos+1;}
-	}
-//and add extra alpha or beta orbitals
-if(nocc[0]!=nocc[1])
-	{
-	int spin= nocc[0]>nocc[1] ? 1 : -1;
-	for(int iocc=noccmin+1; iocc<=noccmax; ++iocc)
-		{
-		int pos=2*shiftcore + 2*noccmin + iocc-noccmin-1;
-		tmp[pos] = spin * (iocc+numcore);
-		if(uhf) positions[spin==1?0:1][iocc-1] = pos;
-		}
-	}
-
-//store the vacuum
-tmp.put(slaterfile,false);	
-
-//now generate all possible excitations
-
-//order of indices will be occ,virt
-//notice that we make replacement in place - parity of permutation to bring a given spinorb in front and after excitation to bring it back compensates
-
-if(uhf) 
-{
-for(int spin=0; spin<=1; ++spin) //first all alpha, then all beta excitations
-	{
-	for(int iocc=1; iocc<=nocc[spin]; ++iocc)
-		for(int ivirt=nocc[spin]+1; ivirt<=nocc[spin]+nvirt[spin]; ++ivirt)
-			{
-			//use stored positions to make replacements
-			int pos = positions[spin][iocc-1];
-			int original = tmp[pos];
-			tmp[pos] = (spin?-1:1)*(ivirt + numcore);
-			tmp.put(slaterfile,false);
-			tmp[pos] = original;
-			}
-	}
+  close(slaterfile);
 }
-else //not uhf ... keep original order of determinants for full backward compatibility
-{
-for(int iocc=1; iocc<=nocc[0]; ++iocc)
-	for(int ivirt=nocc[0]+1; ivirt<=nocc[0]+nvirt[0]; ++ivirt)
-		{
-		tmp[2*shiftcore + 2*iocc-2] = ivirt + numcore;
-		tmp.put(slaterfile,false); 		//alpha excitation
-		tmp[2*shiftcore + 2*iocc-2] = iocc + numcore;
-
-		tmp[2*shiftcore + 2*iocc-1] = -ivirt -numcore;
-		tmp.put(slaterfile,false);	 //beta excitation
-		tmp[2*shiftcore + 2*iocc-1] = -iocc - numcore;
-		}
-}
-
-//cout <<"Number of determinants generated = "<<1+nocc[0]*nvirt[0]+nocc[1]*nvirt[1]<<endl;
-
-close(slaterfile);
-}
-

--- a/g2g/cioverlap/g2g_cioverlap.cpp
+++ b/g2g/cioverlap/g2g_cioverlap.cpp
@@ -1,18 +1,14 @@
 #include <iostream>
 
-
-void cioverlap(double*,double*,double*,double*,
-               double*,double*,int*,double*,double*,int&,int&,int&,int&,
-               int& ndets);
+void cioverlap(double*, double*, double*, double*, double*, double*, int*,
+               double*, double*, int&, int&, int&, int&, int& ndets);
 
 using namespace std;
-extern "C" void g2g_cioverlap_(double* wfunc, double* wfunc_old,
-        double* coef, double* coef_old, double* Sbig, double* sigma,
-        int* kind_coupling, double* phases, double* phases_old,  
-        int& M, int& NCO, int& Nvirt, int& nstates, int& ndets)
-{
-   cioverlap(wfunc,wfunc_old,coef,coef_old,Sbig,sigma,
-             kind_coupling,phases,phases_old,
-             M,NCO,Nvirt,nstates,ndets);
+extern "C" void g2g_cioverlap_(double* wfunc, double* wfunc_old, double* coef,
+                               double* coef_old, double* Sbig, double* sigma,
+                               int* kind_coupling, double* phases,
+                               double* phases_old, int& M, int& NCO, int& Nvirt,
+                               int& nstates, int& ndets) {
+  cioverlap(wfunc, wfunc_old, coef, coef_old, Sbig, sigma, kind_coupling,
+            phases, phases_old, M, NCO, Nvirt, nstates, ndets);
 }
-

--- a/g2g/common.h
+++ b/g2g/common.h
@@ -39,7 +39,7 @@
 #endif
 
 #if FULL_DOUBLE
-   #define MIN_PRECISION DBL_MIN
+#define MIN_PRECISION DBL_MIN
 #else
-   #define MIN_PRECISION FLT_MIN
+#define MIN_PRECISION FLT_MIN
 #endif

--- a/g2g/cpu/compute_Wmat.cpp
+++ b/g2g/cpu/compute_Wmat.cpp
@@ -16,8 +16,7 @@
 namespace G2G {
 template <class scalar_type>
 void PointGroupCPU<scalar_type>::calc_W_mat(HostMatrix<double>& W_output_local,
-                                            CDFTVars& my_cdft_vars){
-
+                                            CDFTVars& my_cdft_vars) {
   const uint group_m = this->total_functions();
   const int npoints = this->points.size();
 
@@ -35,42 +34,45 @@ void PointGroupCPU<scalar_type>::calc_W_mat(HostMatrix<double>& W_output_local,
     const scalar_type wp = this->points[point].weight;
 
     for (int i = 0; i < my_cdft_vars.regions; i++) {
-    for (int j = 0; j < my_cdft_vars.natom(i); j++) {
-      factors_cdft(point,i) = wp * (scalar_type) (this->points[point].atom_weights(my_cdft_vars.atoms(j,i)));
-    }
+      for (int j = 0; j < my_cdft_vars.natom(i); j++) {
+        factors_cdft(point, i) =
+            wp * (scalar_type)(this->points[point].atom_weights(
+                     my_cdft_vars.atoms(j, i)));
+      }
     }
   }
 
   const int indexes = this->rmm_bigs.size();
   for (int i = 0; i < indexes; i++) {
-      int bi = this->rmm_bigs[i],
-          row = this->rmm_rows[i],
-          col = this->rmm_cols[i];
+    int bi = this->rmm_bigs[i], row = this->rmm_rows[i],
+        col = this->rmm_cols[i];
 
-      double res = 0.0;
-      double tmp = 0.0;
-      const scalar_type* fvr = function_values_transposed.row(row);
-      const scalar_type* fvc = function_values_transposed.row(col);
+    double res = 0.0;
+    double tmp = 0.0;
+    const scalar_type* fvr = function_values_transposed.row(row);
+    const scalar_type* fvc = function_values_transposed.row(col);
 
-      if (my_cdft_vars.do_chrg) {
-        for (int point = 0; point < npoints; point++) {
-        for (int j = 0; j < my_cdft_vars.regions; j++) {  
-           tmp += fvr[point] * fvc[point] * factors_cdft(point,j) * my_cdft_vars.Vc(j);
-        }
-        }
-        res += tmp;
-      }
-
-      if (my_cdft_vars.do_spin) {
-        for (int point = 0; point < npoints; point++) {
+    if (my_cdft_vars.do_chrg) {
+      for (int point = 0; point < npoints; point++) {
         for (int j = 0; j < my_cdft_vars.regions; j++) {
-          res -= fvr[point] * fvc[point] * factors_cdft(point,j) * my_cdft_vars.Vs(j);
+          tmp += fvr[point] * fvc[point] * factors_cdft(point, j) *
+                 my_cdft_vars.Vc(j);
         }
+      }
+      res += tmp;
+    }
+
+    if (my_cdft_vars.do_spin) {
+      for (int point = 0; point < npoints; point++) {
+        for (int j = 0; j < my_cdft_vars.regions; j++) {
+          res -= fvr[point] * fvc[point] * factors_cdft(point, j) *
+                 my_cdft_vars.Vs(j);
         }
-      }      
-      W_output_local(bi) += res;
+      }
+    }
+    W_output_local(bi) += res;
   }
-  
+
 #if CPU_RECOMPUTE or !GPU_KERNELS
   /* clear functions */
   function_values.deallocate();
@@ -95,4 +97,4 @@ template class PointGroup<float>;
 template class PointGroupCPU<float>;
 #endif
 
-}
+}  // namespace G2G

--- a/g2g/cpu/functions.cpp
+++ b/g2g/cpu/functions.cpp
@@ -70,7 +70,7 @@ void PointGroupCPU<scalar_type>::compute_functions(bool forces, bool gga) {
         // e^(-84) results in a number close to 10^(-37), which is the
         // minimum precision for floats. 70 was chosen in order to take
         // into account the contribution of c to t0.
-        if (expon >  70.0) continue;
+        if (expon > 70.0) continue;
         scalar_type t0 = exp(-expon) * c;
         t += t0;
         if (forces || gga) tg += t0 * a;
@@ -364,4 +364,4 @@ template class PointGroupCPU<double>;
 #else
 template class PointGroupCPU<float>;
 #endif
-}
+}  // namespace G2G

--- a/g2g/cpu/iteration.cpp
+++ b/g2g/cpu/iteration.cpp
@@ -54,11 +54,11 @@ void PointGroupCPU<scalar_type>::solve_closed(
 
 #if USE_LIBXC
 
-#define libxc_init_param \
+#define libxc_init_param                                              \
   fortran_vars.func_id, fortran_vars.func_coef, fortran_vars.nx_func, \
-  fortran_vars.nc_func, fortran_vars.nsr_id, fortran_vars.screen, \
-  XC_UNPOLARIZED
-  LibxcProxy<scalar_type,3> libxcProxy(libxc_init_param);
+      fortran_vars.nc_func, fortran_vars.nsr_id, fortran_vars.screen, \
+      XC_UNPOLARIZED
+  LibxcProxy<scalar_type, 3> libxcProxy(libxc_init_param);
 #undef libxc_init_param
 
 #endif
@@ -125,7 +125,8 @@ void PointGroupCPU<scalar_type>::solve_closed(
     reduction(+ : localenergy) schedule(static)
     for (int point = 0; point < npoints; point++) {
       scalar_type pd, tdx, tdy, tdz, tdd1x, tdd1y, tdd1z, tdd2x, tdd2y, tdd2z;
-      pd = tdx = tdy = tdz = tdd1x = tdd1y = tdd1z = tdd2x = tdd2y = tdd2z =0.0;
+      pd = tdx = tdy = tdz = tdd1x = tdd1y = tdd1z = tdd2x = tdd2y = tdd2z =
+          0.0;
 
       const scalar_type* fv = function_values.row(point);
       const scalar_type* gxv = gX.row(point);
@@ -189,11 +190,11 @@ void PointGroupCPU<scalar_type>::solve_closed(
       const vec_type3 dd2(tdd2x, tdd2y, tdd2z);
 
 #if USE_LIBXC
-    /** Libxc CPU - version **/
-    libxcProxy.doSCF(pd,dxyz,dd1,dd2,exc,corr,y2a);
+      /** Libxc CPU - version **/
+      libxcProxy.doSCF(pd, dxyz, dd1, dd2, exc, corr, y2a);
 #else
-    calc_ggaCS_in<scalar_type, 3>(pd, dxyz, dd1, dd2, exc, corr, y2a, iexch,
-                                  fortran_vars.fexc);
+      calc_ggaCS_in<scalar_type, 3>(pd, dxyz, dd1, dd2, exc, corr, y2a, iexch,
+                                    fortran_vars.fexc);
 #endif
 
       const scalar_type wp = this->points[point].weight;
@@ -217,8 +218,9 @@ void PointGroupCPU<scalar_type>::solve_closed(
         if (my_cdft_vars.do_chrg) {
           for (int i = 0; i < my_cdft_vars.regions; i++) {
             for (int j = 0; j < my_cdft_vars.natom(i); j++) {
-              factors_cdft(point,i) = wp
-                                    * (this->points[point].atom_weights(my_cdft_vars.atoms(j,i)));
+              factors_cdft(point, i) =
+                  wp *
+                  (this->points[point].atom_weights(my_cdft_vars.atoms(j, i)));
             }
           }
         }
@@ -306,7 +308,8 @@ void PointGroupCPU<scalar_type>::solve_closed(
       if (my_cdft_vars.do_chrg) {
         for (int point = 0; point < npoints; point++) {
           for (int j = 0; j < my_cdft_vars.regions; j++) {
-            res += fvr[point] * fvc[point] * factors_cdft(point,j) * my_cdft_vars.Vc(j);
+            res += fvr[point] * fvc[point] * factors_cdft(point, j) *
+                   my_cdft_vars.Vc(j);
           }
         }
       }
@@ -357,7 +360,8 @@ void PointGroupCPU<scalar_type>::solve_opened(
   // prepare rmm_input for this group
   timers.density.start();
 
-  HostMatrix<scalar_type> rmm_input_a(group_m, group_m), rmm_input_b(group_m, group_m);
+  HostMatrix<scalar_type> rmm_input_a(group_m, group_m),
+      rmm_input_b(group_m, group_m);
   get_rmm_input(rmm_input_a, rmm_input_b);
 
   vector<vec_type3> forces_a, forces_b;
@@ -402,9 +406,9 @@ void PointGroupCPU<scalar_type>::solve_opened(
           tdd2z_b;  // dxy, dxz, dyz
 
       pd_a = tdx_a = tdy_a = tdz_a = tdd1x_a = tdd1y_a = tdd1z_a = tdd2x_a =
-          tdd2y_a = tdd2z_a = (scalar_type) 0.0;
+          tdd2y_a = tdd2z_a = (scalar_type)0.0;
       pd_b = tdx_b = tdy_b = tdz_b = tdd1x_b = tdd1y_b = tdd1z_b = tdd2x_b =
-          tdd2y_b = tdd2z_b = (scalar_type) 0.0;
+          tdd2y_b = tdd2z_b = (scalar_type)0.0;
 
       // Evaluated basis functions, derivatives and gradient for the point
       const scalar_type* fv = function_values.row(point);
@@ -515,10 +519,10 @@ void PointGroupCPU<scalar_type>::solve_opened(
         // Also calculates Becke partition if needed.
         if (fortran_vars.becke) {
           for (int i = 0; i < fortran_vars.atoms; i++) {
-            becke_dens(i) += wp * (pd_a + pd_b)
-                                * (this->points[point].atom_weights(i));
-            becke_spin(i) += wp * (pd_b - pd_a)
-                                * (this->points[point].atom_weights(i));
+            becke_dens(i) +=
+                wp * (pd_a + pd_b) * (this->points[point].atom_weights(i));
+            becke_spin(i) +=
+                wp * (pd_b - pd_a) * (this->points[point].atom_weights(i));
           }
         }
       }
@@ -531,11 +535,12 @@ void PointGroupCPU<scalar_type>::solve_opened(
         if (my_cdft_vars.do_chrg || my_cdft_vars.do_spin) {
           for (int i = 0; i < my_cdft_vars.regions; i++) {
             for (int j = 0; j < my_cdft_vars.natom(i); j++) {
-              factors_cdft(point,i) = wp
-                                  * (this->points[point].atom_weights(my_cdft_vars.atoms(j,i)));
+              factors_cdft(point, i) =
+                  wp *
+                  (this->points[point].atom_weights(my_cdft_vars.atoms(j, i)));
             }
           }
-        }        
+        }
       }
     }
   }
@@ -649,16 +654,20 @@ void PointGroupCPU<scalar_type>::solve_opened(
       if (my_cdft_vars.do_chrg) {
         for (int j = 0; j < my_cdft_vars.regions; j++) {
           for (int point = 0; point < npoints; point++) {
-            res_a += fvr[point] * fvc[point] * factors_cdft(point,j) * my_cdft_vars.Vc(j);
-            res_b += fvr[point] * fvc[point] * factors_cdft(point,j) * my_cdft_vars.Vc(j);
+            res_a += fvr[point] * fvc[point] * factors_cdft(point, j) *
+                     my_cdft_vars.Vc(j);
+            res_b += fvr[point] * fvc[point] * factors_cdft(point, j) *
+                     my_cdft_vars.Vc(j);
           }
         }
       }
       if (my_cdft_vars.do_spin) {
         for (int j = 0; j < my_cdft_vars.regions; j++) {
           for (int point = 0; point < npoints; point++) {
-            res_a -= fvr[point] * fvc[point] * factors_cdft(point,j) * my_cdft_vars.Vs(j);
-            res_b += fvr[point] * fvc[point] * factors_cdft(point,j) * my_cdft_vars.Vs(j);
+            res_a -= fvr[point] * fvc[point] * factors_cdft(point, j) *
+                     my_cdft_vars.Vs(j);
+            res_b += fvr[point] * fvc[point] * factors_cdft(point, j) *
+                     my_cdft_vars.Vs(j);
           }
         }
       }
@@ -693,4 +702,4 @@ template class PointGroupCPU<double>;
 template class PointGroup<float>;
 template class PointGroupCPU<float>;
 #endif
-}
+}  // namespace G2G

--- a/g2g/cpu/weight.cpp
+++ b/g2g/cpu/weight.cpp
@@ -117,4 +117,4 @@ template class PointGroupCPU<double>;
 template class PointGroup<float>;
 template class PointGroupCPU<float>;
 #endif
-}
+}  // namespace G2G

--- a/g2g/cuda/compute_Wmat.cu
+++ b/g2g/cuda/compute_Wmat.cu
@@ -23,139 +23,140 @@
 /*******************************************************************
 ** This subroutine is similar to solve_x, and it is used only     **
 ** for CDFT calculations. It only computes the W matrix required  **
-** for Hab calculations in Mixed CDFT.                            ** 
+** for Hab calculations in Mixed CDFT.                            **
 ** Since there is no difference between open and closed shells,   **
 ** at least at this level, we only need one subroutine.           **
 *******************************************************************/
 namespace G2G {
 
-template<class scalar_type>
+template <class scalar_type>
 void PointGroupGPU<scalar_type>::calc_W_mat(HostMatrix<double>& W_output_local,
-                                            CDFTVars& my_cdft_vars){
+                                            CDFTVars& my_cdft_vars) {
+  int device;
+  cudaGetDevice(&device);
+  current_device = device;
 
-   int device;
-   cudaGetDevice(&device);
-   current_device = device;
+  /** Compute this group's functions **/
+  compute_functions(false, false);
+  uint group_m = this->total_functions();
+  uint n_points = this->number_of_points;
 
-   /** Compute this group's functions **/
-   compute_functions(false, false);
-   uint group_m  = this->total_functions();
-   uint n_points = this->number_of_points;
+  /* CUDA-related dimensions */
+  const int block_height = divUp(group_m, 2 * DENSITY_BLOCK_SIZE);
+  dim3 threadBlock(DENSITY_BLOCK_SIZE, 1, 1);
+  dim3 threadGrid(n_points, block_height, 1);
 
-   /* CUDA-related dimensions */
-   const int block_height = divUp(group_m, 2*DENSITY_BLOCK_SIZE);
-   dim3 threadBlock(DENSITY_BLOCK_SIZE,1,1);
-   dim3 threadGrid(n_points,block_height,1);
+  /* These are used for w accumulation in a given point of the grid */
+  const dim3 threadGrid_accumulate(divUp(n_points, DENSITY_ACCUM_BLOCK_SIZE), 1,
+                                   1);
+  const dim3 threadBlock_accumulate(DENSITY_ACCUM_BLOCK_SIZE, 1, 1);
 
-   /* These are used for w accumulation in a given point of the grid */
-   const dim3 threadGrid_accumulate(divUp(n_points,DENSITY_ACCUM_BLOCK_SIZE),1,1);
-   const dim3 threadBlock_accumulate(DENSITY_ACCUM_BLOCK_SIZE,1,1);
+  /** Load points from group **/
+  HostMatrix<scalar_type> point_weights_cpu(n_points, 1);
+  uint i = 0;
+  for (vector<Point>::const_iterator p = this->points.begin();
+       p != this->points.end(); ++p, ++i) {
+    point_weights_cpu(i) = p->weight;
+  }
+  CudaMatrix<scalar_type> point_weights_gpu;
+  point_weights_gpu = point_weights_cpu;
 
-   /** Load points from group **/
-   HostMatrix<scalar_type> point_weights_cpu(n_points, 1);
-   uint i = 0;
-   for (vector<Point>::const_iterator p = this->points.begin(); p != this->points.end(); ++p, ++i) {
-      point_weights_cpu(i) = p->weight;
-   }
-   CudaMatrix<scalar_type> point_weights_gpu;
-   point_weights_gpu = point_weights_cpu;
+  // Becke Weights setup.
+  CudaMatrix<scalar_type> becke_w_gpu;
 
-   // Becke Weights setup.
-   CudaMatrix<scalar_type> becke_w_gpu;
+  becke_w_gpu.resize(fortran_vars.atoms * n_points);
+  HostMatrix<scalar_type> becke_w_cpu(fortran_vars.atoms * n_points);
 
-   becke_w_gpu.resize(fortran_vars.atoms * n_points);
-   HostMatrix<scalar_type> becke_w_cpu(fortran_vars.atoms * n_points);
-
-   for (unsigned int jpoint = 0; jpoint < n_points; jpoint++) {
-   for (unsigned int iatom = 0; iatom < fortran_vars.atoms; iatom++) {
+  for (unsigned int jpoint = 0; jpoint < n_points; jpoint++) {
+    for (unsigned int iatom = 0; iatom < fortran_vars.atoms; iatom++) {
       becke_w_cpu(jpoint * fortran_vars.atoms + iatom) =
-                           (scalar_type) this->points[jpoint].atom_weights(iatom);
-   }
-   }
-   becke_w_gpu = becke_w_cpu;
+          (scalar_type)this->points[jpoint].atom_weights(iatom);
+    }
+  }
+  becke_w_gpu = becke_w_cpu;
 
-   CudaMatrix<scalar_type> cdft_factors_gpu;
-   cdft_factors_gpu.resize(my_cdft_vars.regions * n_points);
-   cdft_factors_gpu.zero();
+  CudaMatrix<scalar_type> cdft_factors_gpu;
+  cdft_factors_gpu.resize(my_cdft_vars.regions * n_points);
+  cdft_factors_gpu.zero();
 
-   CudaMatrix<uint> cdft_atoms(my_cdft_vars.atoms);
-   CudaMatrix<uint> cdft_natom(my_cdft_vars.natom);
+  CudaMatrix<uint> cdft_atoms(my_cdft_vars.atoms);
+  CudaMatrix<uint> cdft_natom(my_cdft_vars.natom);
 
-   // Here we accumulate the w for each point.
-   gpu_cdft_factors<scalar_type><<<threadGrid_accumulate, threadBlock_accumulate>>>(
-                                             cdft_factors_gpu.data, cdft_natom.data, 
-                                             cdft_atoms.data,  point_weights_gpu.data,
-                                             becke_w_gpu.data, n_points,
-                                             fortran_vars.atoms, my_cdft_vars.regions,
-                                             my_cdft_vars.max_nat);
-   
-   cudaAssertNoError("compute_cdft_weights");
-   
+  // Here we accumulate the w for each point.
+  gpu_cdft_factors<scalar_type>
+      <<<threadGrid_accumulate, threadBlock_accumulate>>>(
+          cdft_factors_gpu.data, cdft_natom.data, cdft_atoms.data,
+          point_weights_gpu.data, becke_w_gpu.data, n_points,
+          fortran_vars.atoms, my_cdft_vars.regions, my_cdft_vars.max_nat);
 
-   // We now accumulate the constraints in a single W matrix.
-   CudaMatrix<scalar_type> W_factors_gpu;
-   W_factors_gpu.resize(n_points);
-   W_factors_gpu.zero();
+  cudaAssertNoError("compute_cdft_weights");
 
-   CudaMatrix<scalar_type> cdft_Vc;
-   if (my_cdft_vars.do_chrg) {
-     HostMatrix<scalar_type> cdft_Vc_cpu(my_cdft_vars.regions);
-     cdft_Vc.resize(my_cdft_vars.regions);
-     for (unsigned int i = 0; i < my_cdft_vars.regions; i++) {
-       cdft_Vc_cpu(i) = (scalar_type) my_cdft_vars.Vc(i);
-     }
-     cdft_Vc = cdft_Vc_cpu;
-  
-     gpu_cdft_factors_accum<scalar_type><<<threadGrid_accumulate, threadBlock_accumulate>>>(
-                                           cdft_factors_gpu.data, this->number_of_points,
-                                           my_cdft_vars.regions, cdft_Vc.data, W_factors_gpu.data);
-   }
+  // We now accumulate the constraints in a single W matrix.
+  CudaMatrix<scalar_type> W_factors_gpu;
+  W_factors_gpu.resize(n_points);
+  W_factors_gpu.zero();
 
-   CudaMatrix<scalar_type> cdft_Vs;
-   if (my_cdft_vars.do_spin) {
-      HostMatrix<scalar_type> cdft_Vs_cpu(my_cdft_vars.regions);
-      cdft_Vs.resize(my_cdft_vars.regions);
-      for (unsigned int i = 0; i < my_cdft_vars.regions; i++) {
-        cdft_Vs_cpu(i) = (scalar_type) -my_cdft_vars.Vs(i);
-      }
-      cdft_Vs = cdft_Vs_cpu;
+  CudaMatrix<scalar_type> cdft_Vc;
+  if (my_cdft_vars.do_chrg) {
+    HostMatrix<scalar_type> cdft_Vc_cpu(my_cdft_vars.regions);
+    cdft_Vc.resize(my_cdft_vars.regions);
+    for (unsigned int i = 0; i < my_cdft_vars.regions; i++) {
+      cdft_Vc_cpu(i) = (scalar_type)my_cdft_vars.Vc(i);
+    }
+    cdft_Vc = cdft_Vc_cpu;
 
-      gpu_cdft_factors_accum<scalar_type><<<threadGrid_accumulate, threadBlock_accumulate>>>(
-                                             cdft_factors_gpu.data, this->number_of_points,
-                                             my_cdft_vars.regions, cdft_Vs.data, W_factors_gpu.data);
-   }
+    gpu_cdft_factors_accum<scalar_type>
+        <<<threadGrid_accumulate, threadBlock_accumulate>>>(
+            cdft_factors_gpu.data, this->number_of_points, my_cdft_vars.regions,
+            cdft_Vc.data, W_factors_gpu.data);
+  }
 
-   // This part calculates Fi * w * Fj, with w being cdft_factors.
-   // Only use enough blocks for lower triangle
-   uint blocksPerRow = divUp(group_m, RMM_BLOCK_SIZE_XY);
-   threadGrid = dim3(blocksPerRow*(blocksPerRow+1)/2);
-   threadBlock = dim3(RMM_BLOCK_SIZE_XY, RMM_BLOCK_SIZE_XY);
+  CudaMatrix<scalar_type> cdft_Vs;
+  if (my_cdft_vars.do_spin) {
+    HostMatrix<scalar_type> cdft_Vs_cpu(my_cdft_vars.regions);
+    cdft_Vs.resize(my_cdft_vars.regions);
+    for (unsigned int i = 0; i < my_cdft_vars.regions; i++) {
+      cdft_Vs_cpu(i) = (scalar_type)-my_cdft_vars.Vs(i);
+    }
+    cdft_Vs = cdft_Vs_cpu;
 
-   CudaMatrix<scalar_type> w_output_gpu(COALESCED_DIMENSION(group_m), group_m);
-   w_output_gpu.zero();
+    gpu_cdft_factors_accum<scalar_type>
+        <<<threadGrid_accumulate, threadBlock_accumulate>>>(
+            cdft_factors_gpu.data, this->number_of_points, my_cdft_vars.regions,
+            cdft_Vs.data, W_factors_gpu.data);
+  }
 
-   // For calls with a single block (pretty common with cubes) don't bother doing 
-   // the arithmetic to get block position in the matrix
-   if (blocksPerRow > 1) {
-      gpu_update_rmm<scalar_type,true><<<threadGrid, threadBlock>>>(W_factors_gpu.data, n_points,
-                                                                    w_output_gpu.data, function_values.data,
-                                                                    group_m);
-   } else {
-      gpu_update_rmm<scalar_type,false><<<threadGrid, threadBlock>>>(W_factors_gpu.data, n_points,
-                                                                     w_output_gpu.data, function_values.data,
-                                                                     group_m);
-   }
+  // This part calculates Fi * w * Fj, with w being cdft_factors.
+  // Only use enough blocks for lower triangle
+  uint blocksPerRow = divUp(group_m, RMM_BLOCK_SIZE_XY);
+  threadGrid = dim3(blocksPerRow * (blocksPerRow + 1) / 2);
+  threadBlock = dim3(RMM_BLOCK_SIZE_XY, RMM_BLOCK_SIZE_XY);
 
-   cudaAssertNoError("update_wmat");
+  CudaMatrix<scalar_type> w_output_gpu(COALESCED_DIMENSION(group_m), group_m);
+  w_output_gpu.zero();
 
-   /*** Contribute this RMM to the total RMM ***/
-   HostMatrix<scalar_type> w_output_cpu(w_output_gpu);
-   this->add_rmm_output(w_output_cpu, W_output_local);
+  // For calls with a single block (pretty common with cubes) don't bother doing
+  // the arithmetic to get block position in the matrix
+  if (blocksPerRow > 1) {
+    gpu_update_rmm<scalar_type, true><<<threadGrid, threadBlock>>>(
+        W_factors_gpu.data, n_points, w_output_gpu.data, function_values.data,
+        group_m);
+  } else {
+    gpu_update_rmm<scalar_type, false><<<threadGrid, threadBlock>>>(
+        W_factors_gpu.data, n_points, w_output_gpu.data, function_values.data,
+        group_m);
+  }
 
-   /* clear functions */
-   if(!(this->inGlobal)) {
-      function_values.deallocate();
-   }
+  cudaAssertNoError("update_wmat");
+
+  /*** Contribute this RMM to the total RMM ***/
+  HostMatrix<scalar_type> w_output_cpu(w_output_gpu);
+  this->add_rmm_output(w_output_cpu, W_output_local);
+
+  /* clear functions */
+  if (!(this->inGlobal)) {
+    function_values.deallocate();
+  }
 }
 
 #if FULL_DOUBLE
@@ -165,4 +166,4 @@ template class PointGroupGPU<double>;
 template class PointGroup<float>;
 template class PointGroupGPU<float>;
 #endif
-}
+}  // namespace G2G

--- a/g2g/cuda/iteration.cu
+++ b/g2g/cuda/iteration.cu
@@ -494,7 +494,7 @@ void PointGroupGPU<scalar_type>::solve_closed(
   /* compute forces */
   if (compute_forces) {
     //************ Repongo los valores que puse a cero antes, para las fuerzas
-    //son necesarios (o por lo mens utiles)
+    // son necesarios (o por lo mens utiles)
     for (uint i = 0; i < (group_m); i++) {
       for (uint j = 0; j < (group_m); j++) {
         if ((i >= group_m) || (j >= group_m) || (j > i)) {
@@ -1075,8 +1075,8 @@ void PointGroupGPU<scalar_type>::solve_opened(
   }
 
   // Deshago el bind de textura de rmm
-  cudaUnbindTexture(rmm_input_gpu_tex);  // Enroque el Unbind con el Free, asi
-                                         // parece mas logico. Nano
+  cudaUnbindTexture(rmm_input_gpu_tex);   // Enroque el Unbind con el Free, asi
+                                          // parece mas logico. Nano
   cudaUnbindTexture(rmm_input_gpu_tex2);  // Enroque el Unbind con el Free, asi
                                           // parece mas logico. Nano
   cudaFreeArray(cuArray1);

--- a/g2g/cuda/kernels/becke.h
+++ b/g2g/cuda/kernels/becke.h
@@ -1,12 +1,12 @@
 #define WIDTH 4
 template <class scalar_type>
-__global__ void gpu_compute_becke_os(scalar_type* becke_dens, scalar_type* becke_spin,
+__global__ void gpu_compute_becke_os(scalar_type* becke_dens,
+                                     scalar_type* becke_spin,
                                      const scalar_type* partial_density_a,
                                      const scalar_type* partial_density_b,
                                      const scalar_type* point_weights,
                                      const scalar_type* becke_w, uint points,
                                      uint atoms, int block_height) {
-  
   uint point = blockIdx.x * DENSITY_ACCUM_BLOCK_SIZE + threadIdx.x;
 
   scalar_type _partial_density_a(0.0f);
@@ -14,7 +14,7 @@ __global__ void gpu_compute_becke_os(scalar_type* becke_dens, scalar_type* becke
 
   // Checks if we are in a valid thread.
   if (!(point < points)) return;
-    
+
   for (int j = 0; j < block_height; j++) {
     const int this_row = j * points + point;
     _partial_density_a += partial_density_a[this_row];
@@ -22,41 +22,43 @@ __global__ void gpu_compute_becke_os(scalar_type* becke_dens, scalar_type* becke
   }
 
   for (int j = 0; j < atoms; j++) {
-    becke_dens[point*atoms +j] += (_partial_density_b + _partial_density_a)
-                                  * point_weights[point] * becke_w[point*atoms +j];
-    becke_spin[point*atoms +j] += (_partial_density_b - _partial_density_a) 
-                                  * point_weights[point] * becke_w[point*atoms +j];
+    becke_dens[point * atoms + j] += (_partial_density_b + _partial_density_a) *
+                                     point_weights[point] *
+                                     becke_w[point * atoms + j];
+    becke_spin[point * atoms + j] += (_partial_density_b - _partial_density_a) *
+                                     point_weights[point] *
+                                     becke_w[point * atoms + j];
   }
 }
 
 template <class scalar_type>
 __global__ void gpu_compute_becke_cs(scalar_type* becke_dens,
                                      const scalar_type* partial_density,
-                                     const scalar_type* point_weights, 
+                                     const scalar_type* point_weights,
                                      const scalar_type* becke_w, uint points,
                                      uint atoms, int block_height) {
-  
   uint point = blockIdx.x * DENSITY_ACCUM_BLOCK_SIZE + threadIdx.x;
 
   scalar_type _partial_density(0.0f);
 
   // Checks if we are in a valid thread.
   if (!(point < points)) return;
-    
+
   for (int j = 0; j < block_height; j++) {
     const int this_row = j * points + point;
     _partial_density += partial_density[this_row];
   }
-  
+
   for (int j = 0; j < atoms; j++) {
-    becke_dens[point*atoms +j] += _partial_density * point_weights[point] * becke_w[point*atoms +j];
+    becke_dens[point * atoms + j] +=
+        _partial_density * point_weights[point] * becke_w[point * atoms + j];
   }
 }
 
 template <class scalar_type>
 __global__ void gpu_cdft_factors(scalar_type* factors, const uint* reg_natom,
                                  const uint* reg_atoms,
-                                 const scalar_type* point_weights, 
+                                 const scalar_type* point_weights,
                                  const scalar_type* becke_w, uint points,
                                  uint atoms, uint regions, uint max_nat) {
   uint point = blockIdx.x * DENSITY_ACCUM_BLOCK_SIZE + threadIdx.x;
@@ -64,12 +66,12 @@ __global__ void gpu_cdft_factors(scalar_type* factors, const uint* reg_natom,
   scalar_type _accum_factor;
   // Checks if thread is valid.
   if (!(point < points)) return;
-  for (int j = 0; j < regions     ; j++) {
-    _accum_factor = (scalar_type) 0.0f;
+  for (int j = 0; j < regions; j++) {
+    _accum_factor = (scalar_type)0.0f;
     for (int i = 0; i < reg_natom[j]; i++) {
-      _accum_factor += becke_w[point*atoms + reg_atoms[j*max_nat + i]];
+      _accum_factor += becke_w[point * atoms + reg_atoms[j * max_nat + i]];
     }
-    factors[point*regions +j] = point_weights[point] * _accum_factor;
+    factors[point * regions + j] = point_weights[point] * _accum_factor;
   }
 }
 
@@ -82,6 +84,6 @@ __global__ void gpu_cdft_factors_accum(scalar_type* factors, uint points,
   // Checks if thread is valid.
   if (!(point < points)) return;
   for (int j = 0; j < regions; j++) {
-    newfacs[point] += factors[point*regions + j] * pot[j];
+    newfacs[point] += factors[point * regions + j] * pot[j];
   }
 }

--- a/g2g/cuda/kernels/energy.h
+++ b/g2g/cuda/kernels/energy.h
@@ -180,12 +180,12 @@ __global__ void gpu_compute_density(
   for (int j = 2; j <= DENSITY_BLOCK_SIZE; j = j * 2) {
     int index = position + DENSITY_BLOCK_SIZE / j;
     if (position < DENSITY_BLOCK_SIZE / j) {
-      fj_sh[position]   += fj_sh[index];
-      fgj_sh[position]  += fgj_sh[index];
+      fj_sh[position] += fj_sh[index];
+      fgj_sh[position] += fgj_sh[index];
       fh1j_sh[position] += fh1j_sh[index];
       fh2j_sh[position] += fh2j_sh[index];
     }
-    __syncthreads();  
+    __syncthreads();
   }
 
   if (threadIdx.x == 0) {

--- a/g2g/cuda/kernels/energy_open.h
+++ b/g2g/cuda/kernels/energy_open.h
@@ -66,7 +66,7 @@ __global__ void gpu_compute_density_opened(
   // Si nos vamos a pasar del bloque con el segundo puntero, hacemos que haga la
   // misma cuenta
   if (min_i > m) {
-    min_i  = min_i - DENSITY_BLOCK_SIZE;
+    min_i = min_i - DENSITY_BLOCK_SIZE;
   }
 
   if (valid_thread2) {

--- a/g2g/cuda/kernels/functions.h
+++ b/g2g/cuda/kernels/functions.h
@@ -23,9 +23,8 @@ static __device__ __host__ void compute_function(
     // e^(-84) results in a number close to 10^(-37), which is the
     // minimum precision for floats. 70 was chosen in order to take
     // into account the contribution of c to t0.
-    if (exponent >  70.0) continue;
-    scalar_type t0 =
-        exp(-exponent) * factor_c_sh[contraction];
+    if (exponent > 70.0) continue;
+    scalar_type t0 = exp(-exponent) * factor_c_sh[contraction];
     t += t0;
     if (do_forces || do_gga) tg += t0 * factor_a_sh[contraction];
     if (do_gga)

--- a/g2g/datatypes/cpu_primitives.h
+++ b/g2g/datatypes/cpu_primitives.h
@@ -3,22 +3,54 @@
 #if (CPU_KERNELS && !GPU_KERNELS)
 
 typedef unsigned int uint;
-typedef struct uint1 { uint x; } uint1;
-typedef struct uint2 { uint x, y; } uint2;
-typedef struct uint3 { uint x, y, z; } uint3;
-typedef struct uint4 { uint x, y, z, w; } uint4;
-typedef struct int1 { int x; } int1;
-typedef struct int2 { int x, y; } int2;
-typedef struct int3 { int x, y, z; } int3;
-typedef struct int4 { int x, y, z, w; } int4;
-typedef struct float1 { float x; } float1;
-typedef struct float2 { float x, y; } float2;
-typedef struct float3 { float x, y, z; } float3;
-typedef struct float4 { float x, y, z, w; } float4;
-typedef struct double1 { double x; } double1;
-typedef struct double2 { double x, y; } double2;
-typedef struct double3 { double x, y, z; } double3;
-typedef struct double4 { double x, y, z, w; } double4;
+typedef struct uint1 {
+  uint x;
+} uint1;
+typedef struct uint2 {
+  uint x, y;
+} uint2;
+typedef struct uint3 {
+  uint x, y, z;
+} uint3;
+typedef struct uint4 {
+  uint x, y, z, w;
+} uint4;
+typedef struct int1 {
+  int x;
+} int1;
+typedef struct int2 {
+  int x, y;
+} int2;
+typedef struct int3 {
+  int x, y, z;
+} int3;
+typedef struct int4 {
+  int x, y, z, w;
+} int4;
+typedef struct float1 {
+  float x;
+} float1;
+typedef struct float2 {
+  float x, y;
+} float2;
+typedef struct float3 {
+  float x, y, z;
+} float3;
+typedef struct float4 {
+  float x, y, z, w;
+} float4;
+typedef struct double1 {
+  double x;
+} double1;
+typedef struct double2 {
+  double x, y;
+} double2;
+typedef struct double3 {
+  double x, y, z;
+} double3;
+typedef struct double4 {
+  double x, y, z, w;
+} double4;
 
 static int1 make_int1(int x) {
   int1 t;

--- a/g2g/excited/calc_FXC.cpp
+++ b/g2g/excited/calc_FXC.cpp
@@ -4,368 +4,369 @@
 
 using namespace std;
 
-void calc_FXC(double* dens, double* tred, double* vsigma, 
-              double* v2rho2, double* v2rhosigma, double* v2sigma2,
-              double* v3rho3, double* v3rho2sigma, double* v3rhosigma2,
-              double* v3sigma3, double* dfac, double* tfac)
-{
-    double tr_dens[2], trgradX[2], trgradY[2], trgradZ[2];
-    tr_dens[0]=tred[0];
-    trgradX[0]=tred[1];
-    trgradY[0]=tred[2];
-    trgradZ[0]=tred[3];
-    tr_dens[1]=tred[0];
-    trgradX[1]=tred[1];
-    trgradY[1]=tred[2];
-    trgradZ[1]=tred[3];
-    double gdensX, gdensY, gdensZ;
-    gdensX = dens[1]*0.5f;
-    gdensY = dens[2]*0.5f;
-    gdensZ = dens[3]*0.5f;
-    double grad_all[4], cont_grad[4];
-    grad_all[0]=trgradX[0]*gdensX+trgradY[0]*gdensY+trgradZ[0]*gdensZ;
-    grad_all[1]=trgradX[1]*gdensX+trgradY[1]*gdensY+trgradZ[1]*gdensZ;
-    grad_all[2]=trgradX[0]*gdensX+trgradY[0]*gdensY+trgradZ[0]*gdensZ;
-    grad_all[3]=trgradX[1]*gdensX+trgradY[1]*gdensY+trgradZ[1]*gdensZ;
-    cont_grad[0]=trgradX[0]*trgradX[0]+trgradY[0]*trgradY[0]+trgradZ[0]*trgradZ[0];
-    cont_grad[1]=trgradX[1]*trgradX[1]+trgradY[1]*trgradY[1]+trgradZ[1]*trgradZ[1];
-    cont_grad[2]=trgradX[0]*trgradX[1]+trgradY[0]*trgradY[1]+trgradZ[0]*trgradZ[1];
-    cont_grad[3]=cont_grad[2];
+void calc_FXC(double* dens, double* tred, double* vsigma, double* v2rho2,
+              double* v2rhosigma, double* v2sigma2, double* v3rho3,
+              double* v3rho2sigma, double* v3rhosigma2, double* v3sigma3,
+              double* dfac, double* tfac) {
+  double tr_dens[2], trgradX[2], trgradY[2], trgradZ[2];
+  tr_dens[0] = tred[0];
+  trgradX[0] = tred[1];
+  trgradY[0] = tred[2];
+  trgradZ[0] = tred[3];
+  tr_dens[1] = tred[0];
+  trgradX[1] = tred[1];
+  trgradY[1] = tred[2];
+  trgradZ[1] = tred[3];
+  double gdensX, gdensY, gdensZ;
+  gdensX = dens[1] * 0.5f;
+  gdensY = dens[2] * 0.5f;
+  gdensZ = dens[3] * 0.5f;
+  double grad_all[4], cont_grad[4];
+  grad_all[0] = trgradX[0] * gdensX + trgradY[0] * gdensY + trgradZ[0] * gdensZ;
+  grad_all[1] = trgradX[1] * gdensX + trgradY[1] * gdensY + trgradZ[1] * gdensZ;
+  grad_all[2] = trgradX[0] * gdensX + trgradY[0] * gdensY + trgradZ[0] * gdensZ;
+  grad_all[3] = trgradX[1] * gdensX + trgradY[1] * gdensY + trgradZ[1] * gdensZ;
+  cont_grad[0] = trgradX[0] * trgradX[0] + trgradY[0] * trgradY[0] +
+                 trgradZ[0] * trgradZ[0];
+  cont_grad[1] = trgradX[1] * trgradX[1] + trgradY[1] * trgradY[1] +
+                 trgradZ[1] * trgradZ[1];
+  cont_grad[2] = trgradX[0] * trgradX[1] + trgradY[0] * trgradY[1] +
+                 trgradZ[0] * trgradZ[1];
+  cont_grad[3] = cont_grad[2];
 
-    // F NON CORE
-    double coef[20];
-    coef[0]=2.0f*(vsigma[0]*2.0f+vsigma[1]);
-    coef[1]=v2rho2[0]*2.0f+v2rho2[1];
-    coef[2]=2.0f*(v2rhosigma[0]*4.0f+v2rhosigma[1]);
-    coef[3]=2.0f*(v2rhosigma[0]*4.0f+v2rhosigma[1]);
-    coef[4]=v2rhosigma[1]*2.0f;
-    coef[5]=v2rhosigma[1]*2.0f;
-    coef[6]=4.0f*(v2sigma2[0]*8.0f+v2sigma2[1]);
-    coef[7]=2.0f*v2sigma2[1]*2.0f;
-    coef[8]=2.0f*v2sigma2[1]*2.0f;
-    coef[9]=v2sigma2[1]*4.0f;
+  // F NON CORE
+  double coef[20];
+  coef[0] = 2.0f * (vsigma[0] * 2.0f + vsigma[1]);
+  coef[1] = v2rho2[0] * 2.0f + v2rho2[1];
+  coef[2] = 2.0f * (v2rhosigma[0] * 4.0f + v2rhosigma[1]);
+  coef[3] = 2.0f * (v2rhosigma[0] * 4.0f + v2rhosigma[1]);
+  coef[4] = v2rhosigma[1] * 2.0f;
+  coef[5] = v2rhosigma[1] * 2.0f;
+  coef[6] = 4.0f * (v2sigma2[0] * 8.0f + v2sigma2[1]);
+  coef[7] = 2.0f * v2sigma2[1] * 2.0f;
+  coef[8] = 2.0f * v2sigma2[1] * 2.0f;
+  coef[9] = v2sigma2[1] * 4.0f;
 
-    double coef1, cograd1;
-    coef1=coef[0];
-    cograd1=coef1*2.0f;
-    double tr_dens1;
-    coef1=coef[1];
-    tr_dens1=coef1*tr_dens[0]*2.0f;
+  double coef1, cograd1;
+  coef1 = coef[0];
+  cograd1 = coef1 * 2.0f;
+  double tr_dens1;
+  coef1 = coef[1];
+  tr_dens1 = coef1 * tr_dens[0] * 2.0f;
 
-    double grad_all1;
-    coef1=coef[2]+coef[3];
-    tr_dens1=tr_dens1+coef1*grad_all[0];
-    grad_all1=coef1*tr_dens[0];
+  double grad_all1;
+  coef1 = coef[2] + coef[3];
+  tr_dens1 = tr_dens1 + coef1 * grad_all[0];
+  grad_all1 = coef1 * tr_dens[0];
 
-    double grad_all2;
-    coef1=coef[4]+coef[5];
-    tr_dens1=tr_dens1+coef1*grad_all[2];
-    grad_all2=coef1*tr_dens[0];
+  double grad_all2;
+  coef1 = coef[4] + coef[5];
+  tr_dens1 = tr_dens1 + coef1 * grad_all[2];
+  grad_all2 = coef1 * tr_dens[0];
 
-    coef1=coef[6];
-    grad_all1=grad_all1+coef[6]*grad_all[0]*2.0f;
-    coef1=coef[7]+coef[8];
-    grad_all1=grad_all1+coef1*grad_all[2];
-    grad_all2=grad_all2+coef1*grad_all[0];
-    coef1=coef[9];
-    grad_all2=grad_all2+coef1*grad_all[2]*2.0f;
+  coef1 = coef[6];
+  grad_all1 = grad_all1 + coef[6] * grad_all[0] * 2.0f;
+  coef1 = coef[7] + coef[8];
+  grad_all1 = grad_all1 + coef1 * grad_all[2];
+  grad_all2 = grad_all2 + coef1 * grad_all[0];
+  coef1 = coef[9];
+  grad_all2 = grad_all2 + coef1 * grad_all[2] * 2.0f;
 
-    // --AB AND BA COMPONENTS--
-    coef[10]=vsigma[1]*2.0f;
-    coef[11]=v2rho2[1];
-    coef[12]=2.0f*v2rhosigma[1];
-    coef[13]=2.0f*v2rhosigma[1];
-    coef[14]=v2rhosigma[1]*2.0f;
-    coef[15]=v2rhosigma[1]*2.0f;
-    coef[16]=4.0f*v2sigma2[1];
-    coef[17]=2.0f*v2sigma2[1]*2.0f;
-    coef[18]=2.0f*v2sigma2[1]*2.0f;
-    coef[19]=v2sigma2[1]*4.0f;
+  // --AB AND BA COMPONENTS--
+  coef[10] = vsigma[1] * 2.0f;
+  coef[11] = v2rho2[1];
+  coef[12] = 2.0f * v2rhosigma[1];
+  coef[13] = 2.0f * v2rhosigma[1];
+  coef[14] = v2rhosigma[1] * 2.0f;
+  coef[15] = v2rhosigma[1] * 2.0f;
+  coef[16] = 4.0f * v2sigma2[1];
+  coef[17] = 2.0f * v2sigma2[1] * 2.0f;
+  coef[18] = 2.0f * v2sigma2[1] * 2.0f;
+  coef[19] = v2sigma2[1] * 4.0f;
 
-    double cograd2, tr_dens2;
-    coef1=coef[10]*2.0f;
-    cograd2=coef1;
-    coef1=coef[11]*2.0f;
-    tr_dens1=tr_dens1+coef1*tr_dens[1];
-    tr_dens2=coef1*tr_dens[0];
+  double cograd2, tr_dens2;
+  coef1 = coef[10] * 2.0f;
+  cograd2 = coef1;
+  coef1 = coef[11] * 2.0f;
+  tr_dens1 = tr_dens1 + coef1 * tr_dens[1];
+  tr_dens2 = coef1 * tr_dens[0];
 
-    double grad_all3;
-    coef1=coef[12]*2.0f;
-    tr_dens1=tr_dens1+coef1*grad_all[1];
-    grad_all3=coef1*tr_dens[0];
-    coef1=coef[13]*2.0f;
-    tr_dens2=tr_dens2+coef1*grad_all[0];
-    grad_all1=grad_all1+coef1*tr_dens[1];
+  double grad_all3;
+  coef1 = coef[12] * 2.0f;
+  tr_dens1 = tr_dens1 + coef1 * grad_all[1];
+  grad_all3 = coef1 * tr_dens[0];
+  coef1 = coef[13] * 2.0f;
+  tr_dens2 = tr_dens2 + coef1 * grad_all[0];
+  grad_all1 = grad_all1 + coef1 * tr_dens[1];
 
-    double grad_all4;
-    coef1=coef[14]*2.0f;
-    tr_dens1=tr_dens1+coef1*grad_all[3];
-    grad_all4=coef1*tr_dens[0];
-    coef1=coef[15]*2.0f;
-    tr_dens2=tr_dens2+coef1*grad_all[2];
-    grad_all2=grad_all2+coef1*tr_dens[1];
+  double grad_all4;
+  coef1 = coef[14] * 2.0f;
+  tr_dens1 = tr_dens1 + coef1 * grad_all[3];
+  grad_all4 = coef1 * tr_dens[0];
+  coef1 = coef[15] * 2.0f;
+  tr_dens2 = tr_dens2 + coef1 * grad_all[2];
+  grad_all2 = grad_all2 + coef1 * tr_dens[1];
 
-    coef1=coef[16]*2.0f;
-    grad_all1=grad_all1+coef1*grad_all[1];
-    grad_all3=grad_all3+coef1*grad_all[0];
-    coef1=coef[17]*2.0f;
-    grad_all1=grad_all1+coef1*grad_all[3];
-    grad_all4=grad_all4+coef1*grad_all[0];
-    coef1=coef[18]*2.0f;
-    grad_all3=grad_all3+coef1*grad_all[2];
-    grad_all2=grad_all2+coef1*grad_all[1];
-    coef1=coef[19]*2.0f;
-    grad_all2=grad_all2+coef1*grad_all[3];
-    grad_all4=grad_all4+coef1*grad_all[2];
+  coef1 = coef[16] * 2.0f;
+  grad_all1 = grad_all1 + coef1 * grad_all[1];
+  grad_all3 = grad_all3 + coef1 * grad_all[0];
+  coef1 = coef[17] * 2.0f;
+  grad_all1 = grad_all1 + coef1 * grad_all[3];
+  grad_all4 = grad_all4 + coef1 * grad_all[0];
+  coef1 = coef[18] * 2.0f;
+  grad_all3 = grad_all3 + coef1 * grad_all[2];
+  grad_all2 = grad_all2 + coef1 * grad_all[1];
+  coef1 = coef[19] * 2.0f;
+  grad_all2 = grad_all2 + coef1 * grad_all[3];
+  grad_all4 = grad_all4 + coef1 * grad_all[2];
 
-    // --BB COMPONENTS--
-    coef[0]=2.0f*(vsigma[0]*2.0f+vsigma[1]);
-    coef[1]=v2rho2[0]*2.0f+v2rho2[1];
-    coef[2]=2.0f*(v2rhosigma[0]*4.0f+v2rhosigma[1]);
-    coef[3]=2.0f*(v2rhosigma[0]*4.0f+v2rhosigma[1]);
-    coef[4]=v2rhosigma[1]*2.0f;
-    coef[5]=v2rhosigma[1]*2.0f;
-    coef[6]=4.0f*(v2sigma2[0]*8.0f+v2sigma2[1]);
-    coef[7]=2.0f*v2sigma2[1]*2.0f;
-    coef[8]=2.0f*v2sigma2[1]*2.0f;
-    coef[9]=v2sigma2[1]*4.0f;
+  // --BB COMPONENTS--
+  coef[0] = 2.0f * (vsigma[0] * 2.0f + vsigma[1]);
+  coef[1] = v2rho2[0] * 2.0f + v2rho2[1];
+  coef[2] = 2.0f * (v2rhosigma[0] * 4.0f + v2rhosigma[1]);
+  coef[3] = 2.0f * (v2rhosigma[0] * 4.0f + v2rhosigma[1]);
+  coef[4] = v2rhosigma[1] * 2.0f;
+  coef[5] = v2rhosigma[1] * 2.0f;
+  coef[6] = 4.0f * (v2sigma2[0] * 8.0f + v2sigma2[1]);
+  coef[7] = 2.0f * v2sigma2[1] * 2.0f;
+  coef[8] = 2.0f * v2sigma2[1] * 2.0f;
+  coef[9] = v2sigma2[1] * 4.0f;
 
-    coef1=coef[0];
-    coef1=coef[1];
-    tr_dens2=tr_dens2+coef1*tr_dens[1]*2.0f;
-    coef1=coef[2]+coef[3];
-    tr_dens2=tr_dens2+coef1*grad_all[1];
-    grad_all3=grad_all3+coef1*tr_dens[1];
-    coef1=coef[4]+coef[5];
-    tr_dens2=tr_dens2+coef1*grad_all[3];
-    grad_all4=grad_all4+coef1*tr_dens[1];
-    coef1=coef[6];
-    grad_all3=grad_all3+coef1*grad_all[1]*2.0f;
-    coef1=coef[7]+coef[8];
-    grad_all3=grad_all3+coef1*grad_all[3];
-    grad_all4=grad_all4+coef1*grad_all[1];
-    coef1=coef[9];
-    grad_all4=grad_all4+coef1*grad_all[3]*2.0f;
+  coef1 = coef[0];
+  coef1 = coef[1];
+  tr_dens2 = tr_dens2 + coef1 * tr_dens[1] * 2.0f;
+  coef1 = coef[2] + coef[3];
+  tr_dens2 = tr_dens2 + coef1 * grad_all[1];
+  grad_all3 = grad_all3 + coef1 * tr_dens[1];
+  coef1 = coef[4] + coef[5];
+  tr_dens2 = tr_dens2 + coef1 * grad_all[3];
+  grad_all4 = grad_all4 + coef1 * tr_dens[1];
+  coef1 = coef[6];
+  grad_all3 = grad_all3 + coef1 * grad_all[1] * 2.0f;
+  coef1 = coef[7] + coef[8];
+  grad_all3 = grad_all3 + coef1 * grad_all[3];
+  grad_all4 = grad_all4 + coef1 * grad_all[1];
+  coef1 = coef[9];
+  grad_all4 = grad_all4 + coef1 * grad_all[3] * 2.0f;
 
-    // CONTRACTION OF FNC
-    double fncdens,fncdensX,fncdensY,fncdensZ;
-    fncdens=tr_dens1;
-    fncdensX=grad_all1*gdensX+grad_all2*gdensX+
-             cograd1*trgradX[0]+cograd2*trgradX[1];
-    fncdensY=grad_all1*gdensY+grad_all2*gdensY+
-             cograd1*trgradY[0]+cograd2*trgradY[1];
-    fncdensZ=grad_all1*gdensZ+grad_all2*gdensZ+
-             cograd1*trgradZ[0]+cograd2*trgradZ[1];
+  // CONTRACTION OF FNC
+  double fncdens, fncdensX, fncdensY, fncdensZ;
+  fncdens = tr_dens1;
+  fncdensX = grad_all1 * gdensX + grad_all2 * gdensX + cograd1 * trgradX[0] +
+             cograd2 * trgradX[1];
+  fncdensY = grad_all1 * gdensY + grad_all2 * gdensY + cograd1 * trgradY[0] +
+             cograd2 * trgradY[1];
+  fncdensZ = grad_all1 * gdensZ + grad_all2 * gdensZ + cograd1 * trgradZ[0] +
+             cograd2 * trgradZ[1];
 
-    double fnctredX,fnctredY,fnctredZ;
-    fnctredX=grad_all1*trgradX[0]+grad_all4*trgradX[1];
-    fnctredY=grad_all1*trgradY[0]+grad_all4*trgradY[1];
-    fnctredZ=grad_all1*trgradZ[0]+grad_all4*trgradZ[1];
+  double fnctredX, fnctredY, fnctredZ;
+  fnctredX = grad_all1 * trgradX[0] + grad_all4 * trgradX[1];
+  fnctredY = grad_all1 * trgradY[0] + grad_all4 * trgradY[1];
+  fnctredZ = grad_all1 * trgradZ[0] + grad_all4 * trgradZ[1];
 
-    // F CORE
-    coef[0]=2.0f*cont_grad[0];
-    coef[1]=tr_dens[0]*tr_dens[0];
-    coef[2]=2.0f*tr_dens[0]*grad_all[0];
-    coef[3]=2.0f*grad_all[0]*tr_dens[0];
-    coef[4]=grad_all[0]*tr_dens[0];
-    coef[5]=tr_dens[0]*grad_all[0];
-    coef[6]=4.0f*grad_all[0]*grad_all[0];
-    coef[7]=2.0f*grad_all[0]*grad_all[0];
-    coef[8]=2.0f*grad_all[0]*grad_all[0];
-    coef[9]=grad_all[0]*grad_all[0];
+  // F CORE
+  coef[0] = 2.0f * cont_grad[0];
+  coef[1] = tr_dens[0] * tr_dens[0];
+  coef[2] = 2.0f * tr_dens[0] * grad_all[0];
+  coef[3] = 2.0f * grad_all[0] * tr_dens[0];
+  coef[4] = grad_all[0] * tr_dens[0];
+  coef[5] = tr_dens[0] * grad_all[0];
+  coef[6] = 4.0f * grad_all[0] * grad_all[0];
+  coef[7] = 2.0f * grad_all[0] * grad_all[0];
+  coef[8] = 2.0f * grad_all[0] * grad_all[0];
+  coef[9] = grad_all[0] * grad_all[0];
 
-    // EXCHANGE
-    double Xtemp,Xtemp1;
-    Xtemp=coef[0]*v2rhosigma[0]*4.0f;
-    Xtemp1=coef[0]*2.0f*v2sigma2[0]*8.0f;
-    Xtemp=Xtemp+coef[1]*v3rho3[0]*4.0f;
-    Xtemp1=Xtemp1+coef[1]*2.0f*v3rho2sigma[0]*8.0f;
-    Xtemp=Xtemp+coef[2]*v3rho2sigma[0]*8.0f;
-    Xtemp1=Xtemp1+coef[2]*2.0f*v3rhosigma2[0]*16.0f;
-    Xtemp=Xtemp+coef[3]*v3rho2sigma[0]*8.0f;
-    Xtemp1=Xtemp1+coef[3]*2.0f*v3rhosigma2[0]*16.0f;
-    Xtemp=Xtemp+coef[6]*v3rhosigma2[0]*16.0f;
-    Xtemp1=Xtemp1+coef[6]*2.0f*v3sigma3[0]*32.0f;
+  // EXCHANGE
+  double Xtemp, Xtemp1;
+  Xtemp = coef[0] * v2rhosigma[0] * 4.0f;
+  Xtemp1 = coef[0] * 2.0f * v2sigma2[0] * 8.0f;
+  Xtemp = Xtemp + coef[1] * v3rho3[0] * 4.0f;
+  Xtemp1 = Xtemp1 + coef[1] * 2.0f * v3rho2sigma[0] * 8.0f;
+  Xtemp = Xtemp + coef[2] * v3rho2sigma[0] * 8.0f;
+  Xtemp1 = Xtemp1 + coef[2] * 2.0f * v3rhosigma2[0] * 16.0f;
+  Xtemp = Xtemp + coef[3] * v3rho2sigma[0] * 8.0f;
+  Xtemp1 = Xtemp1 + coef[3] * 2.0f * v3rhosigma2[0] * 16.0f;
+  Xtemp = Xtemp + coef[6] * v3rhosigma2[0] * 16.0f;
+  Xtemp1 = Xtemp1 + coef[6] * 2.0f * v3sigma3[0] * 32.0f;
 
-    // CORRELATION
-    double Ctemp,Ctemp1,Ctemp2;
-    Ctemp=coef[0]*v2rhosigma[1];
-    Ctemp1=coef[0]*2.0f*v2sigma2[1];
-    Ctemp2=coef[0]*v2sigma2[1]*2.0f;
-    Ctemp=Ctemp+coef[1]*v3rho3[1];
-    Ctemp1=Ctemp1+coef[1]*2.0f*v3rho2sigma[1];
-    Ctemp2=Ctemp2+coef[1]*v3rho2sigma[1]*2.0f;
-    Ctemp=Ctemp+coef[2]*v3rho2sigma[1];
-    Ctemp1=Ctemp1+coef[2]*2.0f*v3rhosigma2[1];
-    Ctemp2=Ctemp2+coef[2]*v3rhosigma2[1]*2.0f;
-    Ctemp=Ctemp+coef[3]*v3rho2sigma[1];
-    Ctemp1=Ctemp1+coef[3]*2.0f*v3rhosigma2[1];
-    Ctemp2=Ctemp2+coef[3]*v3rhosigma2[1]*2.0f;
-    Ctemp=Ctemp+coef[4]*v3rho2sigma[1]*2.0f;
-    Ctemp1=Ctemp1+coef[4]*2.0f*v3rhosigma2[1]*2.0f;
-    Ctemp2=Ctemp2+coef[4]*v3rhosigma2[1]*4.0f;
-    Ctemp=Ctemp+coef[5]*v3rho2sigma[1]*2.0f;
-    Ctemp1=Ctemp1+coef[5]*2.0f*v3rhosigma2[1]*2.0f;
-    Ctemp2=Ctemp2+coef[5]*v3rhosigma2[1]*4.0f;
-    Ctemp=Ctemp+coef[6]*v3rhosigma2[1];
-    Ctemp1=Ctemp1+coef[6]*2.0f*v3sigma3[1];
-    Ctemp2=Ctemp2+coef[6]*v3sigma3[1]*2.0f;
-    Ctemp=Ctemp+coef[7]*v3rhosigma2[1]*2.0f;
-    Ctemp1=Ctemp1+coef[7]*2.0f*v3sigma3[1]*2.0f;
-    Ctemp2=Ctemp2+coef[7]*v3sigma3[1]*4.0f;
-    Ctemp=Ctemp+coef[8]*v3rhosigma2[1]*2.0f;
-    Ctemp1=Ctemp1+coef[8]*2.0f*v3sigma3[1]*2.0f;
-    Ctemp2=Ctemp2+coef[8]*v3sigma3[1]*4.0f;
-    Ctemp=Ctemp+coef[9]*v3rhosigma2[1]*4.0f;
-    Ctemp1=Ctemp1+coef[9]*2.0f*v3sigma3[1]*4.0f;
-    Ctemp2=Ctemp2+coef[9]*v3sigma3[1]*8.0f;
+  // CORRELATION
+  double Ctemp, Ctemp1, Ctemp2;
+  Ctemp = coef[0] * v2rhosigma[1];
+  Ctemp1 = coef[0] * 2.0f * v2sigma2[1];
+  Ctemp2 = coef[0] * v2sigma2[1] * 2.0f;
+  Ctemp = Ctemp + coef[1] * v3rho3[1];
+  Ctemp1 = Ctemp1 + coef[1] * 2.0f * v3rho2sigma[1];
+  Ctemp2 = Ctemp2 + coef[1] * v3rho2sigma[1] * 2.0f;
+  Ctemp = Ctemp + coef[2] * v3rho2sigma[1];
+  Ctemp1 = Ctemp1 + coef[2] * 2.0f * v3rhosigma2[1];
+  Ctemp2 = Ctemp2 + coef[2] * v3rhosigma2[1] * 2.0f;
+  Ctemp = Ctemp + coef[3] * v3rho2sigma[1];
+  Ctemp1 = Ctemp1 + coef[3] * 2.0f * v3rhosigma2[1];
+  Ctemp2 = Ctemp2 + coef[3] * v3rhosigma2[1] * 2.0f;
+  Ctemp = Ctemp + coef[4] * v3rho2sigma[1] * 2.0f;
+  Ctemp1 = Ctemp1 + coef[4] * 2.0f * v3rhosigma2[1] * 2.0f;
+  Ctemp2 = Ctemp2 + coef[4] * v3rhosigma2[1] * 4.0f;
+  Ctemp = Ctemp + coef[5] * v3rho2sigma[1] * 2.0f;
+  Ctemp1 = Ctemp1 + coef[5] * 2.0f * v3rhosigma2[1] * 2.0f;
+  Ctemp2 = Ctemp2 + coef[5] * v3rhosigma2[1] * 4.0f;
+  Ctemp = Ctemp + coef[6] * v3rhosigma2[1];
+  Ctemp1 = Ctemp1 + coef[6] * 2.0f * v3sigma3[1];
+  Ctemp2 = Ctemp2 + coef[6] * v3sigma3[1] * 2.0f;
+  Ctemp = Ctemp + coef[7] * v3rhosigma2[1] * 2.0f;
+  Ctemp1 = Ctemp1 + coef[7] * 2.0f * v3sigma3[1] * 2.0f;
+  Ctemp2 = Ctemp2 + coef[7] * v3sigma3[1] * 4.0f;
+  Ctemp = Ctemp + coef[8] * v3rhosigma2[1] * 2.0f;
+  Ctemp1 = Ctemp1 + coef[8] * 2.0f * v3sigma3[1] * 2.0f;
+  Ctemp2 = Ctemp2 + coef[8] * v3sigma3[1] * 4.0f;
+  Ctemp = Ctemp + coef[9] * v3rhosigma2[1] * 4.0f;
+  Ctemp1 = Ctemp1 + coef[9] * 2.0f * v3sigma3[1] * 4.0f;
+  Ctemp2 = Ctemp2 + coef[9] * v3sigma3[1] * 8.0f;
 
-    coef[0]=2.0f*cont_grad[1];
-    coef[1]=tr_dens[1]*tr_dens[1];
-    coef[2]=2.0f*tr_dens[1]*grad_all[1];
-    coef[3]=2.0f*grad_all[1]*tr_dens[1];
-    coef[4]=grad_all[1]*tr_dens[1];
-    coef[5]=tr_dens[1]*grad_all[1];
-    coef[6]=4.0f*grad_all[1]*grad_all[1];
-    coef[7]=2.0f*grad_all[1]*grad_all[1];
-    coef[8]=2.0f*grad_all[1]*grad_all[1];
-    coef[9]=grad_all[1]*grad_all[1];
+  coef[0] = 2.0f * cont_grad[1];
+  coef[1] = tr_dens[1] * tr_dens[1];
+  coef[2] = 2.0f * tr_dens[1] * grad_all[1];
+  coef[3] = 2.0f * grad_all[1] * tr_dens[1];
+  coef[4] = grad_all[1] * tr_dens[1];
+  coef[5] = tr_dens[1] * grad_all[1];
+  coef[6] = 4.0f * grad_all[1] * grad_all[1];
+  coef[7] = 2.0f * grad_all[1] * grad_all[1];
+  coef[8] = 2.0f * grad_all[1] * grad_all[1];
+  coef[9] = grad_all[1] * grad_all[1];
 
-    Ctemp=Ctemp+coef[0]*v2rhosigma[1];
-    Ctemp1=Ctemp1+coef[0]*2.0f*v2sigma2[1];
-    Ctemp2=Ctemp2+coef[0]*v2sigma2[1]*2.0f;
-    Ctemp=Ctemp+coef[1]*v3rho3[1];
-    Ctemp1=Ctemp1+coef[1]*2.0f*v3rho2sigma[1];
-    Ctemp2=Ctemp2+coef[1]*v3rho2sigma[1]*2.0f;
-    Ctemp=Ctemp+coef[2]*v3rho2sigma[1];
-    Ctemp1=Ctemp1+coef[2]*2.0f*v3rhosigma2[1];
-    Ctemp2=Ctemp2+coef[2]*v3rhosigma2[1]*2.0f;
-    Ctemp=Ctemp+coef[3]*v3rho2sigma[1];
-    Ctemp1=Ctemp1+coef[3]*2.0f*v3rhosigma2[1];
-    Ctemp2=Ctemp2+coef[3]*v3rhosigma2[1]*2.0f;
-    Ctemp=Ctemp+coef[4]*v3rho2sigma[1]*2.0f;
-    Ctemp1=Ctemp1+coef[4]*2.0f*v3rhosigma2[1]*2.0f;
-    Ctemp2=Ctemp2+coef[4]*v3rhosigma2[1]*4.0f;
-    Ctemp=Ctemp+coef[5]*v3rho2sigma[1]*2.0f;
-    Ctemp1=Ctemp1+coef[5]*2.0f*v3rhosigma2[1]*2.0f;
-    Ctemp2=Ctemp2+coef[5]*v3rhosigma2[1]*4.0f;
-    Ctemp=Ctemp+coef[6]*v3rhosigma2[1];
-    Ctemp1=Ctemp1+coef[6]*2.0f*v3sigma3[1];
-    Ctemp2=Ctemp2+coef[6]*v3sigma3[1]*2.0f;
-    Ctemp=Ctemp+coef[7]*v3rhosigma2[1]*2.0f;
-    Ctemp1=Ctemp1+coef[7]*2.0f*v3sigma3[1]*2.0f;
-    Ctemp2=Ctemp2+coef[7]*v3sigma3[1]*4.0f;
-    Ctemp=Ctemp+coef[8]*v3rhosigma2[1]*2.0f;
-    Ctemp1=Ctemp1+coef[8]*2.0f*v3sigma3[1]*2.0f;
-    Ctemp2=Ctemp2+coef[8]*v3sigma3[1]*4.0f;
-    Ctemp=Ctemp+coef[9]*v3rhosigma2[1]*4.0f;
-    Ctemp1=Ctemp1+coef[9]*2.0f*v3sigma3[1]*4.0f;
-    Ctemp2=Ctemp2+coef[9]*v3sigma3[1]*8.0f;
+  Ctemp = Ctemp + coef[0] * v2rhosigma[1];
+  Ctemp1 = Ctemp1 + coef[0] * 2.0f * v2sigma2[1];
+  Ctemp2 = Ctemp2 + coef[0] * v2sigma2[1] * 2.0f;
+  Ctemp = Ctemp + coef[1] * v3rho3[1];
+  Ctemp1 = Ctemp1 + coef[1] * 2.0f * v3rho2sigma[1];
+  Ctemp2 = Ctemp2 + coef[1] * v3rho2sigma[1] * 2.0f;
+  Ctemp = Ctemp + coef[2] * v3rho2sigma[1];
+  Ctemp1 = Ctemp1 + coef[2] * 2.0f * v3rhosigma2[1];
+  Ctemp2 = Ctemp2 + coef[2] * v3rhosigma2[1] * 2.0f;
+  Ctemp = Ctemp + coef[3] * v3rho2sigma[1];
+  Ctemp1 = Ctemp1 + coef[3] * 2.0f * v3rhosigma2[1];
+  Ctemp2 = Ctemp2 + coef[3] * v3rhosigma2[1] * 2.0f;
+  Ctemp = Ctemp + coef[4] * v3rho2sigma[1] * 2.0f;
+  Ctemp1 = Ctemp1 + coef[4] * 2.0f * v3rhosigma2[1] * 2.0f;
+  Ctemp2 = Ctemp2 + coef[4] * v3rhosigma2[1] * 4.0f;
+  Ctemp = Ctemp + coef[5] * v3rho2sigma[1] * 2.0f;
+  Ctemp1 = Ctemp1 + coef[5] * 2.0f * v3rhosigma2[1] * 2.0f;
+  Ctemp2 = Ctemp2 + coef[5] * v3rhosigma2[1] * 4.0f;
+  Ctemp = Ctemp + coef[6] * v3rhosigma2[1];
+  Ctemp1 = Ctemp1 + coef[6] * 2.0f * v3sigma3[1];
+  Ctemp2 = Ctemp2 + coef[6] * v3sigma3[1] * 2.0f;
+  Ctemp = Ctemp + coef[7] * v3rhosigma2[1] * 2.0f;
+  Ctemp1 = Ctemp1 + coef[7] * 2.0f * v3sigma3[1] * 2.0f;
+  Ctemp2 = Ctemp2 + coef[7] * v3sigma3[1] * 4.0f;
+  Ctemp = Ctemp + coef[8] * v3rhosigma2[1] * 2.0f;
+  Ctemp1 = Ctemp1 + coef[8] * 2.0f * v3sigma3[1] * 2.0f;
+  Ctemp2 = Ctemp2 + coef[8] * v3sigma3[1] * 4.0f;
+  Ctemp = Ctemp + coef[9] * v3rhosigma2[1] * 4.0f;
+  Ctemp1 = Ctemp1 + coef[9] * 2.0f * v3sigma3[1] * 4.0f;
+  Ctemp2 = Ctemp2 + coef[9] * v3sigma3[1] * 8.0f;
 
-    coef[10]=cont_grad[2];
-    coef[11]=tr_dens[0]*tr_dens[1];
-    coef[12]=2.0f*tr_dens[0]*grad_all[1];
-    coef[13]=2.0f*grad_all[0]*tr_dens[1];
-    coef[14]=tr_dens[0]*grad_all[3];
-    coef[15]=grad_all[2]*tr_dens[1];
-    coef[16]=4.0f*grad_all[0]*grad_all[1];
-    coef[17]=2.0f*grad_all[0]*grad_all[3];
-    coef[18]=2.0f*grad_all[2]*grad_all[1];
-    coef[19]=grad_all[2]*grad_all[3];
+  coef[10] = cont_grad[2];
+  coef[11] = tr_dens[0] * tr_dens[1];
+  coef[12] = 2.0f * tr_dens[0] * grad_all[1];
+  coef[13] = 2.0f * grad_all[0] * tr_dens[1];
+  coef[14] = tr_dens[0] * grad_all[3];
+  coef[15] = grad_all[2] * tr_dens[1];
+  coef[16] = 4.0f * grad_all[0] * grad_all[1];
+  coef[17] = 2.0f * grad_all[0] * grad_all[3];
+  coef[18] = 2.0f * grad_all[2] * grad_all[1];
+  coef[19] = grad_all[2] * grad_all[3];
 
-    Ctemp=Ctemp+coef[10]*v2rhosigma[1]*2.0f;
-    Ctemp1=Ctemp1+coef[10]*2.0f*v2sigma2[1]*2.0f;
-    Ctemp2=Ctemp2+coef[10]*v2sigma2[1]*4.0f;
-    Ctemp=Ctemp+coef[11]*v3rho3[1];
-    Ctemp1=Ctemp1+coef[11]*2.0f*v3rho2sigma[1];
-    Ctemp2=Ctemp2+coef[11]*v3rho2sigma[1]*2.0f;
-    Ctemp=Ctemp+coef[12]*v3rho2sigma[1];
-    Ctemp1=Ctemp1+coef[12]*2.0f*v3rhosigma2[1];
-    Ctemp2=Ctemp2+coef[12]*v3rhosigma2[1]*2.0f;
-    Ctemp=Ctemp+coef[13]*v3rho2sigma[1];
-    Ctemp1=Ctemp1+coef[13]*2.0f*v3rhosigma2[1];
-    Ctemp2=Ctemp2+coef[13]*v3rhosigma2[1]*2.0f;
-    Ctemp=Ctemp+coef[14]*v3rho2sigma[1]*2.0f;
-    Ctemp1=Ctemp1+coef[14]*2.0f*v3rhosigma2[1]*2.0f;
-    Ctemp2=Ctemp2+coef[14]*v3rhosigma2[1]*4.0f;
-    Ctemp=Ctemp+coef[15]*v3rho2sigma[1]*2.0f;
-    Ctemp1=Ctemp1+coef[15]*2.0f*v3rhosigma2[1]*2.0f;
-    Ctemp2=Ctemp2+coef[15]*v3rhosigma2[1]*4.0f;
-    Ctemp=Ctemp+coef[16]*v3rhosigma2[1];
-    Ctemp1=Ctemp1+coef[16]*2.0f*v3sigma3[1];
-    Ctemp2=Ctemp2+coef[16]*v3sigma3[1]*2.0f;
-    Ctemp=Ctemp+coef[17]*v3rhosigma2[1]*2.0f;
-    Ctemp1=Ctemp1+coef[17]*2.0f*v3sigma3[1]*2.0f;
-    Ctemp2=Ctemp2+coef[17]*v3sigma3[1]*4.0f;
-    Ctemp=Ctemp+coef[18]*v3rhosigma2[1]*2.0f;
-    Ctemp1=Ctemp1+coef[18]*2.0f*v3sigma3[1]*2.0f;
-    Ctemp2=Ctemp2+coef[18]*v3sigma3[1]*4.0f;
-    Ctemp=Ctemp+coef[19]*v3rhosigma2[1]*4.0f;
-    Ctemp1=Ctemp1+coef[19]*2.0f*v3sigma3[1]*4.0f;
-    Ctemp2=Ctemp2+coef[19]*v3sigma3[1]*8.0f;
+  Ctemp = Ctemp + coef[10] * v2rhosigma[1] * 2.0f;
+  Ctemp1 = Ctemp1 + coef[10] * 2.0f * v2sigma2[1] * 2.0f;
+  Ctemp2 = Ctemp2 + coef[10] * v2sigma2[1] * 4.0f;
+  Ctemp = Ctemp + coef[11] * v3rho3[1];
+  Ctemp1 = Ctemp1 + coef[11] * 2.0f * v3rho2sigma[1];
+  Ctemp2 = Ctemp2 + coef[11] * v3rho2sigma[1] * 2.0f;
+  Ctemp = Ctemp + coef[12] * v3rho2sigma[1];
+  Ctemp1 = Ctemp1 + coef[12] * 2.0f * v3rhosigma2[1];
+  Ctemp2 = Ctemp2 + coef[12] * v3rhosigma2[1] * 2.0f;
+  Ctemp = Ctemp + coef[13] * v3rho2sigma[1];
+  Ctemp1 = Ctemp1 + coef[13] * 2.0f * v3rhosigma2[1];
+  Ctemp2 = Ctemp2 + coef[13] * v3rhosigma2[1] * 2.0f;
+  Ctemp = Ctemp + coef[14] * v3rho2sigma[1] * 2.0f;
+  Ctemp1 = Ctemp1 + coef[14] * 2.0f * v3rhosigma2[1] * 2.0f;
+  Ctemp2 = Ctemp2 + coef[14] * v3rhosigma2[1] * 4.0f;
+  Ctemp = Ctemp + coef[15] * v3rho2sigma[1] * 2.0f;
+  Ctemp1 = Ctemp1 + coef[15] * 2.0f * v3rhosigma2[1] * 2.0f;
+  Ctemp2 = Ctemp2 + coef[15] * v3rhosigma2[1] * 4.0f;
+  Ctemp = Ctemp + coef[16] * v3rhosigma2[1];
+  Ctemp1 = Ctemp1 + coef[16] * 2.0f * v3sigma3[1];
+  Ctemp2 = Ctemp2 + coef[16] * v3sigma3[1] * 2.0f;
+  Ctemp = Ctemp + coef[17] * v3rhosigma2[1] * 2.0f;
+  Ctemp1 = Ctemp1 + coef[17] * 2.0f * v3sigma3[1] * 2.0f;
+  Ctemp2 = Ctemp2 + coef[17] * v3sigma3[1] * 4.0f;
+  Ctemp = Ctemp + coef[18] * v3rhosigma2[1] * 2.0f;
+  Ctemp1 = Ctemp1 + coef[18] * 2.0f * v3sigma3[1] * 2.0f;
+  Ctemp2 = Ctemp2 + coef[18] * v3sigma3[1] * 4.0f;
+  Ctemp = Ctemp + coef[19] * v3rhosigma2[1] * 4.0f;
+  Ctemp1 = Ctemp1 + coef[19] * 2.0f * v3sigma3[1] * 4.0f;
+  Ctemp2 = Ctemp2 + coef[19] * v3sigma3[1] * 8.0f;
 
-    // **BA_TERM=AB_TERM**
-    coef[10]=cont_grad[2];
-    coef[11]=tr_dens[0]*tr_dens[1];
-    coef[12]=2.0f*tr_dens[0]*grad_all[1];
-    coef[13]=2.0f*grad_all[0]*tr_dens[1];
-    coef[14]=tr_dens[0]*grad_all[3];
-    coef[15]=grad_all[2]*tr_dens[1];
-    coef[16]=4.0f*grad_all[0]*grad_all[1];
-    coef[17]=2.0f*grad_all[0]*grad_all[3];
-    coef[18]=2.0f*grad_all[2]*grad_all[1];
-    coef[19]=grad_all[2]*grad_all[3];
+  // **BA_TERM=AB_TERM**
+  coef[10] = cont_grad[2];
+  coef[11] = tr_dens[0] * tr_dens[1];
+  coef[12] = 2.0f * tr_dens[0] * grad_all[1];
+  coef[13] = 2.0f * grad_all[0] * tr_dens[1];
+  coef[14] = tr_dens[0] * grad_all[3];
+  coef[15] = grad_all[2] * tr_dens[1];
+  coef[16] = 4.0f * grad_all[0] * grad_all[1];
+  coef[17] = 2.0f * grad_all[0] * grad_all[3];
+  coef[18] = 2.0f * grad_all[2] * grad_all[1];
+  coef[19] = grad_all[2] * grad_all[3];
 
-    Ctemp=Ctemp+coef[10]*v2rhosigma[1]*2.0f;
-    Ctemp1=Ctemp1+coef[10]*2.0f*v2sigma2[1]*2.0f;
-    Ctemp2=Ctemp2+coef[10]*v2sigma2[1]*4.0f;
-    Ctemp=Ctemp+coef[11]*v3rho3[1];
-    Ctemp1=Ctemp1+coef[11]*2.0f*v3rho2sigma[1];
-    Ctemp2=Ctemp2+coef[11]*v3rho2sigma[1]*2.0f;
-    Ctemp=Ctemp+coef[12]*v3rho2sigma[1];
-    Ctemp1=Ctemp1+coef[12]*2.0f*v3rhosigma2[1];
-    Ctemp2=Ctemp2+coef[12]*v3rhosigma2[1]*2.0f;
-    Ctemp=Ctemp+coef[13]*v3rho2sigma[1];
-    Ctemp1=Ctemp1+coef[13]*2.0f*v3rhosigma2[1];
-    Ctemp2=Ctemp2+coef[13]*v3rhosigma2[1]*2.0f;
-    Ctemp=Ctemp+coef[14]*v3rho2sigma[1]*2.0f;
-    Ctemp1=Ctemp1+coef[14]*2.0f*v3rhosigma2[1]*2.0f;
-    Ctemp2=Ctemp2+coef[14]*v3rhosigma2[1]*4.0f;
-    Ctemp=Ctemp+coef[15]*v3rho2sigma[1]*2.0f;
-    Ctemp1=Ctemp1+coef[15]*2.0f*v3rhosigma2[1]*2.0f;
-    Ctemp2=Ctemp2+coef[15]*v3rhosigma2[1]*4.0f;
-    Ctemp=Ctemp+coef[16]*v3rhosigma2[1];
-    Ctemp1=Ctemp1+coef[16]*2.0f*v3sigma3[1];
-    Ctemp2=Ctemp2+coef[16]*v3sigma3[1]*2.0f;
-    Ctemp=Ctemp+coef[17]*v3rhosigma2[1]*2.0f;
-    Ctemp1=Ctemp1+coef[17]*2.0f*v3sigma3[1]*2.0f;
-    Ctemp2=Ctemp2+coef[17]*v3sigma3[1]*4.0f;
-    Ctemp=Ctemp+coef[18]*v3rhosigma2[1]*2.0f;
-    Ctemp1=Ctemp1+coef[18]*2.0f*v3sigma3[1]*2.0f;
-    Ctemp2=Ctemp2+coef[18]*v3sigma3[1]*4.0f;
-    Ctemp=Ctemp+coef[19]*v3rhosigma2[1]*4.0f;
-    Ctemp1=Ctemp1+coef[19]*2.0f*v3sigma3[1]*4.0f;
-    Ctemp2=Ctemp2+coef[19]*v3sigma3[1]*8.0f;
+  Ctemp = Ctemp + coef[10] * v2rhosigma[1] * 2.0f;
+  Ctemp1 = Ctemp1 + coef[10] * 2.0f * v2sigma2[1] * 2.0f;
+  Ctemp2 = Ctemp2 + coef[10] * v2sigma2[1] * 4.0f;
+  Ctemp = Ctemp + coef[11] * v3rho3[1];
+  Ctemp1 = Ctemp1 + coef[11] * 2.0f * v3rho2sigma[1];
+  Ctemp2 = Ctemp2 + coef[11] * v3rho2sigma[1] * 2.0f;
+  Ctemp = Ctemp + coef[12] * v3rho2sigma[1];
+  Ctemp1 = Ctemp1 + coef[12] * 2.0f * v3rhosigma2[1];
+  Ctemp2 = Ctemp2 + coef[12] * v3rhosigma2[1] * 2.0f;
+  Ctemp = Ctemp + coef[13] * v3rho2sigma[1];
+  Ctemp1 = Ctemp1 + coef[13] * 2.0f * v3rhosigma2[1];
+  Ctemp2 = Ctemp2 + coef[13] * v3rhosigma2[1] * 2.0f;
+  Ctemp = Ctemp + coef[14] * v3rho2sigma[1] * 2.0f;
+  Ctemp1 = Ctemp1 + coef[14] * 2.0f * v3rhosigma2[1] * 2.0f;
+  Ctemp2 = Ctemp2 + coef[14] * v3rhosigma2[1] * 4.0f;
+  Ctemp = Ctemp + coef[15] * v3rho2sigma[1] * 2.0f;
+  Ctemp1 = Ctemp1 + coef[15] * 2.0f * v3rhosigma2[1] * 2.0f;
+  Ctemp2 = Ctemp2 + coef[15] * v3rhosigma2[1] * 4.0f;
+  Ctemp = Ctemp + coef[16] * v3rhosigma2[1];
+  Ctemp1 = Ctemp1 + coef[16] * 2.0f * v3sigma3[1];
+  Ctemp2 = Ctemp2 + coef[16] * v3sigma3[1] * 2.0f;
+  Ctemp = Ctemp + coef[17] * v3rhosigma2[1] * 2.0f;
+  Ctemp1 = Ctemp1 + coef[17] * 2.0f * v3sigma3[1] * 2.0f;
+  Ctemp2 = Ctemp2 + coef[17] * v3sigma3[1] * 4.0f;
+  Ctemp = Ctemp + coef[18] * v3rhosigma2[1] * 2.0f;
+  Ctemp1 = Ctemp1 + coef[18] * 2.0f * v3sigma3[1] * 2.0f;
+  Ctemp2 = Ctemp2 + coef[18] * v3sigma3[1] * 4.0f;
+  Ctemp = Ctemp + coef[19] * v3rhosigma2[1] * 4.0f;
+  Ctemp1 = Ctemp1 + coef[19] * 2.0f * v3sigma3[1] * 4.0f;
+  Ctemp2 = Ctemp2 + coef[19] * v3sigma3[1] * 8.0f;
 
-    // CONTRACTION OF FC
-    double fcdens,fcdensG1,fcdensG2,fcdgradX,fcdgradY,fcdgradZ;
-    fcdens=Xtemp+Ctemp;
-    fcdensG1=Xtemp1+Ctemp1;
-    fcdensG2=Ctemp2;
-    fcdgradX=fcdensG1*gdensX+fcdensG2*gdensX;
-    fcdgradY=fcdensG1*gdensY+fcdensG2*gdensY;
-    fcdgradZ=fcdensG1*gdensZ+fcdensG2*gdensZ;
+  // CONTRACTION OF FC
+  double fcdens, fcdensG1, fcdensG2, fcdgradX, fcdgradY, fcdgradZ;
+  fcdens = Xtemp + Ctemp;
+  fcdensG1 = Xtemp1 + Ctemp1;
+  fcdensG2 = Ctemp2;
+  fcdgradX = fcdensG1 * gdensX + fcdensG2 * gdensX;
+  fcdgradY = fcdensG1 * gdensY + fcdensG2 * gdensY;
+  fcdgradZ = fcdensG1 * gdensZ + fcdensG2 * gdensZ;
 
-    // DENSITY FACTOR
-    dfac[0]+=fcdens;
-    dfac[1]+=fnctredX+fcdgradX;
-    dfac[2]+=fnctredY+fcdgradY;
-    dfac[3]+=fnctredZ+fcdgradZ;
+  // DENSITY FACTOR
+  dfac[0] += fcdens;
+  dfac[1] += fnctredX + fcdgradX;
+  dfac[2] += fnctredY + fcdgradY;
+  dfac[3] += fnctredZ + fcdgradZ;
 
-    // TRANSITION DENSITY FACTOR
-    tfac[0]=fncdens;
-    tfac[1]=fncdensX;
-    tfac[2]=fncdensY;
-    tfac[3]=fncdensZ;
+  // TRANSITION DENSITY FACTOR
+  tfac[0] = fncdens;
+  tfac[1] = fncdensX;
+  tfac[2] = fncdensY;
+  tfac[3] = fncdensZ;
 }
-

--- a/g2g/excited/calc_FXC.h
+++ b/g2g/excited/calc_FXC.h
@@ -1,9 +1,8 @@
 #ifndef _CALC_FXC_H
 #define _CALC_FXC_H
 
-void calc_FXC(double* dens, double* tred, double* vsigma,
-              double* v2rho2, double* v2rhosigma, double* v2sigma2,
-              double* v3rho3, double* v3rho2sigma, double* v3rhosigma2,
-              double* v3sigma3, double* dfac, double* tfac);
+void calc_FXC(double* dens, double* tred, double* vsigma, double* v2rho2,
+              double* v2rhosigma, double* v2sigma2, double* v3rho3,
+              double* v3rho2sigma, double* v3rhosigma2, double* v3sigma3,
+              double* dfac, double* tfac);
 #endif
-

--- a/g2g/excited/calc_VXC.cpp
+++ b/g2g/excited/calc_VXC.cpp
@@ -4,110 +4,109 @@
 
 using namespace std;
 
-void calc_VXC(double* dens, double* diff, double* vrho,
-              double* vsigma, double* v2rho2, double* v2rhosigma,
-              double* v2sigma2, double* dfac, double* pfac, int gamma)
-{
-      // DIFFERENCE RELAXED DENSITY
-   double coef[6];
+void calc_VXC(double* dens, double* diff, double* vrho, double* vsigma,
+              double* v2rho2, double* v2rhosigma, double* v2sigma2,
+              double* dfac, double* pfac, int gamma) {
+  // DIFFERENCE RELAXED DENSITY
+  double coef[6];
 
-   double dd = diff[0];
-   double diff_derX, diff_derY, diff_derZ;
-   double dens_derX, dens_derY, dens_derZ;
+  double dd = diff[0];
+  double diff_derX, diff_derY, diff_derZ;
+  double dens_derX, dens_derY, dens_derZ;
 
-   diff_derX = diff[1];
-   diff_derY = diff[2];
-   diff_derZ = diff[3];
-   dens_derX = dens[1] * 0.5f;
-   dens_derY = dens[2] * 0.5f;
-   dens_derZ = dens[3] * 0.5f;
+  diff_derX = diff[1];
+  diff_derY = diff[2];
+  diff_derZ = diff[3];
+  dens_derX = dens[1] * 0.5f;
+  dens_derY = dens[2] * 0.5f;
+  dens_derZ = dens[3] * 0.5f;
 
-   double grad = diff_derX*dens_derX+diff_derY*dens_derY+diff_derZ*dens_derZ;
+  double grad =
+      diff_derX * dens_derX + diff_derY * dens_derY + diff_derZ * dens_derZ;
 
-   // GROUND STATE
-   double gdens,gdensG1,gdensG2;
-   gdens=vrho[0]+vrho[1];
-   gdensG1=2.0f*(vsigma[0]*2.0f+vsigma[1]);
-   gdensG2=vsigma[1]*2.0f;
+  // GROUND STATE
+  double gdens, gdensG1, gdensG2;
+  gdens = vrho[0] + vrho[1];
+  gdensG1 = 2.0f * (vsigma[0] * 2.0f + vsigma[1]);
+  gdensG2 = vsigma[1] * 2.0f;
 
-   // CONTRACTION
-   double gdensX,gdensY,gdensZ;
-   gdensX=gdensG1*dens_derX+gdensG2*dens_derX;
-   gdensY=gdensG1*dens_derY+gdensG2*dens_derY;
-   gdensZ=gdensG1*dens_derZ+gdensG2*dens_derZ;
+  // CONTRACTION
+  double gdensX, gdensY, gdensZ;
+  gdensX = gdensG1 * dens_derX + gdensG2 * dens_derX;
+  gdensY = gdensG1 * dens_derY + gdensG2 * dens_derY;
+  gdensZ = gdensG1 * dens_derZ + gdensG2 * dens_derZ;
 
-   // V NON CORE CONTRIBUTION
-   double dncV1;
-   double grad1,grad2,grad3;
-   dncV1=vrho[0]+vrho[1];
-   grad1=2.0f*(vsigma[0]*2.0f+vsigma[1]);
-   grad2=vsigma[1]*2.0f;
-   grad3=vsigma[1]*2.0f;
+  // V NON CORE CONTRIBUTION
+  double dncV1;
+  double grad1, grad2, grad3;
+  dncV1 = vrho[0] + vrho[1];
+  grad1 = 2.0f * (vsigma[0] * 2.0f + vsigma[1]);
+  grad2 = vsigma[1] * 2.0f;
+  grad3 = vsigma[1] * 2.0f;
 
-   double Vncdens,VncdensX,VncdensY,VncdensZ;
-   double VncdiffX,VncdiffY,VncdiffZ;
-   Vncdens=dncV1;
-   VncdensX=grad1*dens_derX+grad2*dens_derX;
-   VncdensY=grad1*dens_derY+grad2*dens_derY;
-   VncdensZ=grad1*dens_derZ+grad2*dens_derZ;
+  double Vncdens, VncdensX, VncdensY, VncdensZ;
+  double VncdiffX, VncdiffY, VncdiffZ;
+  Vncdens = dncV1;
+  VncdensX = grad1 * dens_derX + grad2 * dens_derX;
+  VncdensY = grad1 * dens_derY + grad2 * dens_derY;
+  VncdensZ = grad1 * dens_derZ + grad2 * dens_derZ;
 
-   VncdiffX=grad1*diff_derX+grad3*diff_derX;
-   VncdiffY=grad1*diff_derY+grad3*diff_derY;
-   VncdiffZ=grad1*diff_derZ+grad3*diff_derZ;
+  VncdiffX = grad1 * diff_derX + grad3 * diff_derX;
+  VncdiffY = grad1 * diff_derY + grad3 * diff_derY;
+  VncdiffZ = grad1 * diff_derZ + grad3 * diff_derZ;
 
-   // V CORE CONTRIBUTION
-   coef[0]=dd;
-   coef[1]=2.0f*grad;
-   coef[2]=grad;
-   coef[3]=dd;
-   coef[4]=2.0f*grad;
-   coef[5]=grad;
+  // V CORE CONTRIBUTION
+  coef[0] = dd;
+  coef[1] = 2.0f * grad;
+  coef[2] = grad;
+  coef[3] = dd;
+  coef[4] = 2.0f * grad;
+  coef[5] = grad;
 
-   double term1,term2,term3;
-   term1=coef[0]*v2rho2[0]*2.0f;
-   term2=2.0f*coef[0]*(v2rhosigma[0]*4.0f+v2rhosigma[1]);
-   term3=coef[0]*v2rhosigma[1]*2.0f;
-   term1=term1+coef[1]*(v2rhosigma[0]*4.0f+v2rhosigma[1]);
-   term2=term2+2.0f*coef[1]*(v2sigma2[0]*8.0f+v2sigma2[1]);
-   term3=term3+coef[1]*v2sigma2[1]*2.0f;
-   term1=term1+coef[2]*v2rhosigma[1]*2.0f;
-   term2=term2+2.0f*coef[2]*v2sigma2[1]*2.0f;
-   term3=term3+coef[2]*v2sigma2[1]*4.0f;
-   term1=term1+coef[3]*v2rho2[1]*2.0f;
-   term2=term2+2.0f*coef[3]*v2rhosigma[1];
-   term3=term3+coef[3]*v2rhosigma[1]*2.0f;
-   term1=term1+coef[4]*v2rhosigma[1];
-   term2=term2+2.0f*coef[4]*v2sigma2[1];
-   term3=term3+coef[4]*v2sigma2[1]*2.0f;
-   term1=term1+coef[5]*v2rhosigma[1]*2.0f;
-   term2=term2+2.0f*coef[5]*v2sigma2[1]*2.0f;
-   term3=term3+coef[5]*v2sigma2[1]*4.0f;
+  double term1, term2, term3;
+  term1 = coef[0] * v2rho2[0] * 2.0f;
+  term2 = 2.0f * coef[0] * (v2rhosigma[0] * 4.0f + v2rhosigma[1]);
+  term3 = coef[0] * v2rhosigma[1] * 2.0f;
+  term1 = term1 + coef[1] * (v2rhosigma[0] * 4.0f + v2rhosigma[1]);
+  term2 = term2 + 2.0f * coef[1] * (v2sigma2[0] * 8.0f + v2sigma2[1]);
+  term3 = term3 + coef[1] * v2sigma2[1] * 2.0f;
+  term1 = term1 + coef[2] * v2rhosigma[1] * 2.0f;
+  term2 = term2 + 2.0f * coef[2] * v2sigma2[1] * 2.0f;
+  term3 = term3 + coef[2] * v2sigma2[1] * 4.0f;
+  term1 = term1 + coef[3] * v2rho2[1] * 2.0f;
+  term2 = term2 + 2.0f * coef[3] * v2rhosigma[1];
+  term3 = term3 + coef[3] * v2rhosigma[1] * 2.0f;
+  term1 = term1 + coef[4] * v2rhosigma[1];
+  term2 = term2 + 2.0f * coef[4] * v2sigma2[1];
+  term3 = term3 + coef[4] * v2sigma2[1] * 2.0f;
+  term1 = term1 + coef[5] * v2rhosigma[1] * 2.0f;
+  term2 = term2 + 2.0f * coef[5] * v2sigma2[1] * 2.0f;
+  term3 = term3 + coef[5] * v2sigma2[1] * 4.0f;
 
-   // CONTRACTION OF VC
-   double Vcdiff,VcdiffX,VcdiffY,VcdiffZ;
-   Vcdiff=term1;
-   VcdiffX=term2*dens_derX+term3*dens_derX;
-   VcdiffY=term2*dens_derY+term3*dens_derY;
-   VcdiffZ=term2*dens_derZ+term3*dens_derZ;
-   // END V CORE
+  // CONTRACTION OF VC
+  double Vcdiff, VcdiffX, VcdiffY, VcdiffZ;
+  Vcdiff = term1;
+  VcdiffX = term2 * dens_derX + term3 * dens_derX;
+  VcdiffY = term2 * dens_derY + term3 * dens_derY;
+  VcdiffZ = term2 * dens_derZ + term3 * dens_derZ;
+  // END V CORE
 
-   if (gamma == 1) {
-     gdens=0.0f;
-     gdensX=0.0f;
-     gdensY=0.0f;
-     gdensZ=0.0f;
-   }
+  if (gamma == 1) {
+    gdens = 0.0f;
+    gdensX = 0.0f;
+    gdensY = 0.0f;
+    gdensZ = 0.0f;
+  }
 
-   // DA
-   dfac[0]=gdens+Vcdiff;
-   dfac[1]=gdensX+VncdiffX+VcdiffX;
-   dfac[2]=gdensY+VncdiffY+VcdiffY;
-   dfac[3]=gdensZ+VncdiffZ+VcdiffZ;
+  // DA
+  dfac[0] = gdens + Vcdiff;
+  dfac[1] = gdensX + VncdiffX + VcdiffX;
+  dfac[2] = gdensY + VncdiffY + VcdiffY;
+  dfac[3] = gdensZ + VncdiffZ + VcdiffZ;
 
-   // PA
-   pfac[0]=Vncdens;
-   pfac[1]=VncdensX;
-   pfac[2]=VncdensY;
-   pfac[3]=VncdensZ;
+  // PA
+  pfac[0] = Vncdens;
+  pfac[1] = VncdensX;
+  pfac[2] = VncdensY;
+  pfac[3] = VncdensZ;
 }
-

--- a/g2g/excited/calc_VXC.h
+++ b/g2g/excited/calc_VXC.h
@@ -1,8 +1,7 @@
 #ifndef _CALC_VXC_H
 #define _CALC_VXC_H
 
-void calc_VXC(double* dens, double* diff, double* vrho,
-              double* vsigma, double* v2rho2, double* v2rhosigma,
-              double* v2sigma2, double* dfac, double* pfac, int gamma);
+void calc_VXC(double* dens, double* diff, double* vrho, double* vsigma,
+              double* v2rho2, double* v2rhosigma, double* v2sigma2,
+              double* dfac, double* pfac, int gamma);
 #endif
-

--- a/g2g/excited/calc_gradients.cpp
+++ b/g2g/excited/calc_gradients.cpp
@@ -13,61 +13,66 @@
 using namespace G2G;
 using namespace std;
 
-void calc_gradients(double* dens, double* diff, double* trad,
-                    double sigma, double* dfac, double* pfac,
-                    double* tfac, int calc_fxc)
-{
-   memset(dfac,0.0f,4*sizeof(double));
-   memset(pfac,0.0f,4*sizeof(double));
-   memset(tfac,0.0f,4*sizeof(double));
+void calc_gradients(double* dens, double* diff, double* trad, double sigma,
+                    double* dfac, double* pfac, double* tfac, int calc_fxc) {
+  memset(dfac, 0.0f, 4 * sizeof(double));
+  memset(pfac, 0.0f, 4 * sizeof(double));
+  memset(tfac, 0.0f, 4 * sizeof(double));
 
 // LIBXC INITIALIZATION
-#define libxc_init_param \
-   fortran_vars.func_id, fortran_vars.func_coef, fortran_vars.nx_func, \
-   fortran_vars.nc_func, fortran_vars.nsr_id, fortran_vars.screen, \
-   XC_UNPOLARIZED
-   LibxcProxy<double,3> libxcProxy(libxc_init_param);
+#define libxc_init_param                                              \
+  fortran_vars.func_id, fortran_vars.func_coef, fortran_vars.nx_func, \
+      fortran_vars.nc_func, fortran_vars.nsr_id, fortran_vars.screen, \
+      XC_UNPOLARIZED
+  LibxcProxy<double, 3> libxcProxy(libxc_init_param);
 #undef libxc_init_param
 
-// OUTPUTS FOR LIBXC: 0 = exchange; 1 = correlation
-   double* vrho        = (double*)malloc(2*sizeof(double));
-   double* vsigma      = (double*)malloc(2*sizeof(double));
-   double* v2rho2      = (double*)malloc(2*sizeof(double));
-   double* v2rhosigma  = (double*)malloc(2*sizeof(double));
-   double* v2sigma2    = (double*)malloc(2*sizeof(double));
-   double* v3rho3      = (double*)malloc(2*sizeof(double));
-   double* v3rho2sigma = (double*)malloc(2*sizeof(double));
-   double* v3rhosigma2 = (double*)malloc(2*sizeof(double));
-   double* v3sigma3    = (double*)malloc(2*sizeof(double));
+  // OUTPUTS FOR LIBXC: 0 = exchange; 1 = correlation
+  double* vrho = (double*)malloc(2 * sizeof(double));
+  double* vsigma = (double*)malloc(2 * sizeof(double));
+  double* v2rho2 = (double*)malloc(2 * sizeof(double));
+  double* v2rhosigma = (double*)malloc(2 * sizeof(double));
+  double* v2sigma2 = (double*)malloc(2 * sizeof(double));
+  double* v3rho3 = (double*)malloc(2 * sizeof(double));
+  double* v3rho2sigma = (double*)malloc(2 * sizeof(double));
+  double* v3rhosigma2 = (double*)malloc(2 * sizeof(double));
+  double* v3sigma3 = (double*)malloc(2 * sizeof(double));
 
-#define libxc_parameter \
-   dens, &sigma, vrho, vsigma, v2rho2, v2rhosigma, v2sigma2, \
-   v3rho3, v3rho2sigma, v3rhosigma2, v3sigma3
-   libxcProxy.terms_derivs(libxc_parameter);
+#define libxc_parameter                                             \
+  dens, &sigma, vrho, vsigma, v2rho2, v2rhosigma, v2sigma2, v3rho3, \
+      v3rho2sigma, v3rhosigma2, v3sigma3
+  libxcProxy.terms_derivs(libxc_parameter);
 #undef libxc_parameter
 
 #define VXC_parameter \
-   dens, diff, vrho, vsigma, v2rho2, v2rhosigma, v2sigma2, \
-   dfac, pfac, calc_fxc
-   calc_VXC(VXC_parameter);
+  dens, diff, vrho, vsigma, v2rho2, v2rhosigma, v2sigma2, dfac, pfac, calc_fxc
+  calc_VXC(VXC_parameter);
 #undef VXC_parameter
 
-   if ( calc_fxc == 0 ) {
-   #define FXC_parameter \
-      dens, trad, vsigma, v2rho2, v2rhosigma, v2sigma2, \
-      v3rho3, v3rho2sigma, v3rhosigma2, v3sigma3, dfac, tfac
-      calc_FXC(FXC_parameter);
-   #undef FXC_parameter
-   }
+  if (calc_fxc == 0) {
+#define FXC_parameter                                                    \
+  dens, trad, vsigma, v2rho2, v2rhosigma, v2sigma2, v3rho3, v3rho2sigma, \
+      v3rhosigma2, v3sigma3, dfac, tfac
+    calc_FXC(FXC_parameter);
+#undef FXC_parameter
+  }
 
-   free(vrho); vrho = NULL;
-   free(vsigma); vsigma = NULL;
-   free(v2rho2); v2rho2 = NULL;
-   free(v2rhosigma); v2rhosigma = NULL;
-   free(v2sigma2); v2sigma2 = NULL;
-   free(v3rho3); v3rho3 = NULL;
-   free(v3rho2sigma); v3rho2sigma = NULL;
-   free(v3rhosigma2); v3rhosigma2 = NULL;
-   free(v3sigma3); v3sigma3 = NULL;
+  free(vrho);
+  vrho = NULL;
+  free(vsigma);
+  vsigma = NULL;
+  free(v2rho2);
+  v2rho2 = NULL;
+  free(v2rhosigma);
+  v2rhosigma = NULL;
+  free(v2sigma2);
+  v2sigma2 = NULL;
+  free(v3rho3);
+  v3rho3 = NULL;
+  free(v3rho2sigma);
+  v3rho2sigma = NULL;
+  free(v3rhosigma2);
+  v3rhosigma2 = NULL;
+  free(v3sigma3);
+  v3sigma3 = NULL;
 }
-

--- a/g2g/excited/cuda/ES_compute_partial.h
+++ b/g2g/excited/cuda/ES_compute_partial.h
@@ -1,10 +1,8 @@
 template <class scalar_type, bool compute_energy, bool compute_factor, bool lda>
-__global__ void ES_compute_partial(uint points,
-                                const scalar_type* function_values, uint m,
-                                const vec_type<scalar_type, 4>* gradient_values,
-                                scalar_type* out_partial_tred, vec_type<scalar_type, 4>* out_tredxyz)
-{
-
+__global__ void ES_compute_partial(
+    uint points, const scalar_type* function_values, uint m,
+    const vec_type<scalar_type, 4>* gradient_values,
+    scalar_type* out_partial_tred, vec_type<scalar_type, 4>* out_tredxyz) {
   uint point = blockIdx.x;
   uint i = threadIdx.x + blockIdx.y * 2 * DENSITY_BLOCK_SIZE;
   uint i2 = i + DENSITY_BLOCK_SIZE;
@@ -12,9 +10,11 @@ __global__ void ES_compute_partial(uint points,
   bool valid_thread = (i < m);
   bool valid_thread2 = (i2 < m);
 
-// Transition density variables
-  scalar_type z, z2; z = z2 = 0.0f;
-  vec_type<scalar_type, 3> z3, z32; z3 = z32 = vec_type<scalar_type, 3>(0.0f, 0.0f, 0.0f);
+  // Transition density variables
+  scalar_type z, z2;
+  z = z2 = 0.0f;
+  vec_type<scalar_type, 3> z3, z32;
+  z3 = z32 = vec_type<scalar_type, 3>(0.0f, 0.0f, 0.0f);
 
   int position = threadIdx.x;
 
@@ -35,7 +35,7 @@ __global__ void ES_compute_partial(uint points,
     if (bj + position < m) {
       fj_sh[position] = function_values[(m)*point + (bj + position)];
       fgj_sh[position] = vec_type<scalar_type, 3>(
-                       gradient_values[(m)*point + (bj + position)]);
+          gradient_values[(m)*point + (bj + position)]);
     }
     __syncthreads();
     scalar_type fjreg;
@@ -50,7 +50,7 @@ __global__ void ES_compute_partial(uint points,
 
           // Transition density
           rdm_this_thread = fetch(tred_gpu_tex, (float)(bj + j), (float)i);
-          z  += rdm_this_thread * fjreg;
+          z += rdm_this_thread * fjreg;
           z3 += fgjreg * rdm_this_thread;
         }
 
@@ -59,16 +59,16 @@ __global__ void ES_compute_partial(uint points,
 
           // Transition density
           rdm_this_thread2 = fetch(tred_gpu_tex, (float)(bj + j), (float)i2);
-          z2  += rdm_this_thread2 * fjreg;
+          z2 += rdm_this_thread2 * fjreg;
           z32 += fgjreg * rdm_this_thread2;
         }
-      } // loop j
-    } // valid tread
-  } // loop bj
+      }  // loop j
+    }    // valid tread
+  }      // loop bj
 
   // Transition density
   scalar_type partial_tred(0.0f);
-  vec_type<scalar_type, 3> tredxyz = vec_type<scalar_type, 3>(0.0f,0.0f,0.0f);
+  vec_type<scalar_type, 3> tredxyz = vec_type<scalar_type, 3>(0.0f, 0.0f, 0.0f);
 
   if (valid_thread) {
     scalar_type Fi = function_values[(m)*point + i];
@@ -85,11 +85,11 @@ __global__ void ES_compute_partial(uint points,
       // Transition density
       partial_tred += Fi2 * z2;
       tredxyz += Fgi2 * z2 + z32 * Fi2;
-    } // valid thread 2
-  } // valid thread
+    }  // valid thread 2
+  }    // valid thread
 
   __syncthreads();
-// Transition density
+  // Transition density
   fj_sh_tred[position] = partial_tred;
   fgj_sh_tred[position] = tredxyz;
   __syncthreads();
@@ -97,7 +97,6 @@ __global__ void ES_compute_partial(uint points,
   for (int j = 2; j <= DENSITY_BLOCK_SIZE; j = j * 2) {
     int index = position + DENSITY_BLOCK_SIZE / j;
     if (position < DENSITY_BLOCK_SIZE / j) {
-
       // Transition density
       fj_sh_tred[position] += fj_sh_tred[index];
       fgj_sh_tred[position] += fgj_sh_tred[index];

--- a/g2g/excited/cuda/accumulate_values.h
+++ b/g2g/excited/cuda/accumulate_values.h
@@ -1,65 +1,59 @@
-template<class T, bool compute_energy, bool compute_factor, bool lda>
-__global__ void accumulate_values(
-                uint points, int block_height,
-                T* partial_density_in,
-                G2G::vec_type<T,WIDTH>* dxyz_in,
-                T* accumulated_density,
-                G2G::vec_type<T,WIDTH>* dxyz_accum)
-{
+template <class T, bool compute_energy, bool compute_factor, bool lda>
+__global__ void accumulate_values(uint points, int block_height,
+                                  T* partial_density_in,
+                                  G2G::vec_type<T, WIDTH>* dxyz_in,
+                                  T* accumulated_density,
+                                  G2G::vec_type<T, WIDTH>* dxyz_accum) {
   uint point = blockIdx.x * DENSITY_ACCUM_BLOCK_SIZE + threadIdx.x;
-  //uint point = blockIdx.x * blockDim.x + threadIdx.x;
+  // uint point = blockIdx.x * blockDim.x + threadIdx.x;
 
   T _partial_density(0.0f);
-  G2G::vec_type<T,WIDTH> _dxyz;
-  _dxyz = G2G::vec_type<T,WIDTH>(0.0f,0.0f,0.0f,0.0f);
+  G2G::vec_type<T, WIDTH> _dxyz;
+  _dxyz = G2G::vec_type<T, WIDTH>(0.0f, 0.0f, 0.0f, 0.0f);
 
   bool valid_thread = (point < points);
 
   if (valid_thread) {
-    for(int j =0 ; j<block_height; j++) {
-      const int this_row = j*points+point;
+    for (int j = 0; j < block_height; j++) {
+      const int this_row = j * points + point;
       _partial_density += partial_density_in[this_row];
       _dxyz += dxyz_in[this_row];
-    } // END J LOOP
+    }  // END J LOOP
 
     accumulated_density[point] = _partial_density;
     dxyz_accum[point] = _dxyz;
-  } // END VALID THREAD
+  }  // END VALID THREAD
 }
 
-template<class T, bool compute_energy, bool compute_factor, bool lda>
-__global__ void accumulate_values(
-                uint points, int block_height,
-                T* partial_tred_in,
-                T* partial_diff_in,
-                G2G::vec_type<T,WIDTH>* tredxyz_in,
-                G2G::vec_type<T,WIDTH>* diffxyz_in,
-                T* accumulated_tred,
-                T* accumulated_diff,
-                G2G::vec_type<T,WIDTH>* tredxyz_accum,
-                G2G::vec_type<T,WIDTH>* diffxyz_accum)
-{
+template <class T, bool compute_energy, bool compute_factor, bool lda>
+__global__ void accumulate_values(uint points, int block_height,
+                                  T* partial_tred_in, T* partial_diff_in,
+                                  G2G::vec_type<T, WIDTH>* tredxyz_in,
+                                  G2G::vec_type<T, WIDTH>* diffxyz_in,
+                                  T* accumulated_tred, T* accumulated_diff,
+                                  G2G::vec_type<T, WIDTH>* tredxyz_accum,
+                                  G2G::vec_type<T, WIDTH>* diffxyz_accum) {
   uint point = blockIdx.x * DENSITY_ACCUM_BLOCK_SIZE + threadIdx.x;
-  //uint point = blockIdx.x * blockDim.x + threadIdx.x;
+  // uint point = blockIdx.x * blockDim.x + threadIdx.x;
 
   T _partial_tred(0.0f);
   T _partial_diff(0.0f);
-  G2G::vec_type<T,WIDTH> _tredxyz;
-  G2G::vec_type<T,WIDTH> _diffxyz;
-  _tredxyz = _diffxyz = G2G::vec_type<T,WIDTH>(0.0f,0.0f,0.0f,0.0f);
+  G2G::vec_type<T, WIDTH> _tredxyz;
+  G2G::vec_type<T, WIDTH> _diffxyz;
+  _tredxyz = _diffxyz = G2G::vec_type<T, WIDTH>(0.0f, 0.0f, 0.0f, 0.0f);
 
   bool valid_thread = (point < points);
 
   if (valid_thread) {
-    for(int j =0 ; j<block_height; j++) {
-      const int this_row = j*points+point;
+    for (int j = 0; j < block_height; j++) {
+      const int this_row = j * points + point;
       // TRANSITION density
       _partial_tred += partial_tred_in[this_row];
       _tredxyz += tredxyz_in[this_row];
       // Difference density
       _partial_diff += partial_diff_in[this_row];
       _diffxyz += diffxyz_in[this_row];
-    } // END J LOOP
+    }  // END J LOOP
 
     // Accumulate TRANSITION density
     accumulated_tred[point] = _partial_tred;
@@ -67,5 +61,5 @@ __global__ void accumulate_values(
     // Accumulate DIFFERENCE density
     accumulated_diff[point] = _partial_diff;
     diffxyz_accum[point] = _diffxyz;
-  } // END VALID THREAD
+  }  // END VALID THREAD
 }

--- a/g2g/excited/cuda/fake_cuda.cu
+++ b/g2g/excited/cuda/fake_cuda.cu
@@ -16,23 +16,26 @@ using namespace std;
 
 namespace G2G {
 
-template<class scalar_type>
-void PointGroupGPU<scalar_type>::lr_closed_init() { }
+template <class scalar_type>
+void PointGroupGPU<scalar_type>::lr_closed_init() {}
 
-template<class scalar_type>
-void PointGroupGPU<scalar_type>::solve_closed_lr(double* T,HostMatrix<double>& Fock) { }
+template <class scalar_type>
+void PointGroupGPU<scalar_type>::solve_closed_lr(double* T,
+                                                 HostMatrix<double>& Fock) {}
 
 template <class scalar_type>
 void PointGroupGPU<scalar_type>::get_tred_input(
-     HostMatrix<scalar_type>& tred_input, HostMatrix<double>& source) const { }
+    HostMatrix<scalar_type>& tred_input, HostMatrix<double>& source) const {}
 
-template<class scalar_type>
- void PointGroupGPU<scalar_type>::
-               solve_3rd_der(double* Tmat,HostMatrix<double>& Fock,int DER) { }
+template <class scalar_type>
+void PointGroupGPU<scalar_type>::solve_3rd_der(double* Tmat,
+                                               HostMatrix<double>& Fock,
+                                               int DER) {}
 
-template<class scalar_type> void PointGroupGPU<scalar_type>::
-        solve_for_exc(double*P,double*V,HostMatrix<double>& F, int MET) { }
-
+template <class scalar_type>
+void PointGroupGPU<scalar_type>::solve_for_exc(double* P, double* V,
+                                               HostMatrix<double>& F, int MET) {
+}
 
 #if FULL_DOUBLE
 template class PointGroup<double>;
@@ -41,5 +44,4 @@ template class PointGroupGPU<double>;
 template class PointGroup<float>;
 template class PointGroupGPU<float>;
 #endif
-}
-
+}  // namespace G2G

--- a/g2g/excited/cuda/g2g_calcgradXC.cu
+++ b/g2g/excited/cuda/g2g_calcgradXC.cu
@@ -14,7 +14,7 @@
 #include "../../timer.h"
 
 #if USE_LIBXC
- #include "../../libxc/libxc_accumulate_point.h"
+#include "../../libxc/libxc_accumulate_point.h"
 #endif
 
 #define POINTS_BLOCK_SIZE 256
@@ -37,237 +37,296 @@ texture<float, 2, cudaReadModeElementType> diff_gpu_for_tex;
 #include "../../cuda/kernels/transpose.h"
 #include "ES_compute_for_partial.h"
 
-template<class scalar_type> void PointGroupGPU<scalar_type>::
-        solve_for_exc(double*P,double*V,HostMatrix<double>& F,int MET)
-{
-   uint group_m = this->total_functions();
-   bool lda = false;
-   bool compute_forces = false;
-   compute_functions(compute_forces, !lda);
+template <class scalar_type>
+void PointGroupGPU<scalar_type>::solve_for_exc(double* P, double* V,
+                                               HostMatrix<double>& F, int MET) {
+  uint group_m = this->total_functions();
+  bool lda = false;
+  bool compute_forces = false;
+  compute_functions(compute_forces, !lda);
 
-// Point weights on CPU and GPU
-   CudaMatrix<scalar_type> point_weights_gpu;
-   HostMatrix<scalar_type> point_weights_cpu(this->number_of_points, 1);
-   uint i = 0;
-   for (vector<Point>::const_iterator p = this->points.begin(); p != this->points.end(); ++p, ++i) {
-     point_weights_cpu(i) = p->weight;
-   }
-   point_weights_gpu = point_weights_cpu;
-   point_weights_cpu.deallocate();
+  // Point weights on CPU and GPU
+  CudaMatrix<scalar_type> point_weights_gpu;
+  HostMatrix<scalar_type> point_weights_cpu(this->number_of_points, 1);
+  uint i = 0;
+  for (vector<Point>::const_iterator p = this->points.begin();
+       p != this->points.end(); ++p, ++i) {
+    point_weights_cpu(i) = p->weight;
+  }
+  point_weights_gpu = point_weights_cpu;
+  point_weights_cpu.deallocate();
 
-// Variables to kernels: gpu_compute
-   dim3 threadBlock, threadGrid;
-   const int block_height= divUp(group_m, 2*DENSITY_BLOCK_SIZE);
-   threadBlock = dim3(DENSITY_BLOCK_SIZE,1,1); // Hay que asegurarse que la cantidad de funciones este en rango
-   threadGrid = dim3(this->number_of_points,block_height,1);
+  // Variables to kernels: gpu_compute
+  dim3 threadBlock, threadGrid;
+  const int block_height = divUp(group_m, 2 * DENSITY_BLOCK_SIZE);
+  threadBlock =
+      dim3(DENSITY_BLOCK_SIZE, 1,
+           1);  // Hay que asegurarse que la cantidad de funciones este en rango
+  threadGrid = dim3(this->number_of_points, block_height, 1);
 
-// Partial Transition Density GPU
-   CudaMatrix<scalar_type> partial_tred_gpu;
-   CudaMatrix< vec_type<scalar_type,4> > tredxyz_gpu;
-   partial_tred_gpu.resize(COALESCED_DIMENSION(this->number_of_points), block_height);
-   tredxyz_gpu.resize(COALESCED_DIMENSION(this->number_of_points),block_height);
+  // Partial Transition Density GPU
+  CudaMatrix<scalar_type> partial_tred_gpu;
+  CudaMatrix<vec_type<scalar_type, 4>> tredxyz_gpu;
+  partial_tred_gpu.resize(COALESCED_DIMENSION(this->number_of_points),
+                          block_height);
+  tredxyz_gpu.resize(COALESCED_DIMENSION(this->number_of_points), block_height);
 
-// Partial Difference Density GPU
-   CudaMatrix<scalar_type> partial_diff_gpu;
-   CudaMatrix< vec_type<scalar_type,4> > diffxyz_gpu;
-   partial_diff_gpu.resize(COALESCED_DIMENSION(this->number_of_points), block_height);
-   diffxyz_gpu.resize(COALESCED_DIMENSION(this->number_of_points),block_height);
+  // Partial Difference Density GPU
+  CudaMatrix<scalar_type> partial_diff_gpu;
+  CudaMatrix<vec_type<scalar_type, 4>> diffxyz_gpu;
+  partial_diff_gpu.resize(COALESCED_DIMENSION(this->number_of_points),
+                          block_height);
+  diffxyz_gpu.resize(COALESCED_DIMENSION(this->number_of_points), block_height);
 
-// Accumulate Values
-   CudaMatrix<scalar_type> tred_accum_gpu;
-   CudaMatrix< vec_type<scalar_type,4> > tredxyz_accum_gpu;
-   tred_accum_gpu.resize(COALESCED_DIMENSION(this->number_of_points));
-   tredxyz_accum_gpu.resize(COALESCED_DIMENSION(this->number_of_points));
+  // Accumulate Values
+  CudaMatrix<scalar_type> tred_accum_gpu;
+  CudaMatrix<vec_type<scalar_type, 4>> tredxyz_accum_gpu;
+  tred_accum_gpu.resize(COALESCED_DIMENSION(this->number_of_points));
+  tredxyz_accum_gpu.resize(COALESCED_DIMENSION(this->number_of_points));
 
-   CudaMatrix<scalar_type> diff_accum_gpu;
-   CudaMatrix< vec_type<scalar_type,4> > diffxyz_accum_gpu;
-   diff_accum_gpu.resize(COALESCED_DIMENSION(this->number_of_points));
-   diffxyz_accum_gpu.resize(COALESCED_DIMENSION(this->number_of_points));
+  CudaMatrix<scalar_type> diff_accum_gpu;
+  CudaMatrix<vec_type<scalar_type, 4>> diffxyz_accum_gpu;
+  diff_accum_gpu.resize(COALESCED_DIMENSION(this->number_of_points));
+  diffxyz_accum_gpu.resize(COALESCED_DIMENSION(this->number_of_points));
 
-// Variables to kernels: accumulate density
-   const dim3 threadGrid_accumulate(divUp(this->number_of_points,DENSITY_ACCUM_BLOCK_SIZE),1,1);
-   const dim3 threadBlock_accumulate(DENSITY_ACCUM_BLOCK_SIZE,1,1);
+  // Variables to kernels: accumulate density
+  const dim3 threadGrid_accumulate(
+      divUp(this->number_of_points, DENSITY_ACCUM_BLOCK_SIZE), 1, 1);
+  const dim3 threadBlock_accumulate(DENSITY_ACCUM_BLOCK_SIZE, 1, 1);
 
-// Transpose functions and gradients
-   #define BLOCK_DIM 16
-   int transposed_width = COALESCED_DIMENSION(this->number_of_points);
-   dim3 transpose_grid(transposed_width / BLOCK_DIM, divUp((group_m),BLOCK_DIM), 1);
-   dim3 transpose_threads(BLOCK_DIM, BLOCK_DIM, 1);
+  // Transpose functions and gradients
+#define BLOCK_DIM 16
+  int transposed_width = COALESCED_DIMENSION(this->number_of_points);
+  dim3 transpose_grid(transposed_width / BLOCK_DIM, divUp((group_m), BLOCK_DIM),
+                      1);
+  dim3 transpose_threads(BLOCK_DIM, BLOCK_DIM, 1);
 
-   CudaMatrix<scalar_type> function_values_transposed;
-   CudaMatrix<vec_type<scalar_type,4> > gradient_values_transposed;
-   function_values_transposed.resize(group_m, COALESCED_DIMENSION(this->number_of_points));
-   gradient_values_transposed.resize( group_m,COALESCED_DIMENSION(this->number_of_points));
+  CudaMatrix<scalar_type> function_values_transposed;
+  CudaMatrix<vec_type<scalar_type, 4>> gradient_values_transposed;
+  function_values_transposed.resize(
+      group_m, COALESCED_DIMENSION(this->number_of_points));
+  gradient_values_transposed.resize(
+      group_m, COALESCED_DIMENSION(this->number_of_points));
 
-   transpose<<<transpose_grid, transpose_threads>>> (function_values_transposed.data,
-       function_values.data, COALESCED_DIMENSION(this->number_of_points), group_m);
+  transpose<<<transpose_grid, transpose_threads>>>(
+      function_values_transposed.data, function_values.data,
+      COALESCED_DIMENSION(this->number_of_points), group_m);
 
-   transpose<<<transpose_grid, transpose_threads>>> (gradient_values_transposed.data,
-       gradient_values.data, COALESCED_DIMENSION(this->number_of_points), group_m );
+  transpose<<<transpose_grid, transpose_threads>>>(
+      gradient_values_transposed.data, gradient_values.data,
+      COALESCED_DIMENSION(this->number_of_points), group_m);
 
-   int M = fortran_vars.m;
-// FORM reduce Transition density
-   HostMatrix<scalar_type> tred_cpu(COALESCED_DIMENSION(group_m), group_m+DENSITY_BLOCK_SIZE);
+  int M = fortran_vars.m;
+  // FORM reduce Transition density
+  HostMatrix<scalar_type> tred_cpu(COALESCED_DIMENSION(group_m),
+                                   group_m + DENSITY_BLOCK_SIZE);
 
-// FORM reduce Difference density
-   HostMatrix<scalar_type> diff_cpu(COALESCED_DIMENSION(group_m), group_m+DENSITY_BLOCK_SIZE);
+  // FORM reduce Difference density
+  HostMatrix<scalar_type> diff_cpu(COALESCED_DIMENSION(group_m),
+                                   group_m + DENSITY_BLOCK_SIZE);
 
-   HostMatrix<double> Pbig(M*(M+1)/2);
-   HostMatrix<double> Vbig(M*(M+1)/2);
-   int index = 0;
-   int row, col;
-   for(row=0;row<M;row++) {
-     Pbig(index) = P[row*M+row];
-     Vbig(index) = V[row*M+row];
-     index += 1;
-     for(col=row+1;col<M;col++) {
-        Pbig(index) = P[row*M+col] + P[col*M+row];
-        Vbig(index) = V[row*M+col] + V[col*M+row];
-        index += 1;
-     }
-   }
-   get_tred_input(tred_cpu,Vbig);
-   get_tred_input(diff_cpu,Pbig);
+  HostMatrix<double> Pbig(M * (M + 1) / 2);
+  HostMatrix<double> Vbig(M * (M + 1) / 2);
+  int index = 0;
+  int row, col;
+  for (row = 0; row < M; row++) {
+    Pbig(index) = P[row * M + row];
+    Vbig(index) = V[row * M + row];
+    index += 1;
+    for (col = row + 1; col < M; col++) {
+      Pbig(index) = P[row * M + col] + P[col * M + row];
+      Vbig(index) = V[row * M + col] + V[col * M + row];
+      index += 1;
+    }
+  }
+  get_tred_input(tred_cpu, Vbig);
+  get_tred_input(diff_cpu, Pbig);
 
-// We put zero
-   for (uint i=0; i<(group_m+DENSITY_BLOCK_SIZE); i++)
-   {
-     for(uint j=0; j<COALESCED_DIMENSION(group_m); j++)
-     {
-       if((i>=group_m) || (j>=group_m) || (j > i))
-       {
-         tred_cpu.data[COALESCED_DIMENSION(group_m)*i+j]=0.0f;
-         diff_cpu.data[COALESCED_DIMENSION(group_m)*i+j]=0.0f;
-       }
-     }
-   }
+  // We put zero
+  for (uint i = 0; i < (group_m + DENSITY_BLOCK_SIZE); i++) {
+    for (uint j = 0; j < COALESCED_DIMENSION(group_m); j++) {
+      if ((i >= group_m) || (j >= group_m) || (j > i)) {
+        tred_cpu.data[COALESCED_DIMENSION(group_m) * i + j] = 0.0f;
+        diff_cpu.data[COALESCED_DIMENSION(group_m) * i + j] = 0.0f;
+      }
+    }
+  }
 
-// Form Bind Texture
-   cudaArray* cuArraytred;
-   cudaMallocArray(&cuArraytred, &tred_gpu_for_tex.channelDesc, tred_cpu.width, tred_cpu.height);
-   cudaMemcpyToArray(cuArraytred,0,0,tred_cpu.data,sizeof(scalar_type)*tred_cpu.width*tred_cpu.height,cudaMemcpyHostToDevice);
-   cudaBindTextureToArray(tred_gpu_for_tex, cuArraytred);
-   cudaArray* cuArraydiff;
-   cudaMallocArray(&cuArraydiff, &diff_gpu_for_tex.channelDesc, diff_cpu.width, diff_cpu.height);
-   cudaMemcpyToArray(cuArraydiff,0,0,diff_cpu.data,sizeof(scalar_type)*diff_cpu.width*diff_cpu.height,cudaMemcpyHostToDevice);
-   cudaBindTextureToArray(diff_gpu_for_tex, cuArraydiff);
+  // Form Bind Texture
+  cudaArray* cuArraytred;
+  cudaMallocArray(&cuArraytred, &tred_gpu_for_tex.channelDesc, tred_cpu.width,
+                  tred_cpu.height);
+  cudaMemcpyToArray(cuArraytred, 0, 0, tred_cpu.data,
+                    sizeof(scalar_type) * tred_cpu.width * tred_cpu.height,
+                    cudaMemcpyHostToDevice);
+  cudaBindTextureToArray(tred_gpu_for_tex, cuArraytred);
+  cudaArray* cuArraydiff;
+  cudaMallocArray(&cuArraydiff, &diff_gpu_for_tex.channelDesc, diff_cpu.width,
+                  diff_cpu.height);
+  cudaMemcpyToArray(cuArraydiff, 0, 0, diff_cpu.data,
+                    sizeof(scalar_type) * diff_cpu.width * diff_cpu.height,
+                    cudaMemcpyHostToDevice);
+  cudaBindTextureToArray(diff_gpu_for_tex, cuArraydiff);
 
-   tred_cpu.deallocate(); diff_cpu.deallocate();
+  tred_cpu.deallocate();
+  diff_cpu.deallocate();
 
 // CALCULATE PARTIAL DENSITIES
-#define compden_parameter \
-   point_weights_gpu.data,this->number_of_points,function_values_transposed.data,\
-   group_m,gradient_values_transposed.data, partial_tred_gpu.data,tredxyz_gpu.data, \
-   partial_diff_gpu.data, diffxyz_gpu.data
-   ES_compute_for_partial<scalar_type,true,true,false><<<threadGrid, threadBlock>>>(compden_parameter);
+#define compden_parameter                                     \
+  point_weights_gpu.data, this->number_of_points,             \
+      function_values_transposed.data, group_m,               \
+      gradient_values_transposed.data, partial_tred_gpu.data, \
+      tredxyz_gpu.data, partial_diff_gpu.data, diffxyz_gpu.data
+  ES_compute_for_partial<scalar_type, true, true, false>
+      <<<threadGrid, threadBlock>>>(compden_parameter);
 
 // ACCUMULATE DENSITIES
-#define accumden_parameter \
-   this->number_of_points, block_height, partial_tred_gpu.data, \
-   partial_diff_gpu.data, tredxyz_gpu.data, diffxyz_gpu.data, \
-   tred_accum_gpu.data, diff_accum_gpu.data, tredxyz_accum_gpu.data, diffxyz_accum_gpu.data
-   accumulate_values<scalar_type,true,true,false><<<threadGrid_accumulate,threadBlock_accumulate>>>(accumden_parameter);
+#define accumden_parameter                                              \
+  this->number_of_points, block_height, partial_tred_gpu.data,          \
+      partial_diff_gpu.data, tredxyz_gpu.data, diffxyz_gpu.data,        \
+      tred_accum_gpu.data, diff_accum_gpu.data, tredxyz_accum_gpu.data, \
+      diffxyz_accum_gpu.data
+  accumulate_values<scalar_type, true, true, false>
+      <<<threadGrid_accumulate, threadBlock_accumulate>>>(accumden_parameter);
 
 #undef compute_parameters
 #undef accumulate_parameters
 
-   partial_tred_gpu.deallocate(); partial_diff_gpu.deallocate();
-   tredxyz_gpu.deallocate(); diffxyz_gpu.deallocate();
+  partial_tred_gpu.deallocate();
+  partial_diff_gpu.deallocate();
+  tredxyz_gpu.deallocate();
+  diffxyz_gpu.deallocate();
 
-// OBTAIN GRADIENTS TERMS
-   CudaMatrix<scalar_type> gdens, ddens, tdens;
-   CudaMatrix< vec_type<scalar_type,4> > gdens_xyz, ddens_xyz, tdens_xyz;
-   gdens.resize(COALESCED_DIMENSION(this->number_of_points));
-   ddens.resize(COALESCED_DIMENSION(this->number_of_points));
-   tdens.resize(COALESCED_DIMENSION(this->number_of_points)); tdens.zero();
-   gdens_xyz.resize(COALESCED_DIMENSION(this->number_of_points));
-   ddens_xyz.resize(COALESCED_DIMENSION(this->number_of_points));
-   tdens_xyz.resize(COALESCED_DIMENSION(this->number_of_points)); tdens_xyz.zero();
+  // OBTAIN GRADIENTS TERMS
+  CudaMatrix<scalar_type> gdens, ddens, tdens;
+  CudaMatrix<vec_type<scalar_type, 4>> gdens_xyz, ddens_xyz, tdens_xyz;
+  gdens.resize(COALESCED_DIMENSION(this->number_of_points));
+  ddens.resize(COALESCED_DIMENSION(this->number_of_points));
+  tdens.resize(COALESCED_DIMENSION(this->number_of_points));
+  tdens.zero();
+  gdens_xyz.resize(COALESCED_DIMENSION(this->number_of_points));
+  ddens_xyz.resize(COALESCED_DIMENSION(this->number_of_points));
+  tdens_xyz.resize(COALESCED_DIMENSION(this->number_of_points));
+  tdens_xyz.zero();
 
-   gpu_calc_gradients<scalar_type,true,true,false>(this->number_of_points,rmm_accum_gpu.data,tred_accum_gpu.data,diff_accum_gpu.data,
-                      dxyz_accum_gpu.data, tredxyz_accum_gpu.data, diffxyz_accum_gpu.data,
-                      gdens.data, tdens.data, ddens.data, gdens_xyz.data, tdens_xyz.data, ddens_xyz.data, MET);
+  gpu_calc_gradients<scalar_type, true, true, false>(
+      this->number_of_points, rmm_accum_gpu.data, tred_accum_gpu.data,
+      diff_accum_gpu.data, dxyz_accum_gpu.data, tredxyz_accum_gpu.data,
+      diffxyz_accum_gpu.data, gdens.data, tdens.data, ddens.data,
+      gdens_xyz.data, tdens_xyz.data, ddens_xyz.data, MET);
 
+  // FORCES CALCULATION
+  CudaMatrix<scalar_type> mat_dens_gpu(group_m, group_m);
+  CudaMatrix<scalar_type> mat_diff_gpu(group_m, group_m);
+  CudaMatrix<scalar_type> mat_tred_gpu(group_m, group_m);
+  HostMatrix<scalar_type> rmm_cpu;
+  rmm_cpu.resize(group_m, group_m);
+  get_rmm_input(rmm_cpu);
+  diff_cpu.resize(group_m, group_m);
+  get_tred_input(diff_cpu, Pbig);
+  tred_cpu.resize(group_m, group_m);
+  get_tred_input(tred_cpu, Vbig);
+  Pbig.deallocate();
+  Vbig.deallocate();
 
-// FORCES CALCULATION
-   CudaMatrix<scalar_type> mat_dens_gpu(group_m,group_m);
-   CudaMatrix<scalar_type> mat_diff_gpu(group_m,group_m);
-   CudaMatrix<scalar_type> mat_tred_gpu(group_m,group_m);
-   HostMatrix<scalar_type> rmm_cpu;
-   rmm_cpu.resize(group_m,group_m);  get_rmm_input(rmm_cpu);
-   diff_cpu.resize(group_m,group_m); get_tred_input(diff_cpu,Pbig);
-   tred_cpu.resize(group_m,group_m); get_tred_input(tred_cpu,Vbig);
-   Pbig.deallocate(); Vbig.deallocate();
+  // Copy Matrices
+  int dim_mat = group_m * group_m;
+  cudaMemcpy(mat_dens_gpu.data, rmm_cpu.data, sizeof(scalar_type) * dim_mat,
+             cudaMemcpyHostToDevice);
+  cudaMemcpy(mat_tred_gpu.data, tred_cpu.data, sizeof(scalar_type) * dim_mat,
+             cudaMemcpyHostToDevice);
+  cudaMemcpy(mat_diff_gpu.data, diff_cpu.data, sizeof(scalar_type) * dim_mat,
+             cudaMemcpyHostToDevice);
+  rmm_cpu.deallocate();
+  diff_cpu.deallocate();
+  tred_cpu.deallocate();
 
-   // Copy Matrices
-   int dim_mat = group_m*group_m;
-   cudaMemcpy(mat_dens_gpu.data,rmm_cpu.data,sizeof(scalar_type)*dim_mat,cudaMemcpyHostToDevice);
-   cudaMemcpy(mat_tred_gpu.data,tred_cpu.data,sizeof(scalar_type)*dim_mat,cudaMemcpyHostToDevice);
-   cudaMemcpy(mat_diff_gpu.data,diff_cpu.data,sizeof(scalar_type)*dim_mat,cudaMemcpyHostToDevice);
-   rmm_cpu.deallocate(); diff_cpu.deallocate(); tred_cpu.deallocate();
+  int block_for = divUp(this->number_of_points, POINTS_BLOCK_SIZE);
+  CudaMatrix<vec_type<scalar_type, 4>> forces_basis;
+  forces_basis.resize(group_m, block_for);
+  forces_basis.zero();
+  CudaMatrix<vec_type<scalar_type, 4>> forces_basis_accum;
+  forces_basis_accum.resize(group_m);
+  forces_basis_accum.zero();
 
-   int block_for = divUp(this->number_of_points, POINTS_BLOCK_SIZE);
-   CudaMatrix< vec_type<scalar_type,4> > forces_basis;
-   forces_basis.resize(group_m,block_for); forces_basis.zero();
-   CudaMatrix< vec_type<scalar_type,4> > forces_basis_accum;
-   forces_basis_accum.resize(group_m); forces_basis_accum.zero();
+  threadGrid = dim3(group_m, 1, 1);
+  dim3 threadBlock_partial = dim3(block_for, 1, 1);
+  dim3 threadBlock_accum = dim3(block_for, 1, 1);
 
-   threadGrid  = dim3(group_m,1,1);
-   dim3 threadBlock_partial = dim3(block_for,1,1);
-   dim3 threadBlock_accum = dim3(block_for,1,1);
+#define partial_forces                                                       \
+  function_values_transposed.data, gradient_values_transposed.data,          \
+      hessian_values_transposed.data, mat_dens_gpu.data, mat_tred_gpu.data,  \
+      mat_diff_gpu.data, gdens.data, tdens.data, ddens.data, gdens_xyz.data, \
+      tdens_xyz.data, ddens_xyz.data, forces_basis.data, group_m,            \
+      this->number_of_points, point_weights_gpu.data, block_for
 
-#define partial_forces \
-   function_values_transposed.data, gradient_values_transposed.data, hessian_values_transposed.data, \
-   mat_dens_gpu.data, mat_tred_gpu.data, mat_diff_gpu.data, gdens.data, tdens.data, ddens.data, \
-   gdens_xyz.data, tdens_xyz.data, ddens_xyz.data, forces_basis.data, group_m, this->number_of_points, \
-   point_weights_gpu.data, block_for
-   
-   gpu_partial_forces<scalar_type,true,true,false><<<threadGrid,threadBlock_partial>>>(partial_forces);
-   gpu_accum_forces<scalar_type,true,true,false><<<threadGrid,threadBlock_accum>>>(forces_basis.data,
-                                                   forces_basis_accum.data, block_for, group_m);
+  gpu_partial_forces<scalar_type, true, true, false>
+      <<<threadGrid, threadBlock_partial>>>(partial_forces);
+  gpu_accum_forces<scalar_type, true, true, false>
+      <<<threadGrid, threadBlock_accum>>>(
+          forces_basis.data, forces_basis_accum.data, block_for, group_m);
 
 #undef partial_forces
 
-   //cudaThreadSynchronize();
-   HostMatrix< vec_type<scalar_type,4> > forces_basis_cpu;
-   forces_basis_cpu.resize(group_m); forces_basis_cpu.zero();
-   cudaMemcpy(forces_basis_cpu.data,forces_basis_accum.data,group_m*sizeof(vec_type<scalar_type,4>), cudaMemcpyDeviceToHost);
-   forces_basis.deallocate(); forces_basis_accum.deallocate();
+  // cudaThreadSynchronize();
+  HostMatrix<vec_type<scalar_type, 4>> forces_basis_cpu;
+  forces_basis_cpu.resize(group_m);
+  forces_basis_cpu.zero();
+  cudaMemcpy(forces_basis_cpu.data, forces_basis_accum.data,
+             group_m * sizeof(vec_type<scalar_type, 4>),
+             cudaMemcpyDeviceToHost);
+  forces_basis.deallocate();
+  forces_basis_accum.deallocate();
 
-   int local_atoms = this->total_nucleii(); // da cuantos atomos locales hay en el grupo
-   HostMatrix<scalar_type> ddx, ddy, ddz;
-   ddx.resize(local_atoms, 1); ddx.zero();
-   ddy.resize(local_atoms, 1); ddy.zero();
-   ddz.resize(local_atoms, 1); ddz.zero();
+  int local_atoms =
+      this->total_nucleii();  // da cuantos atomos locales hay en el grupo
+  HostMatrix<scalar_type> ddx, ddy, ddz;
+  ddx.resize(local_atoms, 1);
+  ddx.zero();
+  ddy.resize(local_atoms, 1);
+  ddy.zero();
+  ddz.resize(local_atoms, 1);
+  ddz.zero();
 
-   for(int i=0; i<group_m; i++) {
-      uint nuc = this->func2local_nuc(i);
-      ddx(nuc) -= forces_basis_cpu(i).x;
-      ddy(nuc) -= forces_basis_cpu(i).y;
-      ddz(nuc) -= forces_basis_cpu(i).z;
-   }
-   forces_basis_cpu.deallocate();
+  for (int i = 0; i < group_m; i++) {
+    uint nuc = this->func2local_nuc(i);
+    ddx(nuc) -= forces_basis_cpu(i).x;
+    ddy(nuc) -= forces_basis_cpu(i).y;
+    ddz(nuc) -= forces_basis_cpu(i).z;
+  }
+  forces_basis_cpu.deallocate();
 
-   for (int i = 0; i < local_atoms; i++) {
-      uint global_atom = this->local2global_nuc[i]; // da el indice del atomo LOCAL al GLOBAL
-      F(global_atom,0) += ddx(i);
-      F(global_atom,1) += ddy(i);
-      F(global_atom,2) += ddz(i);
-   }
-   ddx.deallocate(); ddy.deallocate(), ddz.deallocate();
-   gdens.deallocate(); tdens.deallocate(); ddens.deallocate();
-   gdens_xyz.deallocate(); tdens_xyz.deallocate(); ddens_xyz.deallocate();
+  for (int i = 0; i < local_atoms; i++) {
+    uint global_atom =
+        this->local2global_nuc[i];  // da el indice del atomo LOCAL al GLOBAL
+    F(global_atom, 0) += ddx(i);
+    F(global_atom, 1) += ddy(i);
+    F(global_atom, 2) += ddz(i);
+  }
+  ddx.deallocate();
+  ddy.deallocate(), ddz.deallocate();
+  gdens.deallocate();
+  tdens.deallocate();
+  ddens.deallocate();
+  gdens_xyz.deallocate();
+  tdens_xyz.deallocate();
+  ddens_xyz.deallocate();
 
-// Free Texture and Memory
-   cudaUnbindTexture(tred_gpu_for_tex);
-   cudaUnbindTexture(diff_gpu_for_tex);
-   cudaFreeArray(cuArraytred);
-   cudaFreeArray(cuArraydiff);
-   mat_dens_gpu.deallocate(); mat_diff_gpu.deallocate(); 
-   mat_tred_gpu.deallocate(); diff_accum_gpu.deallocate(); 
-   tred_accum_gpu.deallocate(); diffxyz_accum_gpu.deallocate(); 
-   tredxyz_accum_gpu.deallocate(); point_weights_gpu.deallocate(); 
-   function_values_transposed.deallocate(); gradient_values_transposed.deallocate();
+  // Free Texture and Memory
+  cudaUnbindTexture(tred_gpu_for_tex);
+  cudaUnbindTexture(diff_gpu_for_tex);
+  cudaFreeArray(cuArraytred);
+  cudaFreeArray(cuArraydiff);
+  mat_dens_gpu.deallocate();
+  mat_diff_gpu.deallocate();
+  mat_tred_gpu.deallocate();
+  diff_accum_gpu.deallocate();
+  tred_accum_gpu.deallocate();
+  diffxyz_accum_gpu.deallocate();
+  tredxyz_accum_gpu.deallocate();
+  point_weights_gpu.deallocate();
+  function_values_transposed.deallocate();
+  gradient_values_transposed.deallocate();
 }
 #if FULL_DOUBLE
 template class PointGroup<double>;
@@ -276,4 +335,4 @@ template class PointGroupGPU<double>;
 template class PointGroup<float>;
 template class PointGroupGPU<float>;
 #endif
-}
+}  // namespace G2G

--- a/g2g/excited/cuda/g2g_calculateG.cu
+++ b/g2g/excited/cuda/g2g_calculateG.cu
@@ -35,196 +35,212 @@ texture<float, 2, cudaReadModeElementType> tred_gpu_3rd_tex;
 // comienzan las nuevas
 #include "ES_compute_3rd_partial.h"
 
-template<class scalar_type>
-void PointGroupGPU<scalar_type>::solve_3rd_der(double* T, HostMatrix<double>& Fock, int DER)
-{
-   uint group_m = this->total_functions();
-   bool lda = false;
-   bool compute_forces = false;
+template <class scalar_type>
+void PointGroupGPU<scalar_type>::solve_3rd_der(double* T,
+                                               HostMatrix<double>& Fock,
+                                               int DER) {
+  uint group_m = this->total_functions();
+  bool lda = false;
+  bool compute_forces = false;
 
-   compute_functions(compute_forces, !lda);
+  compute_functions(compute_forces, !lda);
 
-   CudaMatrix<scalar_type> point_weights_gpu;
-   HostMatrix<scalar_type> point_weights_cpu(this->number_of_points, 1);
-   uint i = 0;
-   for (vector<Point>::const_iterator p = this->points.begin(); p != this->points.end(); ++p, ++i) {
-     point_weights_cpu(i) = p->weight;
-   }
-   point_weights_gpu = point_weights_cpu;
-   point_weights_cpu.deallocate();
+  CudaMatrix<scalar_type> point_weights_gpu;
+  HostMatrix<scalar_type> point_weights_cpu(this->number_of_points, 1);
+  uint i = 0;
+  for (vector<Point>::const_iterator p = this->points.begin();
+       p != this->points.end(); ++p, ++i) {
+    point_weights_cpu(i) = p->weight;
+  }
+  point_weights_gpu = point_weights_cpu;
+  point_weights_cpu.deallocate();
 
-// Variables to kernels: gpu_compute
-   dim3 threadBlock, threadGrid;
-   const int block_height= divUp(group_m, 2*DENSITY_BLOCK_SIZE);
-   threadBlock = dim3(DENSITY_BLOCK_SIZE,1,1); // Hay que asegurarse que la cantidad de funciones este en rango
-   threadGrid = dim3(this->number_of_points,block_height,1);
+  // Variables to kernels: gpu_compute
+  dim3 threadBlock, threadGrid;
+  const int block_height = divUp(group_m, 2 * DENSITY_BLOCK_SIZE);
+  threadBlock =
+      dim3(DENSITY_BLOCK_SIZE, 1,
+           1);  // Hay que asegurarse que la cantidad de funciones este en rango
+  threadGrid = dim3(this->number_of_points, block_height, 1);
 
-// Partial Transition Density GPU
-   CudaMatrix<scalar_type> partial_tred_gpu;
-   CudaMatrix< vec_type<scalar_type,4> > tredxyz_gpu;
-   partial_tred_gpu.resize(COALESCED_DIMENSION(this->number_of_points), block_height);
-   tredxyz_gpu.resize(COALESCED_DIMENSION(this->number_of_points),block_height);
+  // Partial Transition Density GPU
+  CudaMatrix<scalar_type> partial_tred_gpu;
+  CudaMatrix<vec_type<scalar_type, 4>> tredxyz_gpu;
+  partial_tred_gpu.resize(COALESCED_DIMENSION(this->number_of_points),
+                          block_height);
+  tredxyz_gpu.resize(COALESCED_DIMENSION(this->number_of_points), block_height);
 
-// Accumulate Values
-   CudaMatrix<scalar_type> tred_accum_gpu;
-   CudaMatrix< vec_type<scalar_type,4> > tredxyz_accum_gpu;
-   tred_accum_gpu.resize(COALESCED_DIMENSION(this->number_of_points));
-   tredxyz_accum_gpu.resize(COALESCED_DIMENSION(this->number_of_points));
+  // Accumulate Values
+  CudaMatrix<scalar_type> tred_accum_gpu;
+  CudaMatrix<vec_type<scalar_type, 4>> tredxyz_accum_gpu;
+  tred_accum_gpu.resize(COALESCED_DIMENSION(this->number_of_points));
+  tredxyz_accum_gpu.resize(COALESCED_DIMENSION(this->number_of_points));
 
-// Variables to kernels: accumulate density
-   const dim3 threadGrid_accumulate(divUp(this->number_of_points,DENSITY_ACCUM_BLOCK_SIZE),1,1);
-   const dim3 threadBlock_accumulate(DENSITY_ACCUM_BLOCK_SIZE,1,1);
+  // Variables to kernels: accumulate density
+  const dim3 threadGrid_accumulate(
+      divUp(this->number_of_points, DENSITY_ACCUM_BLOCK_SIZE), 1, 1);
+  const dim3 threadBlock_accumulate(DENSITY_ACCUM_BLOCK_SIZE, 1, 1);
 
-// Transpose functions and gradients
-   #define BLOCK_DIM 16
-   int transposed_width = COALESCED_DIMENSION(this->number_of_points);
-   dim3 transpose_grid(transposed_width / BLOCK_DIM, divUp((group_m),BLOCK_DIM), 1);
-   dim3 transpose_threads(BLOCK_DIM, BLOCK_DIM, 1);
+  // Transpose functions and gradients
+#define BLOCK_DIM 16
+  int transposed_width = COALESCED_DIMENSION(this->number_of_points);
+  dim3 transpose_grid(transposed_width / BLOCK_DIM, divUp((group_m), BLOCK_DIM),
+                      1);
+  dim3 transpose_threads(BLOCK_DIM, BLOCK_DIM, 1);
 
-   CudaMatrix<scalar_type> function_values_transposed;
-   CudaMatrix<vec_type<scalar_type,4> > gradient_values_transposed;
-   function_values_transposed.resize(group_m, COALESCED_DIMENSION(this->number_of_points));
-   gradient_values_transposed.resize( group_m,COALESCED_DIMENSION(this->number_of_points));
+  CudaMatrix<scalar_type> function_values_transposed;
+  CudaMatrix<vec_type<scalar_type, 4>> gradient_values_transposed;
+  function_values_transposed.resize(
+      group_m, COALESCED_DIMENSION(this->number_of_points));
+  gradient_values_transposed.resize(
+      group_m, COALESCED_DIMENSION(this->number_of_points));
 
-   transpose<<<transpose_grid, transpose_threads>>> (function_values_transposed.data,
-       function_values.data, COALESCED_DIMENSION(this->number_of_points), group_m);
+  transpose<<<transpose_grid, transpose_threads>>>(
+      function_values_transposed.data, function_values.data,
+      COALESCED_DIMENSION(this->number_of_points), group_m);
 
-   transpose<<<transpose_grid, transpose_threads>>> (gradient_values_transposed.data,
-       gradient_values.data, COALESCED_DIMENSION(this->number_of_points), group_m );
+  transpose<<<transpose_grid, transpose_threads>>>(
+      gradient_values_transposed.data, gradient_values.data,
+      COALESCED_DIMENSION(this->number_of_points), group_m);
 
-// FORM reduce Transition density
-   HostMatrix<scalar_type> tred_cpu(COALESCED_DIMENSION(group_m), group_m+DENSITY_BLOCK_SIZE);
-   int M = fortran_vars.m;
+  // FORM reduce Transition density
+  HostMatrix<scalar_type> tred_cpu(COALESCED_DIMENSION(group_m),
+                                   group_m + DENSITY_BLOCK_SIZE);
+  int M = fortran_vars.m;
 
-   HostMatrix<double> Tbig(M*(M+1)/2);
-   int index = 0;
-   int row, col;
-   for(row=0;row<M;row++) {
-     Tbig(index) = T[row*M+row];
-     index += 1;
-     for(col=row+1;col<M;col++) {
-        Tbig(index) = T[row*M+col] + T[col*M+row];
-        index += 1;
-     }
-   }
-   get_tred_input(tred_cpu,Tbig);
-   Tbig.deallocate();
+  HostMatrix<double> Tbig(M * (M + 1) / 2);
+  int index = 0;
+  int row, col;
+  for (row = 0; row < M; row++) {
+    Tbig(index) = T[row * M + row];
+    index += 1;
+    for (col = row + 1; col < M; col++) {
+      Tbig(index) = T[row * M + col] + T[col * M + row];
+      index += 1;
+    }
+  }
+  get_tred_input(tred_cpu, Tbig);
+  Tbig.deallocate();
 
-// ponemos ceros fuera de group_m
-   for (uint i=0; i<(group_m+DENSITY_BLOCK_SIZE); i++)
-   {
-     for(uint j=0; j<COALESCED_DIMENSION(group_m); j++)
-     {
-       if((i>=group_m) || (j>=group_m) || (j > i))
-       {
-         tred_cpu.data[COALESCED_DIMENSION(group_m)*i+j]=0.0f;
-       }
-     }
-   }
+  // ponemos ceros fuera de group_m
+  for (uint i = 0; i < (group_m + DENSITY_BLOCK_SIZE); i++) {
+    for (uint j = 0; j < COALESCED_DIMENSION(group_m); j++) {
+      if ((i >= group_m) || (j >= group_m) || (j > i)) {
+        tred_cpu.data[COALESCED_DIMENSION(group_m) * i + j] = 0.0f;
+      }
+    }
+  }
 
-// Form Bind Textures
-   cudaArray* cuArraytred;
-   cudaMallocArray(&cuArraytred, &tred_gpu_3rd_tex.channelDesc, tred_cpu.width, tred_cpu.height);
-   cudaMemcpyToArray(cuArraytred,0,0,tred_cpu.data,sizeof(scalar_type)*tred_cpu.width*tred_cpu.height,cudaMemcpyHostToDevice);
-   cudaBindTextureToArray(tred_gpu_3rd_tex, cuArraytred);
-   tred_cpu.deallocate();
+  // Form Bind Textures
+  cudaArray* cuArraytred;
+  cudaMallocArray(&cuArraytred, &tred_gpu_3rd_tex.channelDesc, tred_cpu.width,
+                  tred_cpu.height);
+  cudaMemcpyToArray(cuArraytred, 0, 0, tred_cpu.data,
+                    sizeof(scalar_type) * tred_cpu.width * tred_cpu.height,
+                    cudaMemcpyHostToDevice);
+  cudaBindTextureToArray(tred_gpu_3rd_tex, cuArraytred);
+  tred_cpu.deallocate();
 
 // CALCULATE PARTIAL DENSITIES
-#define compden_parameter \
-   this->number_of_points,function_values_transposed.data,group_m,gradient_values_transposed.data,\
-   partial_tred_gpu.data,tredxyz_gpu.data
-   ES_compute_3rd_partial<scalar_type,true,true,false><<<threadGrid, threadBlock>>>(compden_parameter);
+#define compden_parameter                                           \
+  this->number_of_points, function_values_transposed.data, group_m, \
+      gradient_values_transposed.data, partial_tred_gpu.data, tredxyz_gpu.data
+  ES_compute_3rd_partial<scalar_type, true, true, false>
+      <<<threadGrid, threadBlock>>>(compden_parameter);
 
 // ACCUMULATE DENSITIES
-#define accumden_parameter \
-   this->number_of_points, block_height, partial_tred_gpu.data, tredxyz_gpu.data, \
-   tred_accum_gpu.data, tredxyz_accum_gpu.data
-   accumulate_values<scalar_type,true,true,false><<<threadGrid_accumulate,threadBlock_accumulate>>>(accumden_parameter);
+#define accumden_parameter                                     \
+  this->number_of_points, block_height, partial_tred_gpu.data, \
+      tredxyz_gpu.data, tred_accum_gpu.data, tredxyz_accum_gpu.data
+  accumulate_values<scalar_type, true, true, false>
+      <<<threadGrid_accumulate, threadBlock_accumulate>>>(accumden_parameter);
 
 #undef compute_parameter
 #undef accumden_parameter
 
-// LIBXC INITIALIZATION
-   fortran_vars.fexc = fortran_vars.func_coef[0];
-#define libxc_init_param \
-   fortran_vars.func_id, fortran_vars.func_coef, fortran_vars.nx_func, \
-   fortran_vars.nc_func, fortran_vars.nsr_id, fortran_vars.screen, \
-   XC_UNPOLARIZED
-   LibxcProxy_cuda<scalar_type,4> libxcProxy_cuda(libxc_init_param);
+  // LIBXC INITIALIZATION
+  fortran_vars.fexc = fortran_vars.func_coef[0];
+#define libxc_init_param                                              \
+  fortran_vars.func_id, fortran_vars.func_coef, fortran_vars.nx_func, \
+      fortran_vars.nc_func, fortran_vars.nsr_id, fortran_vars.screen, \
+      XC_UNPOLARIZED
+  LibxcProxy_cuda<scalar_type, 4> libxcProxy_cuda(libxc_init_param);
 #undef libxc_init_param
 
-   CudaMatrix<scalar_type> lrCoef_gpu;
-   lrCoef_gpu.resize(COALESCED_DIMENSION(this->number_of_points));
+  CudaMatrix<scalar_type> lrCoef_gpu;
+  lrCoef_gpu.resize(COALESCED_DIMENSION(this->number_of_points));
 
-// DEFINE OUTPUTS
-   CudaMatrix< vec_type<scalar_type,4> > Txyz;
-   CudaMatrix< vec_type<scalar_type,4> > Dxyz;
-   Txyz.resize(COALESCED_DIMENSION(this->number_of_points));
-   Dxyz.resize(COALESCED_DIMENSION(this->number_of_points));
+  // DEFINE OUTPUTS
+  CudaMatrix<vec_type<scalar_type, 4>> Txyz;
+  CudaMatrix<vec_type<scalar_type, 4>> Dxyz;
+  Txyz.resize(COALESCED_DIMENSION(this->number_of_points));
+  Dxyz.resize(COALESCED_DIMENSION(this->number_of_points));
 
-   if ( DER == 2 ) {
-      libxc_gpu_coefLR<scalar_type, true, true, false>(&libxcProxy_cuda,this->number_of_points,
-               rmm_accum_gpu.data,tred_accum_gpu.data,dxyz_accum_gpu.data,
-               tredxyz_accum_gpu.data,
-               // Outputs
-               Dxyz.data, Txyz.data, lrCoef_gpu.data);
-   } else {
-      libxc_gpu_coefZv<scalar_type, true, true, false>(&libxcProxy_cuda,this->number_of_points,
-                rmm_accum_gpu.data,tred_accum_gpu.data,dxyz_accum_gpu.data,
-                tredxyz_accum_gpu.data,
-                // Outputs
-                Dxyz.data, Txyz.data, lrCoef_gpu.data);
-   }
+  if (DER == 2) {
+    libxc_gpu_coefLR<scalar_type, true, true, false>(
+        &libxcProxy_cuda, this->number_of_points, rmm_accum_gpu.data,
+        tred_accum_gpu.data, dxyz_accum_gpu.data, tredxyz_accum_gpu.data,
+        // Outputs
+        Dxyz.data, Txyz.data, lrCoef_gpu.data);
+  } else {
+    libxc_gpu_coefZv<scalar_type, true, true, false>(
+        &libxcProxy_cuda, this->number_of_points, rmm_accum_gpu.data,
+        tred_accum_gpu.data, dxyz_accum_gpu.data, tredxyz_accum_gpu.data,
+        // Outputs
+        Dxyz.data, Txyz.data, lrCoef_gpu.data);
+  }
 
-// CALCULATE TERMS
-   CudaMatrix<scalar_type> terms_lr;
-   terms_lr.resize(group_m,COALESCED_DIMENSION(this->number_of_points));
-   threadGrid  = dim3(this->number_of_points);
-   threadBlock = dim3(group_m);
+  // CALCULATE TERMS
+  CudaMatrix<scalar_type> terms_lr;
+  terms_lr.resize(group_m, COALESCED_DIMENSION(this->number_of_points));
+  threadGrid = dim3(this->number_of_points);
+  threadBlock = dim3(group_m);
 
-#define compute_parameters \
-   this->number_of_points, group_m, point_weights_gpu.data, function_values_transposed.data, \
-   gradient_values_transposed.data, lrCoef_gpu.data, Dxyz.data, \
-   Txyz.data, terms_lr.data
+#define compute_parameters                                              \
+  this->number_of_points, group_m, point_weights_gpu.data,              \
+      function_values_transposed.data, gradient_values_transposed.data, \
+      lrCoef_gpu.data, Dxyz.data, Txyz.data, terms_lr.data
 
-   gpu_obtain_term<scalar_type,false,true,false><<<threadGrid,threadBlock>>>(compute_parameters);
+  gpu_obtain_term<scalar_type, false, true, false>
+      <<<threadGrid, threadBlock>>>(compute_parameters);
 #undef compute_parameters
 
-// CALCULATE FOCK
-   const int block_size = divUp(group_m,RMM_BLOCK_SIZE_XY);
-   const int MM = block_size * (block_size+1) / 2;
-   threadGrid = dim3(MM,1,1);
-   threadBlock = dim3(RMM_BLOCK_SIZE_XY,RMM_BLOCK_SIZE_XY);
+  // CALCULATE FOCK
+  const int block_size = divUp(group_m, RMM_BLOCK_SIZE_XY);
+  const int MM = block_size * (block_size + 1) / 2;
+  threadGrid = dim3(MM, 1, 1);
+  threadBlock = dim3(RMM_BLOCK_SIZE_XY, RMM_BLOCK_SIZE_XY);
 
-   CudaMatrix<scalar_type> smallFock_gpu(group_m,group_m);
-   smallFock_gpu.zero();
-#define compute_parameters \
-   this->number_of_points, group_m, point_weights_gpu.data, function_values_transposed.data, terms_lr.data, \
-   smallFock_gpu.data
+  CudaMatrix<scalar_type> smallFock_gpu(group_m, group_m);
+  smallFock_gpu.zero();
+#define compute_parameters                                 \
+  this->number_of_points, group_m, point_weights_gpu.data, \
+      function_values_transposed.data, terms_lr.data, smallFock_gpu.data
 
-   gpu_obtain_fock<scalar_type,false,true,false><<<threadGrid,threadBlock>>>(compute_parameters);
+  gpu_obtain_fock<scalar_type, false, true, false>
+      <<<threadGrid, threadBlock>>>(compute_parameters);
 #undef compute_parameters
 
-// Obtain the global fock
-   HostMatrix<scalar_type> smallFock(smallFock_gpu);
-   smallFock_gpu.deallocate();
-   this->add_rmm_output(smallFock,Fock);
+  // Obtain the global fock
+  HostMatrix<scalar_type> smallFock(smallFock_gpu);
+  smallFock_gpu.deallocate();
+  this->add_rmm_output(smallFock, Fock);
 
-// Free Memory
-   smallFock.deallocate();
-   cudaUnbindTexture(tred_gpu_3rd_tex);
-   cudaFreeArray(cuArraytred);
-   Txyz.deallocate();
-   Dxyz.deallocate();
-   partial_tred_gpu.deallocate();
-   tredxyz_gpu.deallocate();
-   tred_accum_gpu.deallocate();
-   tredxyz_accum_gpu.deallocate();
-   lrCoef_gpu.deallocate();
-   point_weights_gpu.deallocate();
-   function_values_transposed.deallocate();
-   gradient_values_transposed.deallocate();
-   terms_lr.deallocate();
+  // Free Memory
+  smallFock.deallocate();
+  cudaUnbindTexture(tred_gpu_3rd_tex);
+  cudaFreeArray(cuArraytred);
+  Txyz.deallocate();
+  Dxyz.deallocate();
+  partial_tred_gpu.deallocate();
+  tredxyz_gpu.deallocate();
+  tred_accum_gpu.deallocate();
+  tredxyz_accum_gpu.deallocate();
+  lrCoef_gpu.deallocate();
+  point_weights_gpu.deallocate();
+  function_values_transposed.deallocate();
+  gradient_values_transposed.deallocate();
+  terms_lr.deallocate();
 }
 
 #if FULL_DOUBLE
@@ -234,6 +250,4 @@ template class PointGroupGPU<double>;
 template class PointGroup<float>;
 template class PointGroupGPU<float>;
 #endif
-}
-
-
+}  // namespace G2G

--- a/g2g/excited/cuda/g2g_calculateXC.cu
+++ b/g2g/excited/cuda/g2g_calculateXC.cu
@@ -38,299 +38,324 @@ texture<float, 2, cudaReadModeElementType> tred_gpu_tex;
 #include "GS_compute_partial.h"
 #include "ES_compute_partial.h"
 
-template<class scalar_type>
-void PointGroupGPU<scalar_type>::solve_closed_lr(double* T, HostMatrix<double>& Fock)
-{
-   cudaError_t err = cudaSuccess;
-   Timers timers;
+template <class scalar_type>
+void PointGroupGPU<scalar_type>::solve_closed_lr(double* T,
+                                                 HostMatrix<double>& Fock) {
+  cudaError_t err = cudaSuccess;
+  Timers timers;
 
-   uint group_m = this->total_functions();
-   bool lda = false;
-   bool compute_forces = false;
+  uint group_m = this->total_functions();
+  bool lda = false;
+  bool compute_forces = false;
 
-   compute_functions(compute_forces, !lda);
+  compute_functions(compute_forces, !lda);
 
-// Point weights on CPU and GPU
-   CudaMatrix<scalar_type> point_weights_gpu;
-   HostMatrix<scalar_type> point_weights_cpu(this->number_of_points, 1);
-   uint i = 0;
-   for (vector<Point>::const_iterator p = this->points.begin(); p != this->points.end(); ++p, ++i) {
-     point_weights_cpu(i) = p->weight;
-   }
-   point_weights_gpu = point_weights_cpu;
-   point_weights_cpu.deallocate();
+  // Point weights on CPU and GPU
+  CudaMatrix<scalar_type> point_weights_gpu;
+  HostMatrix<scalar_type> point_weights_cpu(this->number_of_points, 1);
+  uint i = 0;
+  for (vector<Point>::const_iterator p = this->points.begin();
+       p != this->points.end(); ++p, ++i) {
+    point_weights_cpu(i) = p->weight;
+  }
+  point_weights_gpu = point_weights_cpu;
+  point_weights_cpu.deallocate();
 
-// Variables to kernels: gpu_compute
-   dim3 threadBlock, threadGrid;
-   const int block_height= divUp(group_m, 2*DENSITY_BLOCK_SIZE);
-   threadBlock = dim3(DENSITY_BLOCK_SIZE,1,1); // Hay que asegurarse que la cantidad de funciones este en rango
-   threadGrid = dim3(this->number_of_points,block_height,1);
+  // Variables to kernels: gpu_compute
+  dim3 threadBlock, threadGrid;
+  const int block_height = divUp(group_m, 2 * DENSITY_BLOCK_SIZE);
+  threadBlock =
+      dim3(DENSITY_BLOCK_SIZE, 1,
+           1);  // Hay que asegurarse que la cantidad de funciones este en rango
+  threadGrid = dim3(this->number_of_points, block_height, 1);
 
-// Partial Transition Density GPU
-   CudaMatrix<scalar_type> partial_tred_gpu;
-   CudaMatrix< vec_type<scalar_type,4> > tredxyz_gpu;
-   partial_tred_gpu.resize(COALESCED_DIMENSION(this->number_of_points), block_height);
-   tredxyz_gpu.resize(COALESCED_DIMENSION(this->number_of_points),block_height);
+  // Partial Transition Density GPU
+  CudaMatrix<scalar_type> partial_tred_gpu;
+  CudaMatrix<vec_type<scalar_type, 4>> tredxyz_gpu;
+  partial_tred_gpu.resize(COALESCED_DIMENSION(this->number_of_points),
+                          block_height);
+  tredxyz_gpu.resize(COALESCED_DIMENSION(this->number_of_points), block_height);
 
-// Accumulate Values
-   CudaMatrix<scalar_type> tred_accum_gpu;
-   CudaMatrix< vec_type<scalar_type,4> > tredxyz_accum_gpu;
-   tred_accum_gpu.resize(COALESCED_DIMENSION(this->number_of_points));
-   tredxyz_accum_gpu.resize(COALESCED_DIMENSION(this->number_of_points));
+  // Accumulate Values
+  CudaMatrix<scalar_type> tred_accum_gpu;
+  CudaMatrix<vec_type<scalar_type, 4>> tredxyz_accum_gpu;
+  tred_accum_gpu.resize(COALESCED_DIMENSION(this->number_of_points));
+  tredxyz_accum_gpu.resize(COALESCED_DIMENSION(this->number_of_points));
 
-// Variables to kernels: accumulate density
-   const dim3 threadGrid_accumulate(divUp(this->number_of_points,DENSITY_ACCUM_BLOCK_SIZE),1,1);
-   const dim3 threadBlock_accumulate(DENSITY_ACCUM_BLOCK_SIZE,1,1);
+  // Variables to kernels: accumulate density
+  const dim3 threadGrid_accumulate(
+      divUp(this->number_of_points, DENSITY_ACCUM_BLOCK_SIZE), 1, 1);
+  const dim3 threadBlock_accumulate(DENSITY_ACCUM_BLOCK_SIZE, 1, 1);
 
-// Transpose functions and gradients
-   #define BLOCK_DIM 16
-   int transposed_width = COALESCED_DIMENSION(this->number_of_points);
-   dim3 transpose_grid(transposed_width / BLOCK_DIM, divUp((group_m),BLOCK_DIM), 1);
-   dim3 transpose_threads(BLOCK_DIM, BLOCK_DIM, 1);
+  // Transpose functions and gradients
+#define BLOCK_DIM 16
+  int transposed_width = COALESCED_DIMENSION(this->number_of_points);
+  dim3 transpose_grid(transposed_width / BLOCK_DIM, divUp((group_m), BLOCK_DIM),
+                      1);
+  dim3 transpose_threads(BLOCK_DIM, BLOCK_DIM, 1);
 
-   CudaMatrix<scalar_type> function_values_transposed;
-   CudaMatrix<vec_type<scalar_type,4> > gradient_values_transposed;
-   function_values_transposed.resize(group_m, COALESCED_DIMENSION(this->number_of_points));
-   gradient_values_transposed.resize( group_m,COALESCED_DIMENSION(this->number_of_points));
+  CudaMatrix<scalar_type> function_values_transposed;
+  CudaMatrix<vec_type<scalar_type, 4>> gradient_values_transposed;
+  function_values_transposed.resize(
+      group_m, COALESCED_DIMENSION(this->number_of_points));
+  gradient_values_transposed.resize(
+      group_m, COALESCED_DIMENSION(this->number_of_points));
 
-   transpose<<<transpose_grid, transpose_threads>>> (function_values_transposed.data,
-       function_values.data, COALESCED_DIMENSION(this->number_of_points), group_m);
+  transpose<<<transpose_grid, transpose_threads>>>(
+      function_values_transposed.data, function_values.data,
+      COALESCED_DIMENSION(this->number_of_points), group_m);
 
-   transpose<<<transpose_grid, transpose_threads>>> (gradient_values_transposed.data,
-       gradient_values.data, COALESCED_DIMENSION(this->number_of_points), group_m );
+  transpose<<<transpose_grid, transpose_threads>>>(
+      gradient_values_transposed.data, gradient_values.data,
+      COALESCED_DIMENSION(this->number_of_points), group_m);
 
-// FORM reduce Transition density
-   HostMatrix<scalar_type> tred_cpu(COALESCED_DIMENSION(group_m), group_m+DENSITY_BLOCK_SIZE);
-   int M = fortran_vars.m;
+  // FORM reduce Transition density
+  HostMatrix<scalar_type> tred_cpu(COALESCED_DIMENSION(group_m),
+                                   group_m + DENSITY_BLOCK_SIZE);
+  int M = fortran_vars.m;
 
-   HostMatrix<double> Tbig(M*(M+1)/2);
-   int index = 0;
-   int row, col;
-   for(row=0;row<M;row++) {
-     Tbig(index) = T[row*M+row];
-     index += 1;
-     for(col=row+1;col<M;col++) {
-        Tbig(index) = T[row*M+col] + T[col*M+row];
-        index += 1;
-     }
-   }
-   get_tred_input(tred_cpu,Tbig);
-   Tbig.deallocate();
+  HostMatrix<double> Tbig(M * (M + 1) / 2);
+  int index = 0;
+  int row, col;
+  for (row = 0; row < M; row++) {
+    Tbig(index) = T[row * M + row];
+    index += 1;
+    for (col = row + 1; col < M; col++) {
+      Tbig(index) = T[row * M + col] + T[col * M + row];
+      index += 1;
+    }
+  }
+  get_tred_input(tred_cpu, Tbig);
+  Tbig.deallocate();
 
-// ponemos ceros fuera de group_m
-   for (uint i=0; i<(group_m+DENSITY_BLOCK_SIZE); i++)
-   {
-     for(uint j=0; j<COALESCED_DIMENSION(group_m); j++)
-     {
-       if((i>=group_m) || (j>=group_m) || (j > i))
-       {
-         tred_cpu.data[COALESCED_DIMENSION(group_m)*i+j]=0.0f;
-       }
-     }
-   }
+  // ponemos ceros fuera de group_m
+  for (uint i = 0; i < (group_m + DENSITY_BLOCK_SIZE); i++) {
+    for (uint j = 0; j < COALESCED_DIMENSION(group_m); j++) {
+      if ((i >= group_m) || (j >= group_m) || (j > i)) {
+        tred_cpu.data[COALESCED_DIMENSION(group_m) * i + j] = 0.0f;
+      }
+    }
+  }
 
-// Form Bind Textures
-   cudaArray* cuArraytred;
-   cudaMallocArray(&cuArraytred, &tred_gpu_tex.channelDesc, tred_cpu.width, tred_cpu.height);
-   cudaMemcpyToArray(cuArraytred,0,0,tred_cpu.data,sizeof(scalar_type)*tred_cpu.width*tred_cpu.height,cudaMemcpyHostToDevice);
-   cudaBindTextureToArray(tred_gpu_tex, cuArraytred);
-   tred_cpu.deallocate();
+  // Form Bind Textures
+  cudaArray* cuArraytred;
+  cudaMallocArray(&cuArraytred, &tred_gpu_tex.channelDesc, tred_cpu.width,
+                  tred_cpu.height);
+  cudaMemcpyToArray(cuArraytred, 0, 0, tred_cpu.data,
+                    sizeof(scalar_type) * tred_cpu.width * tred_cpu.height,
+                    cudaMemcpyHostToDevice);
+  cudaBindTextureToArray(tred_gpu_tex, cuArraytred);
+  tred_cpu.deallocate();
 
 // CALCULATE PARTIAL DENSITIES
-#define compden_parameter \
-   this->number_of_points,function_values_transposed.data,group_m,gradient_values_transposed.data,\
-   partial_tred_gpu.data,tredxyz_gpu.data
-   ES_compute_partial<scalar_type,true,true,false><<<threadGrid, threadBlock>>>(compden_parameter);
+#define compden_parameter                                           \
+  this->number_of_points, function_values_transposed.data, group_m, \
+      gradient_values_transposed.data, partial_tred_gpu.data, tredxyz_gpu.data
+  ES_compute_partial<scalar_type, true, true, false>
+      <<<threadGrid, threadBlock>>>(compden_parameter);
 
 // ACCUMULATE DENSITIES
-#define accumden_parameter \
-   this->number_of_points, block_height, partial_tred_gpu.data, tredxyz_gpu.data, \
-   tred_accum_gpu.data, tredxyz_accum_gpu.data
-   accumulate_values<scalar_type,true,true,false><<<threadGrid_accumulate,threadBlock_accumulate>>>(accumden_parameter);
+#define accumden_parameter                                     \
+  this->number_of_points, block_height, partial_tred_gpu.data, \
+      tredxyz_gpu.data, tred_accum_gpu.data, tredxyz_accum_gpu.data
+  accumulate_values<scalar_type, true, true, false>
+      <<<threadGrid_accumulate, threadBlock_accumulate>>>(accumden_parameter);
 
 #undef compute_parameters
 #undef accumulate_parameters
 
-// LIBXC INITIALIZATION
+  // LIBXC INITIALIZATION
   fortran_vars.fexc = fortran_vars.func_coef[0];
-#define libxc_init_param \
-   fortran_vars.func_id, fortran_vars.func_coef, fortran_vars.nx_func, \
-   fortran_vars.nc_func, fortran_vars.nsr_id, fortran_vars.screen, \
-   XC_UNPOLARIZED
-   LibxcProxy_cuda<scalar_type,4> libxcProxy_cuda(libxc_init_param);
+#define libxc_init_param                                              \
+  fortran_vars.func_id, fortran_vars.func_coef, fortran_vars.nx_func, \
+      fortran_vars.nc_func, fortran_vars.nsr_id, fortran_vars.screen, \
+      XC_UNPOLARIZED
+  LibxcProxy_cuda<scalar_type, 4> libxcProxy_cuda(libxc_init_param);
 #undef libxc_init_param
 
-   CudaMatrix<scalar_type> lrCoef_gpu;
-   lrCoef_gpu.resize(COALESCED_DIMENSION(this->number_of_points));
+  CudaMatrix<scalar_type> lrCoef_gpu;
+  lrCoef_gpu.resize(COALESCED_DIMENSION(this->number_of_points));
 
-// DEFINE OUTPUTS
-   CudaMatrix< vec_type<scalar_type,4> > Txyz;
-   CudaMatrix< vec_type<scalar_type,4> > Dxyz;
-   Txyz.resize(COALESCED_DIMENSION(this->number_of_points));
-   Dxyz.resize(COALESCED_DIMENSION(this->number_of_points));
+  // DEFINE OUTPUTS
+  CudaMatrix<vec_type<scalar_type, 4>> Txyz;
+  CudaMatrix<vec_type<scalar_type, 4>> Dxyz;
+  Txyz.resize(COALESCED_DIMENSION(this->number_of_points));
+  Dxyz.resize(COALESCED_DIMENSION(this->number_of_points));
 
-   libxc_gpu_coefLR<scalar_type, true, true, false>(&libxcProxy_cuda,this->number_of_points,
-               rmm_accum_gpu.data,tred_accum_gpu.data,dxyz_accum_gpu.data,
-               tredxyz_accum_gpu.data,
-               // Outputs
-               Dxyz.data, Txyz.data, lrCoef_gpu.data);
+  libxc_gpu_coefLR<scalar_type, true, true, false>(
+      &libxcProxy_cuda, this->number_of_points, rmm_accum_gpu.data,
+      tred_accum_gpu.data, dxyz_accum_gpu.data, tredxyz_accum_gpu.data,
+      // Outputs
+      Dxyz.data, Txyz.data, lrCoef_gpu.data);
 
-// CALCULATE TERMS
-   CudaMatrix<scalar_type> terms_lr;
-   terms_lr.resize(group_m,COALESCED_DIMENSION(this->number_of_points));
-   threadGrid  = dim3(this->number_of_points);
-   threadBlock = dim3(group_m);
+  // CALCULATE TERMS
+  CudaMatrix<scalar_type> terms_lr;
+  terms_lr.resize(group_m, COALESCED_DIMENSION(this->number_of_points));
+  threadGrid = dim3(this->number_of_points);
+  threadBlock = dim3(group_m);
 
-#define compute_parameters \
-   this->number_of_points, group_m, point_weights_gpu.data, function_values_transposed.data, \
-   gradient_values_transposed.data, lrCoef_gpu.data, Dxyz.data, \
-   Txyz.data, terms_lr.data
+#define compute_parameters                                              \
+  this->number_of_points, group_m, point_weights_gpu.data,              \
+      function_values_transposed.data, gradient_values_transposed.data, \
+      lrCoef_gpu.data, Dxyz.data, Txyz.data, terms_lr.data
 
-   gpu_obtain_term<scalar_type,false,true,false><<<threadGrid,threadBlock>>>(compute_parameters);
+  gpu_obtain_term<scalar_type, false, true, false>
+      <<<threadGrid, threadBlock>>>(compute_parameters);
 #undef compute_parameters
 
-// CALCULATE FOCK
-   const int block_size = divUp(group_m,RMM_BLOCK_SIZE_XY);
-   const int MM = block_size * (block_size+1) / 2;
-   threadGrid = dim3(MM,1,1);
-   threadBlock = dim3(RMM_BLOCK_SIZE_XY,RMM_BLOCK_SIZE_XY);
+  // CALCULATE FOCK
+  const int block_size = divUp(group_m, RMM_BLOCK_SIZE_XY);
+  const int MM = block_size * (block_size + 1) / 2;
+  threadGrid = dim3(MM, 1, 1);
+  threadBlock = dim3(RMM_BLOCK_SIZE_XY, RMM_BLOCK_SIZE_XY);
 
-   CudaMatrix<scalar_type> smallFock_gpu(group_m,group_m);
-   smallFock_gpu.zero();
-#define compute_parameters \
-   this->number_of_points, group_m, point_weights_gpu.data, function_values_transposed.data, terms_lr.data, \
-   smallFock_gpu.data
+  CudaMatrix<scalar_type> smallFock_gpu(group_m, group_m);
+  smallFock_gpu.zero();
+#define compute_parameters                                 \
+  this->number_of_points, group_m, point_weights_gpu.data, \
+      function_values_transposed.data, terms_lr.data, smallFock_gpu.data
 
-   gpu_obtain_fock<scalar_type,false,true,false><<<threadGrid,threadBlock>>>(compute_parameters);
+  gpu_obtain_fock<scalar_type, false, true, false>
+      <<<threadGrid, threadBlock>>>(compute_parameters);
 #undef compute_parameters
 
-// Obtain the global fock
-   HostMatrix<scalar_type> smallFock(smallFock_gpu);
-   smallFock_gpu.deallocate();
-   this->add_rmm_output(smallFock,Fock);
+  // Obtain the global fock
+  HostMatrix<scalar_type> smallFock(smallFock_gpu);
+  smallFock_gpu.deallocate();
+  this->add_rmm_output(smallFock, Fock);
 
-// Free Memory
-   smallFock.deallocate();
-   cudaUnbindTexture(tred_gpu_tex);
-   cudaFreeArray(cuArraytred);
-   Txyz.deallocate();
-   Dxyz.deallocate();
-   partial_tred_gpu.deallocate();
-   tredxyz_gpu.deallocate();
-   tred_accum_gpu.deallocate();
-   tredxyz_accum_gpu.deallocate();
-   lrCoef_gpu.deallocate();
-   point_weights_gpu.deallocate();
-   function_values_transposed.deallocate();
-   gradient_values_transposed.deallocate();
-   terms_lr.deallocate();
+  // Free Memory
+  smallFock.deallocate();
+  cudaUnbindTexture(tred_gpu_tex);
+  cudaFreeArray(cuArraytred);
+  Txyz.deallocate();
+  Dxyz.deallocate();
+  partial_tred_gpu.deallocate();
+  tredxyz_gpu.deallocate();
+  tred_accum_gpu.deallocate();
+  tredxyz_accum_gpu.deallocate();
+  lrCoef_gpu.deallocate();
+  point_weights_gpu.deallocate();
+  function_values_transposed.deallocate();
+  gradient_values_transposed.deallocate();
+  terms_lr.deallocate();
 }
 
 template <class scalar_type>
 void PointGroupGPU<scalar_type>::get_tred_input(
-    HostMatrix<scalar_type>& tred_input, HostMatrix<double>& source) const
-{
+    HostMatrix<scalar_type>& tred_input, HostMatrix<double>& source) const {
   tred_input.zero();
   const int indexes = this->rmm_bigs.size();
   for (int i = 0; i < indexes; i++) {
     int ii = this->rmm_rows[i], jj = this->rmm_cols[i], bi = this->rmm_bigs[i];
     tred_input(ii, jj) = tred_input(jj, ii) = (scalar_type)source(bi);
   }
-
 }
 
-template<class scalar_type> void PointGroupGPU<scalar_type>::
-               lr_closed_init()
-{
-   cudaError_t err = cudaSuccess;
-   uint group_m = this->total_functions();
-   bool lda = false;
-   bool compute_forces = false;
+template <class scalar_type>
+void PointGroupGPU<scalar_type>::lr_closed_init() {
+  cudaError_t err = cudaSuccess;
+  uint group_m = this->total_functions();
+  bool lda = false;
+  bool compute_forces = false;
 
-   compute_functions(compute_forces, !lda);
+  compute_functions(compute_forces, !lda);
 
-// Variables to kernels: gpu_compute
-   dim3 threadBlock, threadGrid;
-   const int block_height= divUp(group_m, 2*DENSITY_BLOCK_SIZE);
-   threadBlock = dim3(DENSITY_BLOCK_SIZE,1,1); // Hay que asegurarse que la cantidad de funciones este en rango
-   threadGrid = dim3(this->number_of_points,block_height,1);
+  // Variables to kernels: gpu_compute
+  dim3 threadBlock, threadGrid;
+  const int block_height = divUp(group_m, 2 * DENSITY_BLOCK_SIZE);
+  threadBlock =
+      dim3(DENSITY_BLOCK_SIZE, 1,
+           1);  // Hay que asegurarse que la cantidad de funciones este en rango
+  threadGrid = dim3(this->number_of_points, block_height, 1);
 
-// Ground State Density GPU
-   CudaMatrix<scalar_type> partial_densities_gpu;
-   CudaMatrix< vec_type<scalar_type,4> > dxyz_gpu;
-   partial_densities_gpu.resize(COALESCED_DIMENSION(this->number_of_points), block_height);
-   dxyz_gpu.resize(COALESCED_DIMENSION(this->number_of_points),block_height);
+  // Ground State Density GPU
+  CudaMatrix<scalar_type> partial_densities_gpu;
+  CudaMatrix<vec_type<scalar_type, 4>> dxyz_gpu;
+  partial_densities_gpu.resize(COALESCED_DIMENSION(this->number_of_points),
+                               block_height);
+  dxyz_gpu.resize(COALESCED_DIMENSION(this->number_of_points), block_height);
 
-// Accumulate Values
-   rmm_accum_gpu.resize(COALESCED_DIMENSION(this->number_of_points));
-   dxyz_accum_gpu.resize(COALESCED_DIMENSION(this->number_of_points));
+  // Accumulate Values
+  rmm_accum_gpu.resize(COALESCED_DIMENSION(this->number_of_points));
+  dxyz_accum_gpu.resize(COALESCED_DIMENSION(this->number_of_points));
 
-// Variables to kernels: accumulate density
-   const dim3 threadGrid_accumulate(divUp(this->number_of_points,DENSITY_ACCUM_BLOCK_SIZE),1,1);
-   const dim3 threadBlock_accumulate(DENSITY_ACCUM_BLOCK_SIZE,1,1);
+  // Variables to kernels: accumulate density
+  const dim3 threadGrid_accumulate(
+      divUp(this->number_of_points, DENSITY_ACCUM_BLOCK_SIZE), 1, 1);
+  const dim3 threadBlock_accumulate(DENSITY_ACCUM_BLOCK_SIZE, 1, 1);
 
-// Transpose functions and gradients
-   #define BLOCK_DIM 16
-   int transposed_width = COALESCED_DIMENSION(this->number_of_points);
-   dim3 transpose_grid(transposed_width / BLOCK_DIM, divUp((group_m),BLOCK_DIM), 1);
-   dim3 transpose_threads(BLOCK_DIM, BLOCK_DIM, 1);
+  // Transpose functions and gradients
+#define BLOCK_DIM 16
+  int transposed_width = COALESCED_DIMENSION(this->number_of_points);
+  dim3 transpose_grid(transposed_width / BLOCK_DIM, divUp((group_m), BLOCK_DIM),
+                      1);
+  dim3 transpose_threads(BLOCK_DIM, BLOCK_DIM, 1);
 
-   CudaMatrix<scalar_type> function_values_transposed;
-   CudaMatrix<vec_type<scalar_type,4> > gradient_values_transposed;
-   function_values_transposed.resize(group_m, COALESCED_DIMENSION(this->number_of_points));
-   gradient_values_transposed.resize( group_m,COALESCED_DIMENSION(this->number_of_points));
+  CudaMatrix<scalar_type> function_values_transposed;
+  CudaMatrix<vec_type<scalar_type, 4>> gradient_values_transposed;
+  function_values_transposed.resize(
+      group_m, COALESCED_DIMENSION(this->number_of_points));
+  gradient_values_transposed.resize(
+      group_m, COALESCED_DIMENSION(this->number_of_points));
 
-   transpose<<<transpose_grid, transpose_threads>>> (function_values_transposed.data,
-       function_values.data, COALESCED_DIMENSION(this->number_of_points), group_m);
+  transpose<<<transpose_grid, transpose_threads>>>(
+      function_values_transposed.data, function_values.data,
+      COALESCED_DIMENSION(this->number_of_points), group_m);
 
-   transpose<<<transpose_grid, transpose_threads>>> (gradient_values_transposed.data,
-       gradient_values.data, COALESCED_DIMENSION(this->number_of_points), group_m );
+  transpose<<<transpose_grid, transpose_threads>>>(
+      gradient_values_transposed.data, gradient_values.data,
+      COALESCED_DIMENSION(this->number_of_points), group_m);
 
-// FORM reduce GS density
-   HostMatrix<scalar_type> rmm_cpu(COALESCED_DIMENSION(group_m), group_m+DENSITY_BLOCK_SIZE);
-   get_rmm_input(rmm_cpu);
+  // FORM reduce GS density
+  HostMatrix<scalar_type> rmm_cpu(COALESCED_DIMENSION(group_m),
+                                  group_m + DENSITY_BLOCK_SIZE);
+  get_rmm_input(rmm_cpu);
 
-// ponemos ceros fuera de group_m
-   for (uint i=0; i<(group_m+DENSITY_BLOCK_SIZE); i++)
-   {
-     for(uint j=0; j<COALESCED_DIMENSION(group_m); j++)
-     {
-       if((i>=group_m) || (j>=group_m) || (j > i))
-       {
-         rmm_cpu.data[COALESCED_DIMENSION(group_m)*i+j]=0.0f;
-       }
-     }
-   }
+  // ponemos ceros fuera de group_m
+  for (uint i = 0; i < (group_m + DENSITY_BLOCK_SIZE); i++) {
+    for (uint j = 0; j < COALESCED_DIMENSION(group_m); j++) {
+      if ((i >= group_m) || (j >= group_m) || (j > i)) {
+        rmm_cpu.data[COALESCED_DIMENSION(group_m) * i + j] = 0.0f;
+      }
+    }
+  }
 
-// Form Bind Textures
-   cudaArray* cuArrayrmm;
-   cudaMallocArray(&cuArrayrmm, &rmm_gpu_tex.channelDesc, rmm_cpu.width, rmm_cpu.height);
-   cudaMemcpyToArray(cuArrayrmm,0,0,rmm_cpu.data,sizeof(scalar_type)*rmm_cpu.width*rmm_cpu.height,cudaMemcpyHostToDevice);
-   cudaBindTextureToArray(rmm_gpu_tex, cuArrayrmm);
-   rmm_cpu.deallocate();
+  // Form Bind Textures
+  cudaArray* cuArrayrmm;
+  cudaMallocArray(&cuArrayrmm, &rmm_gpu_tex.channelDesc, rmm_cpu.width,
+                  rmm_cpu.height);
+  cudaMemcpyToArray(cuArrayrmm, 0, 0, rmm_cpu.data,
+                    sizeof(scalar_type) * rmm_cpu.width * rmm_cpu.height,
+                    cudaMemcpyHostToDevice);
+  cudaBindTextureToArray(rmm_gpu_tex, cuArrayrmm);
+  rmm_cpu.deallocate();
 
 // CALCULATE PARTIAL DENSITIES
-#define compden_parameter \
-   this->number_of_points,function_values_transposed.data,group_m,gradient_values_transposed.data, \
-   partial_densities_gpu.data,dxyz_gpu.data
-   GS_compute_partial<scalar_type,true,true,false><<<threadGrid, threadBlock>>>(compden_parameter);
+#define compden_parameter                                           \
+  this->number_of_points, function_values_transposed.data, group_m, \
+      gradient_values_transposed.data, partial_densities_gpu.data,  \
+      dxyz_gpu.data
+  GS_compute_partial<scalar_type, true, true, false>
+      <<<threadGrid, threadBlock>>>(compden_parameter);
 
 // ACCUMULATE DENSITIES
-#define accumden_parameter \
-   this->number_of_points, block_height, partial_densities_gpu.data, dxyz_gpu.data, \
-   rmm_accum_gpu.data, dxyz_accum_gpu.data
-   accumulate_values<scalar_type,true,true,false><<<threadGrid_accumulate,threadBlock_accumulate>>>(accumden_parameter);
+#define accumden_parameter                                          \
+  this->number_of_points, block_height, partial_densities_gpu.data, \
+      dxyz_gpu.data, rmm_accum_gpu.data, dxyz_accum_gpu.data
+  accumulate_values<scalar_type, true, true, false>
+      <<<threadGrid_accumulate, threadBlock_accumulate>>>(accumden_parameter);
 
 #undef compute_parameters
 #undef accumulate_parameters
 
-// FREE MEMORY
-   cudaUnbindTexture(rmm_gpu_tex);
-   cudaFreeArray(cuArrayrmm);
-   partial_densities_gpu.deallocate();
-   dxyz_gpu.deallocate();
-   function_values_transposed.deallocate();
-   gradient_values_transposed.deallocate();
+  // FREE MEMORY
+  cudaUnbindTexture(rmm_gpu_tex);
+  cudaFreeArray(cuArrayrmm);
+  partial_densities_gpu.deallocate();
+  dxyz_gpu.deallocate();
+  function_values_transposed.deallocate();
+  gradient_values_transposed.deallocate();
 }
 
 #if FULL_DOUBLE
@@ -340,5 +365,4 @@ template class PointGroupGPU<double>;
 template class PointGroup<float>;
 template class PointGroupGPU<float>;
 #endif
-}
-
+}  // namespace G2G

--- a/g2g/excited/cuda/gpu_calc_gradients.h
+++ b/g2g/excited/cuda/gpu_calc_gradients.h
@@ -2,92 +2,95 @@ using namespace G2G;
 #include "gpu_vxc.h"
 #include "gpu_fxc.h"
 
-template<class T, bool compute_energy, bool compute_factor, bool lda>
-void gpu_calc_gradients(uint npoints,T* dens, T* tred, T* diff,
-                        G2G::vec_type<T,WIDTH>* dxyz,
-                        G2G::vec_type<T,WIDTH>* tredxyz,
-                        G2G::vec_type<T,WIDTH>* diffxyz, 
-                        T* ddum, T* vdum, T* pdum,
-                        G2G::vec_type<T,WIDTH>* ddum_xyz,
-                        G2G::vec_type<T,WIDTH>* vdum_xyz,
-                        G2G::vec_type<T,WIDTH>* pdum_xyz, 
-                        int calc_fxc)
-{
-// LIBXC INITIALIZATION
+template <class T, bool compute_energy, bool compute_factor, bool lda>
+void gpu_calc_gradients(uint npoints, T* dens, T* tred, T* diff,
+                        G2G::vec_type<T, WIDTH>* dxyz,
+                        G2G::vec_type<T, WIDTH>* tredxyz,
+                        G2G::vec_type<T, WIDTH>* diffxyz, T* ddum, T* vdum,
+                        T* pdum, G2G::vec_type<T, WIDTH>* ddum_xyz,
+                        G2G::vec_type<T, WIDTH>* vdum_xyz,
+                        G2G::vec_type<T, WIDTH>* pdum_xyz, int calc_fxc) {
+  // LIBXC INITIALIZATION
   fortran_vars.fexc = fortran_vars.func_coef[0];
-#define libxc_init_param \
+#define libxc_init_param                                              \
   fortran_vars.func_id, fortran_vars.func_coef, fortran_vars.nx_func, \
-  fortran_vars.nc_func, fortran_vars.nsr_id, fortran_vars.screen, \
-  XC_UNPOLARIZED
-  LibxcProxy_cuda<T,4> libxcProxy_cuda(libxc_init_param);
+      fortran_vars.nc_func, fortran_vars.nsr_id, fortran_vars.screen, \
+      XC_UNPOLARIZED
+  LibxcProxy_cuda<T, 4> libxcProxy_cuda(libxc_init_param);
 #undef libxc_init_param
- 
-// LIBXC VARIABLES
-   CudaMatrix< vec_type<T,2> > vrho;
-   vrho.resize(COALESCED_DIMENSION(npoints));
-   CudaMatrix< vec_type<T,2> > vsigma;
-   vsigma.resize(COALESCED_DIMENSION(npoints));
-   CudaMatrix< vec_type<T,2> > v2rho2;
-   v2rho2.resize(COALESCED_DIMENSION(npoints));
-   CudaMatrix< vec_type<T,2> > v2rhosigma;
-   v2rhosigma.resize(COALESCED_DIMENSION(npoints));
-   CudaMatrix< vec_type<T,2> > v2sigma2;
-   v2sigma2.resize(COALESCED_DIMENSION(npoints));
-   CudaMatrix< vec_type<T,2> > v3rho3;
-   v3rho3.resize(COALESCED_DIMENSION(npoints));
-   CudaMatrix< vec_type<T,2> > v3rho2sigma;
-   v3rho2sigma.resize(COALESCED_DIMENSION(npoints));
-   CudaMatrix< vec_type<T,2> > v3rhosigma2;
-   v3rhosigma2.resize(COALESCED_DIMENSION(npoints));
-   CudaMatrix< vec_type<T,2> > v3sigma3;
-   v3sigma3.resize(COALESCED_DIMENSION(npoints));
+
+  // LIBXC VARIABLES
+  CudaMatrix<vec_type<T, 2>> vrho;
+  vrho.resize(COALESCED_DIMENSION(npoints));
+  CudaMatrix<vec_type<T, 2>> vsigma;
+  vsigma.resize(COALESCED_DIMENSION(npoints));
+  CudaMatrix<vec_type<T, 2>> v2rho2;
+  v2rho2.resize(COALESCED_DIMENSION(npoints));
+  CudaMatrix<vec_type<T, 2>> v2rhosigma;
+  v2rhosigma.resize(COALESCED_DIMENSION(npoints));
+  CudaMatrix<vec_type<T, 2>> v2sigma2;
+  v2sigma2.resize(COALESCED_DIMENSION(npoints));
+  CudaMatrix<vec_type<T, 2>> v3rho3;
+  v3rho3.resize(COALESCED_DIMENSION(npoints));
+  CudaMatrix<vec_type<T, 2>> v3rho2sigma;
+  v3rho2sigma.resize(COALESCED_DIMENSION(npoints));
+  CudaMatrix<vec_type<T, 2>> v3rhosigma2;
+  v3rhosigma2.resize(COALESCED_DIMENSION(npoints));
+  CudaMatrix<vec_type<T, 2>> v3sigma3;
+  v3sigma3.resize(COALESCED_DIMENSION(npoints));
 
 // CALL LIBXC
-#define libxc_parameter \
-   &libxcProxy_cuda, npoints, dens, dxyz, vrho.data, vsigma.data, v2rho2.data, v2rhosigma.data, \
-   v2sigma2.data, v3rho3.data, v3rho2sigma.data, v3rhosigma2.data, v3sigma3.data
-   libxc_gpu_derivs<T, true, true, false>(libxc_parameter);
+#define libxc_parameter                                                       \
+  &libxcProxy_cuda, npoints, dens, dxyz, vrho.data, vsigma.data, v2rho2.data, \
+      v2rhosigma.data, v2sigma2.data, v3rho3.data, v3rho2sigma.data,          \
+      v3rhosigma2.data, v3sigma3.data
+  libxc_gpu_derivs<T, true, true, false>(libxc_parameter);
 
 #undef libxc_parameter
 
-   int threadsPerBlock = 256;
-   int blocksPerGrid = (npoints + threadsPerBlock - 1) / threadsPerBlock;
-#define VXC_parameter \
-   npoints, diff, dxyz, diffxyz, vrho.data, vsigma.data, v2rho2.data, \
-   v2rhosigma.data, v2sigma2.data, ddum, pdum, ddum_xyz, pdum_xyz, calc_fxc
+  int threadsPerBlock = 256;
+  int blocksPerGrid = (npoints + threadsPerBlock - 1) / threadsPerBlock;
+#define VXC_parameter                                                \
+  npoints, diff, dxyz, diffxyz, vrho.data, vsigma.data, v2rho2.data, \
+      v2rhosigma.data, v2sigma2.data, ddum, pdum, ddum_xyz, pdum_xyz, calc_fxc
 
-   gpu_calc_VXC<T,true,true,false><<<blocksPerGrid,threadsPerBlock>>>(VXC_parameter);
+  gpu_calc_VXC<T, true, true, false>
+      <<<blocksPerGrid, threadsPerBlock>>>(VXC_parameter);
 
 #undef VXC_parameter
 
-   if ( calc_fxc == 0 ) {
-      #define FXC_parameter \
-         npoints, dens, tred, dxyz, tredxyz, vsigma.data, v2rho2.data, v2rhosigma.data, \
-         v2sigma2.data, v3rho3.data, v3rho2sigma.data, v3rhosigma2.data, v3sigma3.data, \
-         ddum, vdum, ddum_xyz, vdum_xyz
+  if (calc_fxc == 0) {
+#define FXC_parameter                                                \
+  npoints, dens, tred, dxyz, tredxyz, vsigma.data, v2rho2.data,      \
+      v2rhosigma.data, v2sigma2.data, v3rho3.data, v3rho2sigma.data, \
+      v3rhosigma2.data, v3sigma3.data, ddum, vdum, ddum_xyz, vdum_xyz
 
-         gpu_calc_FXC<T,true,true,false><<<blocksPerGrid,threadsPerBlock>>>(FXC_parameter);
+    gpu_calc_FXC<T, true, true, false>
+        <<<blocksPerGrid, threadsPerBlock>>>(FXC_parameter);
 
-      #undef FXC_parameter
-   }
-   vrho.deallocate(); vsigma.deallocate();
-   v2rho2.deallocate(), v2rhosigma.deallocate(); v2sigma2.deallocate();
-   v3rho3.deallocate(), v3rho2sigma.deallocate(), v3rhosigma2.deallocate(), v3sigma3.deallocate();
+#undef FXC_parameter
+  }
+  vrho.deallocate();
+  vsigma.deallocate();
+  v2rho2.deallocate(), v2rhosigma.deallocate();
+  v2sigma2.deallocate();
+  v3rho3.deallocate(), v3rho2sigma.deallocate(), v3rhosigma2.deallocate(),
+      v3sigma3.deallocate();
 
-/*
-   // DEBUG //
-   T* rho_cpu = (T*) malloc(sizeof(T) * npoints);
-   cudaMemcpy(rho_cpu,diff,npoints*(sizeof(T)),cudaMemcpyDeviceToHost);
+  /*
+     // DEBUG //
+     T* rho_cpu = (T*) malloc(sizeof(T) * npoints);
+     cudaMemcpy(rho_cpu,diff,npoints*(sizeof(T)),cudaMemcpyDeviceToHost);
 
-   HostMatrix< vec_type<T,4> > var_cpu;
-   var_cpu.resize(COALESCED_DIMENSION(npoints)); var_cpu.zero();
-   cudaMemcpy(var_cpu.data,diffxyz,npoints*(sizeof(vec_type<T,4>)),cudaMemcpyDeviceToHost);
+     HostMatrix< vec_type<T,4> > var_cpu;
+     var_cpu.resize(COALESCED_DIMENSION(npoints)); var_cpu.zero();
+     cudaMemcpy(var_cpu.data,diffxyz,npoints*(sizeof(vec_type<T,4>)),cudaMemcpyDeviceToHost);
 
-   for(int i=0; i<npoints; i++) {
-      printf("%f %f %f %f\n",rho_cpu[i], var_cpu(i).x, var_cpu(i).y, var_cpu(i).z);
+     for(int i=0; i<npoints; i++) {
+        printf("%f %f %f %f\n",rho_cpu[i], var_cpu(i).x, var_cpu(i).y,
+     var_cpu(i).z);
 
-   }
-   exit(-1);
-*/
+     }
+     exit(-1);
+  */
 }
-

--- a/g2g/excited/cuda/gpu_fxc.h
+++ b/g2g/excited/cuda/gpu_fxc.h
@@ -1,375 +1,383 @@
-template<class T, bool compute_energy, bool compute_factor, bool lda>
-__global__ void gpu_calc_FXC(uint points, T* dens, T* trad, G2G::vec_type<T,WIDTH>* dxyz,
-                G2G::vec_type<T,WIDTH>* tradxyz, G2G::vec_type<T,2>* vsigma,
-                G2G::vec_type<T,2>* v2rho2, G2G::vec_type<T,2>* v2rhosigma,
-                G2G::vec_type<T,2>* v2sigma2, G2G::vec_type<T,2>* v3rho3,
-                G2G::vec_type<T,2>* v3rho2sigma, G2G::vec_type<T,2>* v3rhosigma2,
-                G2G::vec_type<T,2>* v3sigma3, 
-                // OUTPUTS //
-                T* dfac, T* tfac, G2G::vec_type<T,WIDTH>* dfacxyz, G2G::vec_type<T,WIDTH>* tfacxyz)
-{
-   uint idx = blockDim.x * blockIdx.x + threadIdx.x;
+template <class T, bool compute_energy, bool compute_factor, bool lda>
+__global__ void gpu_calc_FXC(
+    uint points, T* dens, T* trad, G2G::vec_type<T, WIDTH>* dxyz,
+    G2G::vec_type<T, WIDTH>* tradxyz, G2G::vec_type<T, 2>* vsigma,
+    G2G::vec_type<T, 2>* v2rho2, G2G::vec_type<T, 2>* v2rhosigma,
+    G2G::vec_type<T, 2>* v2sigma2, G2G::vec_type<T, 2>* v3rho3,
+    G2G::vec_type<T, 2>* v3rho2sigma, G2G::vec_type<T, 2>* v3rhosigma2,
+    G2G::vec_type<T, 2>* v3sigma3,
+    // OUTPUTS //
+    T* dfac, T* tfac, G2G::vec_type<T, WIDTH>* dfacxyz,
+    G2G::vec_type<T, WIDTH>* tfacxyz) {
+  uint idx = blockDim.x * blockIdx.x + threadIdx.x;
 
-   if ( idx < points ) {
-      // TRANSITION DENSITY
-      double tr_dens[2], trgradX[2], trgradY[2], trgradZ[2];
-      tr_dens[0]=trad[idx];
-      trgradX[0]=tradxyz[idx].x;
-      trgradY[0]=tradxyz[idx].y;
-      trgradZ[0]=tradxyz[idx].z;
-      tr_dens[1]=trad[idx];
-      trgradX[1]=tradxyz[idx].x;
-      trgradY[1]=tradxyz[idx].y;
-      trgradZ[1]=tradxyz[idx].z;
-      double gdensX, gdensY, gdensZ;
-      gdensX = dxyz[idx].x*0.5f;
-      gdensY = dxyz[idx].y*0.5f;
-      gdensZ = dxyz[idx].z*0.5f;
+  if (idx < points) {
+    // TRANSITION DENSITY
+    double tr_dens[2], trgradX[2], trgradY[2], trgradZ[2];
+    tr_dens[0] = trad[idx];
+    trgradX[0] = tradxyz[idx].x;
+    trgradY[0] = tradxyz[idx].y;
+    trgradZ[0] = tradxyz[idx].z;
+    tr_dens[1] = trad[idx];
+    trgradX[1] = tradxyz[idx].x;
+    trgradY[1] = tradxyz[idx].y;
+    trgradZ[1] = tradxyz[idx].z;
+    double gdensX, gdensY, gdensZ;
+    gdensX = dxyz[idx].x * 0.5f;
+    gdensY = dxyz[idx].y * 0.5f;
+    gdensZ = dxyz[idx].z * 0.5f;
 
-      double grad_all[4], cont_grad[4];
-      grad_all[0]=trgradX[0]*gdensX+trgradY[0]*gdensY+trgradZ[0]*gdensZ;
-      grad_all[1]=trgradX[1]*gdensX+trgradY[1]*gdensY+trgradZ[1]*gdensZ;
-      grad_all[2]=trgradX[0]*gdensX+trgradY[0]*gdensY+trgradZ[0]*gdensZ;
-      grad_all[3]=trgradX[1]*gdensX+trgradY[1]*gdensY+trgradZ[1]*gdensZ;
-      cont_grad[0]=trgradX[0]*trgradX[0]+trgradY[0]*trgradY[0]+trgradZ[0]*trgradZ[0];
-      cont_grad[1]=trgradX[1]*trgradX[1]+trgradY[1]*trgradY[1]+trgradZ[1]*trgradZ[1];
-      cont_grad[2]=trgradX[0]*trgradX[1]+trgradY[0]*trgradY[1]+trgradZ[0]*trgradZ[1];
-      cont_grad[3]=cont_grad[2];
-   
-      // F NON CORE
-      double coef[20];
-      coef[0]=2.0f*(vsigma[idx].x*2.0f+vsigma[idx].y);
-      coef[1]=v2rho2[idx].x*2.0f+v2rho2[idx].y;
-      coef[2]=2.0f*(v2rhosigma[idx].x*4.0f+v2rhosigma[idx].y);
-      coef[3]=2.0f*(v2rhosigma[idx].x*4.0f+v2rhosigma[idx].y);
-      coef[4]=v2rhosigma[idx].y*2.0f;
-      coef[5]=v2rhosigma[idx].y*2.0f;
-      coef[6]=4.0f*(v2sigma2[idx].x*8.0f+v2sigma2[idx].y);
-      coef[7]=2.0f*v2sigma2[idx].y*2.0f;
-      coef[8]=2.0f*v2sigma2[idx].y*2.0f;
-      coef[9]=v2sigma2[idx].y*4.0f;
+    double grad_all[4], cont_grad[4];
+    grad_all[0] =
+        trgradX[0] * gdensX + trgradY[0] * gdensY + trgradZ[0] * gdensZ;
+    grad_all[1] =
+        trgradX[1] * gdensX + trgradY[1] * gdensY + trgradZ[1] * gdensZ;
+    grad_all[2] =
+        trgradX[0] * gdensX + trgradY[0] * gdensY + trgradZ[0] * gdensZ;
+    grad_all[3] =
+        trgradX[1] * gdensX + trgradY[1] * gdensY + trgradZ[1] * gdensZ;
+    cont_grad[0] = trgradX[0] * trgradX[0] + trgradY[0] * trgradY[0] +
+                   trgradZ[0] * trgradZ[0];
+    cont_grad[1] = trgradX[1] * trgradX[1] + trgradY[1] * trgradY[1] +
+                   trgradZ[1] * trgradZ[1];
+    cont_grad[2] = trgradX[0] * trgradX[1] + trgradY[0] * trgradY[1] +
+                   trgradZ[0] * trgradZ[1];
+    cont_grad[3] = cont_grad[2];
 
-      double coef1, cograd1;
-      coef1=coef[0];
-      cograd1=coef1*2.0f;
-      double tr_dens1;
-      coef1=coef[1];
-      tr_dens1=coef1*tr_dens[0]*2.0f;
+    // F NON CORE
+    double coef[20];
+    coef[0] = 2.0f * (vsigma[idx].x * 2.0f + vsigma[idx].y);
+    coef[1] = v2rho2[idx].x * 2.0f + v2rho2[idx].y;
+    coef[2] = 2.0f * (v2rhosigma[idx].x * 4.0f + v2rhosigma[idx].y);
+    coef[3] = 2.0f * (v2rhosigma[idx].x * 4.0f + v2rhosigma[idx].y);
+    coef[4] = v2rhosigma[idx].y * 2.0f;
+    coef[5] = v2rhosigma[idx].y * 2.0f;
+    coef[6] = 4.0f * (v2sigma2[idx].x * 8.0f + v2sigma2[idx].y);
+    coef[7] = 2.0f * v2sigma2[idx].y * 2.0f;
+    coef[8] = 2.0f * v2sigma2[idx].y * 2.0f;
+    coef[9] = v2sigma2[idx].y * 4.0f;
 
-      double grad_all1;
-      coef1=coef[2]+coef[3];
-      tr_dens1=tr_dens1+coef1*grad_all[0];
-      grad_all1=coef1*tr_dens[0];
+    double coef1, cograd1;
+    coef1 = coef[0];
+    cograd1 = coef1 * 2.0f;
+    double tr_dens1;
+    coef1 = coef[1];
+    tr_dens1 = coef1 * tr_dens[0] * 2.0f;
 
-      double grad_all2;
-      coef1=coef[4]+coef[5];
-      tr_dens1=tr_dens1+coef1*grad_all[2];
-      grad_all2=coef1*tr_dens[0];
+    double grad_all1;
+    coef1 = coef[2] + coef[3];
+    tr_dens1 = tr_dens1 + coef1 * grad_all[0];
+    grad_all1 = coef1 * tr_dens[0];
 
-      coef1=coef[6];
-      grad_all1=grad_all1+coef[6]*grad_all[0]*2.0f;
-      coef1=coef[7]+coef[8];
-      grad_all1=grad_all1+coef1*grad_all[2];
-      grad_all2=grad_all2+coef1*grad_all[0];
-      coef1=coef[9];
-      grad_all2=grad_all2+coef1*grad_all[2]*2.0f;
-  
-      // --AB AND BA COMPONENTS--
-      coef[10]=vsigma[idx].y*2.0f;
-      coef[11]=v2rho2[idx].y;
-      coef[12]=2.0f*v2rhosigma[idx].y;
-      coef[13]=2.0f*v2rhosigma[idx].y;
-      coef[14]=v2rhosigma[idx].y*2.0f;
-      coef[15]=v2rhosigma[idx].y*2.0f;
-      coef[16]=4.0f*v2sigma2[idx].y;
-      coef[17]=2.0f*v2sigma2[idx].y*2.0f;
-      coef[18]=2.0f*v2sigma2[idx].y*2.0f;
-      coef[19]=v2sigma2[idx].y*4.0f;
+    double grad_all2;
+    coef1 = coef[4] + coef[5];
+    tr_dens1 = tr_dens1 + coef1 * grad_all[2];
+    grad_all2 = coef1 * tr_dens[0];
 
-      double cograd2, tr_dens2;
-      coef1=coef[10]*2.0f;
-      cograd2=coef1;
-      coef1=coef[11]*2.0f;
-      tr_dens1=tr_dens1+coef1*tr_dens[1];
-      tr_dens2=coef1*tr_dens[0];
+    coef1 = coef[6];
+    grad_all1 = grad_all1 + coef[6] * grad_all[0] * 2.0f;
+    coef1 = coef[7] + coef[8];
+    grad_all1 = grad_all1 + coef1 * grad_all[2];
+    grad_all2 = grad_all2 + coef1 * grad_all[0];
+    coef1 = coef[9];
+    grad_all2 = grad_all2 + coef1 * grad_all[2] * 2.0f;
 
-      double grad_all3;
-      coef1=coef[12]*2.0f;
-      tr_dens1=tr_dens1+coef1*grad_all[1];
-      grad_all3=coef1*tr_dens[0];
-      coef1=coef[13]*2.0f;
-      tr_dens2=tr_dens2+coef1*grad_all[0];
-      grad_all1=grad_all1+coef1*tr_dens[1];
+    // --AB AND BA COMPONENTS--
+    coef[10] = vsigma[idx].y * 2.0f;
+    coef[11] = v2rho2[idx].y;
+    coef[12] = 2.0f * v2rhosigma[idx].y;
+    coef[13] = 2.0f * v2rhosigma[idx].y;
+    coef[14] = v2rhosigma[idx].y * 2.0f;
+    coef[15] = v2rhosigma[idx].y * 2.0f;
+    coef[16] = 4.0f * v2sigma2[idx].y;
+    coef[17] = 2.0f * v2sigma2[idx].y * 2.0f;
+    coef[18] = 2.0f * v2sigma2[idx].y * 2.0f;
+    coef[19] = v2sigma2[idx].y * 4.0f;
 
-      double grad_all4;
-      coef1=coef[14]*2.0f;
-      tr_dens1=tr_dens1+coef1*grad_all[3];
-      grad_all4=coef1*tr_dens[0];
-      coef1=coef[15]*2.0f;
-      tr_dens2=tr_dens2+coef1*grad_all[2];
-      grad_all2=grad_all2+coef1*tr_dens[1];
+    double cograd2, tr_dens2;
+    coef1 = coef[10] * 2.0f;
+    cograd2 = coef1;
+    coef1 = coef[11] * 2.0f;
+    tr_dens1 = tr_dens1 + coef1 * tr_dens[1];
+    tr_dens2 = coef1 * tr_dens[0];
 
-      coef1=coef[16]*2.0f;
-      grad_all1=grad_all1+coef1*grad_all[1];
-      grad_all3=grad_all3+coef1*grad_all[0];
-      coef1=coef[17]*2.0f;
-      grad_all1=grad_all1+coef1*grad_all[3];
-      grad_all4=grad_all4+coef1*grad_all[0];
-      coef1=coef[18]*2.0f;
-      grad_all3=grad_all3+coef1*grad_all[2];
-      grad_all2=grad_all2+coef1*grad_all[1];
-      coef1=coef[19]*2.0f;
-      grad_all2=grad_all2+coef1*grad_all[3];
-      grad_all4=grad_all4+coef1*grad_all[2];
+    double grad_all3;
+    coef1 = coef[12] * 2.0f;
+    tr_dens1 = tr_dens1 + coef1 * grad_all[1];
+    grad_all3 = coef1 * tr_dens[0];
+    coef1 = coef[13] * 2.0f;
+    tr_dens2 = tr_dens2 + coef1 * grad_all[0];
+    grad_all1 = grad_all1 + coef1 * tr_dens[1];
 
-      // --BB COMPONENTS--
-      coef[0]=2.0f*(vsigma[idx].x*2.0f+vsigma[idx].y);
-      coef[1]=v2rho2[idx].x*2.0f+v2rho2[idx].y;
-      coef[2]=2.0f*(v2rhosigma[idx].x*4.0f+v2rhosigma[idx].y);
-      coef[3]=2.0f*(v2rhosigma[idx].x*4.0f+v2rhosigma[idx].y);
-      coef[4]=v2rhosigma[idx].y*2.0f;
-      coef[5]=v2rhosigma[idx].y*2.0f;
-      coef[6]=4.0f*(v2sigma2[idx].x*8.0f+v2sigma2[idx].y);
-      coef[7]=2.0f*v2sigma2[idx].y*2.0f;
-      coef[8]=2.0f*v2sigma2[idx].y*2.0f;
-      coef[9]=v2sigma2[idx].y*4.0f;
+    double grad_all4;
+    coef1 = coef[14] * 2.0f;
+    tr_dens1 = tr_dens1 + coef1 * grad_all[3];
+    grad_all4 = coef1 * tr_dens[0];
+    coef1 = coef[15] * 2.0f;
+    tr_dens2 = tr_dens2 + coef1 * grad_all[2];
+    grad_all2 = grad_all2 + coef1 * tr_dens[1];
 
-      coef1=coef[0];
-      coef1=coef[1];
-      tr_dens2=tr_dens2+coef1*tr_dens[1]*2.0f;
-      coef1=coef[2]+coef[3];
-      tr_dens2=tr_dens2+coef1*grad_all[1];
-      grad_all3=grad_all3+coef1*tr_dens[1];
-      coef1=coef[4]+coef[5];
-      tr_dens2=tr_dens2+coef1*grad_all[3];
-      grad_all4=grad_all4+coef1*tr_dens[1];
-      coef1=coef[6];
-      grad_all3=grad_all3+coef1*grad_all[1]*2.0f;
-      coef1=coef[7]+coef[8];
-      grad_all3=grad_all3+coef1*grad_all[3];
-      grad_all4=grad_all4+coef1*grad_all[1];
-      coef1=coef[9];
-      grad_all4=grad_all4+coef1*grad_all[3]*2.0f;
+    coef1 = coef[16] * 2.0f;
+    grad_all1 = grad_all1 + coef1 * grad_all[1];
+    grad_all3 = grad_all3 + coef1 * grad_all[0];
+    coef1 = coef[17] * 2.0f;
+    grad_all1 = grad_all1 + coef1 * grad_all[3];
+    grad_all4 = grad_all4 + coef1 * grad_all[0];
+    coef1 = coef[18] * 2.0f;
+    grad_all3 = grad_all3 + coef1 * grad_all[2];
+    grad_all2 = grad_all2 + coef1 * grad_all[1];
+    coef1 = coef[19] * 2.0f;
+    grad_all2 = grad_all2 + coef1 * grad_all[3];
+    grad_all4 = grad_all4 + coef1 * grad_all[2];
 
-      // CONTRACTION OF FNC
-      double fncdens,fncdensX,fncdensY,fncdensZ;
-      fncdens=tr_dens1;
-      fncdensX=grad_all1*gdensX+grad_all2*gdensX+
-               cograd1*trgradX[0]+cograd2*trgradX[1];
-      fncdensY=grad_all1*gdensY+grad_all2*gdensY+
-               cograd1*trgradY[0]+cograd2*trgradY[1];
-      fncdensZ=grad_all1*gdensZ+grad_all2*gdensZ+
-               cograd1*trgradZ[0]+cograd2*trgradZ[1];
+    // --BB COMPONENTS--
+    coef[0] = 2.0f * (vsigma[idx].x * 2.0f + vsigma[idx].y);
+    coef[1] = v2rho2[idx].x * 2.0f + v2rho2[idx].y;
+    coef[2] = 2.0f * (v2rhosigma[idx].x * 4.0f + v2rhosigma[idx].y);
+    coef[3] = 2.0f * (v2rhosigma[idx].x * 4.0f + v2rhosigma[idx].y);
+    coef[4] = v2rhosigma[idx].y * 2.0f;
+    coef[5] = v2rhosigma[idx].y * 2.0f;
+    coef[6] = 4.0f * (v2sigma2[idx].x * 8.0f + v2sigma2[idx].y);
+    coef[7] = 2.0f * v2sigma2[idx].y * 2.0f;
+    coef[8] = 2.0f * v2sigma2[idx].y * 2.0f;
+    coef[9] = v2sigma2[idx].y * 4.0f;
 
-      double fnctredX,fnctredY,fnctredZ;
-      fnctredX=grad_all1*trgradX[0]+grad_all4*trgradX[1];
-      fnctredY=grad_all1*trgradY[0]+grad_all4*trgradY[1];
-      fnctredZ=grad_all1*trgradZ[0]+grad_all4*trgradZ[1];
+    coef1 = coef[0];
+    coef1 = coef[1];
+    tr_dens2 = tr_dens2 + coef1 * tr_dens[1] * 2.0f;
+    coef1 = coef[2] + coef[3];
+    tr_dens2 = tr_dens2 + coef1 * grad_all[1];
+    grad_all3 = grad_all3 + coef1 * tr_dens[1];
+    coef1 = coef[4] + coef[5];
+    tr_dens2 = tr_dens2 + coef1 * grad_all[3];
+    grad_all4 = grad_all4 + coef1 * tr_dens[1];
+    coef1 = coef[6];
+    grad_all3 = grad_all3 + coef1 * grad_all[1] * 2.0f;
+    coef1 = coef[7] + coef[8];
+    grad_all3 = grad_all3 + coef1 * grad_all[3];
+    grad_all4 = grad_all4 + coef1 * grad_all[1];
+    coef1 = coef[9];
+    grad_all4 = grad_all4 + coef1 * grad_all[3] * 2.0f;
 
-      // F CORE
-      coef[0]=2.0f*cont_grad[0];
-      coef[1]=tr_dens[0]*tr_dens[0];
-      coef[2]=2.0f*tr_dens[0]*grad_all[0];
-      coef[3]=2.0f*grad_all[0]*tr_dens[0];
-      coef[4]=grad_all[0]*tr_dens[0];
-      coef[5]=tr_dens[0]*grad_all[0];
-      coef[6]=4.0f*grad_all[0]*grad_all[0];
-      coef[7]=2.0f*grad_all[0]*grad_all[0];
-      coef[8]=2.0f*grad_all[0]*grad_all[0];
-      coef[9]=grad_all[0]*grad_all[0];
+    // CONTRACTION OF FNC
+    double fncdens, fncdensX, fncdensY, fncdensZ;
+    fncdens = tr_dens1;
+    fncdensX = grad_all1 * gdensX + grad_all2 * gdensX + cograd1 * trgradX[0] +
+               cograd2 * trgradX[1];
+    fncdensY = grad_all1 * gdensY + grad_all2 * gdensY + cograd1 * trgradY[0] +
+               cograd2 * trgradY[1];
+    fncdensZ = grad_all1 * gdensZ + grad_all2 * gdensZ + cograd1 * trgradZ[0] +
+               cograd2 * trgradZ[1];
 
-      // EXCHANGE
-      double Xtemp,Xtemp1;
-      Xtemp=coef[0]*v2rhosigma[idx].x*4.0f;
-      Xtemp1=coef[0]*2.0f*v2sigma2[idx].x*8.0f;
-      Xtemp=Xtemp+coef[1]*v3rho3[idx].x*4.0f;
-      Xtemp1=Xtemp1+coef[1]*2.0f*v3rho2sigma[idx].x*8.0f;
-      Xtemp=Xtemp+coef[2]*v3rho2sigma[idx].x*8.0f;
-      Xtemp1=Xtemp1+coef[2]*2.0f*v3rhosigma2[idx].x*16.0f;
-      Xtemp=Xtemp+coef[3]*v3rho2sigma[idx].x*8.0f;
-      Xtemp1=Xtemp1+coef[3]*2.0f*v3rhosigma2[idx].x*16.0f;
-      Xtemp=Xtemp+coef[6]*v3rhosigma2[idx].x*16.0f;
-      Xtemp1=Xtemp1+coef[6]*2.0f*v3sigma3[idx].x*32.0f;
+    double fnctredX, fnctredY, fnctredZ;
+    fnctredX = grad_all1 * trgradX[0] + grad_all4 * trgradX[1];
+    fnctredY = grad_all1 * trgradY[0] + grad_all4 * trgradY[1];
+    fnctredZ = grad_all1 * trgradZ[0] + grad_all4 * trgradZ[1];
 
-      // CORRELATION
-      double Ctemp,Ctemp1,Ctemp2;
-      Ctemp=coef[0]*v2rhosigma[idx].y;
-      Ctemp1=coef[0]*2.0f*v2sigma2[idx].y;
-      Ctemp2=coef[0]*v2sigma2[idx].y*2.0f;
-      Ctemp=Ctemp+coef[1]*v3rho3[idx].y;
-      Ctemp1=Ctemp1+coef[1]*2.0f*v3rho2sigma[idx].y;
-      Ctemp2=Ctemp2+coef[1]*v3rho2sigma[idx].y*2.0f;
-      Ctemp=Ctemp+coef[2]*v3rho2sigma[idx].y;
-      Ctemp1=Ctemp1+coef[2]*2.0f*v3rhosigma2[idx].y;
-      Ctemp2=Ctemp2+coef[2]*v3rhosigma2[idx].y*2.0f;
-      Ctemp=Ctemp+coef[3]*v3rho2sigma[idx].y;
-      Ctemp1=Ctemp1+coef[3]*2.0f*v3rhosigma2[idx].y;
-      Ctemp2=Ctemp2+coef[3]*v3rhosigma2[idx].y*2.0f;
-      Ctemp=Ctemp+coef[4]*v3rho2sigma[idx].y*2.0f;
-      Ctemp1=Ctemp1+coef[4]*2.0f*v3rhosigma2[idx].y*2.0f;
-      Ctemp2=Ctemp2+coef[4]*v3rhosigma2[idx].y*4.0f;
-      Ctemp=Ctemp+coef[5]*v3rho2sigma[idx].y*2.0f;
-      Ctemp1=Ctemp1+coef[5]*2.0f*v3rhosigma2[idx].y*2.0f;
-      Ctemp2=Ctemp2+coef[5]*v3rhosigma2[idx].y*4.0f;
-      Ctemp=Ctemp+coef[6]*v3rhosigma2[idx].y;
-      Ctemp1=Ctemp1+coef[6]*2.0f*v3sigma3[idx].y;
-      Ctemp2=Ctemp2+coef[6]*v3sigma3[idx].y*2.0f;
-      Ctemp=Ctemp+coef[7]*v3rhosigma2[idx].y*2.0f;
-      Ctemp1=Ctemp1+coef[7]*2.0f*v3sigma3[idx].y*2.0f;
-      Ctemp2=Ctemp2+coef[7]*v3sigma3[idx].y*4.0f;
-      Ctemp=Ctemp+coef[8]*v3rhosigma2[idx].y*2.0f;
-      Ctemp1=Ctemp1+coef[8]*2.0f*v3sigma3[idx].y*2.0f;
-      Ctemp2=Ctemp2+coef[8]*v3sigma3[idx].y*4.0f;
-      Ctemp=Ctemp+coef[9]*v3rhosigma2[idx].y*4.0f;
-      Ctemp1=Ctemp1+coef[9]*2.0f*v3sigma3[idx].y*4.0f;
-      Ctemp2=Ctemp2+coef[9]*v3sigma3[idx].y*8.0f;
+    // F CORE
+    coef[0] = 2.0f * cont_grad[0];
+    coef[1] = tr_dens[0] * tr_dens[0];
+    coef[2] = 2.0f * tr_dens[0] * grad_all[0];
+    coef[3] = 2.0f * grad_all[0] * tr_dens[0];
+    coef[4] = grad_all[0] * tr_dens[0];
+    coef[5] = tr_dens[0] * grad_all[0];
+    coef[6] = 4.0f * grad_all[0] * grad_all[0];
+    coef[7] = 2.0f * grad_all[0] * grad_all[0];
+    coef[8] = 2.0f * grad_all[0] * grad_all[0];
+    coef[9] = grad_all[0] * grad_all[0];
 
-      coef[0]=2.0f*cont_grad[1];
-      coef[1]=tr_dens[1]*tr_dens[1];
-      coef[2]=2.0f*tr_dens[1]*grad_all[1];
-      coef[3]=2.0f*grad_all[1]*tr_dens[1];
-      coef[4]=grad_all[1]*tr_dens[1];
-      coef[5]=tr_dens[1]*grad_all[1];
-      coef[6]=4.0f*grad_all[1]*grad_all[1];
-      coef[7]=2.0f*grad_all[1]*grad_all[1];
-      coef[8]=2.0f*grad_all[1]*grad_all[1];
-      coef[9]=grad_all[1]*grad_all[1];
+    // EXCHANGE
+    double Xtemp, Xtemp1;
+    Xtemp = coef[0] * v2rhosigma[idx].x * 4.0f;
+    Xtemp1 = coef[0] * 2.0f * v2sigma2[idx].x * 8.0f;
+    Xtemp = Xtemp + coef[1] * v3rho3[idx].x * 4.0f;
+    Xtemp1 = Xtemp1 + coef[1] * 2.0f * v3rho2sigma[idx].x * 8.0f;
+    Xtemp = Xtemp + coef[2] * v3rho2sigma[idx].x * 8.0f;
+    Xtemp1 = Xtemp1 + coef[2] * 2.0f * v3rhosigma2[idx].x * 16.0f;
+    Xtemp = Xtemp + coef[3] * v3rho2sigma[idx].x * 8.0f;
+    Xtemp1 = Xtemp1 + coef[3] * 2.0f * v3rhosigma2[idx].x * 16.0f;
+    Xtemp = Xtemp + coef[6] * v3rhosigma2[idx].x * 16.0f;
+    Xtemp1 = Xtemp1 + coef[6] * 2.0f * v3sigma3[idx].x * 32.0f;
 
-      Ctemp=Ctemp+coef[0]*v2rhosigma[idx].y;
-      Ctemp1=Ctemp1+coef[0]*2.0f*v2sigma2[idx].y;
-      Ctemp2=Ctemp2+coef[0]*v2sigma2[idx].y*2.0f;
-      Ctemp=Ctemp+coef[1]*v3rho3[idx].y;
-      Ctemp1=Ctemp1+coef[1]*2.0f*v3rho2sigma[idx].y;
-      Ctemp2=Ctemp2+coef[1]*v3rho2sigma[idx].y*2.0f;
-      Ctemp=Ctemp+coef[2]*v3rho2sigma[idx].y;
-      Ctemp1=Ctemp1+coef[2]*2.0f*v3rhosigma2[idx].y;
-      Ctemp2=Ctemp2+coef[2]*v3rhosigma2[idx].y*2.0f;
-      Ctemp=Ctemp+coef[3]*v3rho2sigma[idx].y;
-      Ctemp1=Ctemp1+coef[3]*2.0f*v3rhosigma2[idx].y;
-      Ctemp2=Ctemp2+coef[3]*v3rhosigma2[idx].y*2.0f;
-      Ctemp=Ctemp+coef[4]*v3rho2sigma[idx].y*2.0f;
-      Ctemp1=Ctemp1+coef[4]*2.0f*v3rhosigma2[idx].y*2.0f;
-      Ctemp2=Ctemp2+coef[4]*v3rhosigma2[idx].y*4.0f;
-      Ctemp=Ctemp+coef[5]*v3rho2sigma[idx].y*2.0f;
-      Ctemp1=Ctemp1+coef[5]*2.0f*v3rhosigma2[idx].y*2.0f;
-      Ctemp2=Ctemp2+coef[5]*v3rhosigma2[idx].y*4.0f;
-      Ctemp=Ctemp+coef[6]*v3rhosigma2[idx].y;
-      Ctemp1=Ctemp1+coef[6]*2.0f*v3sigma3[idx].y;
-      Ctemp2=Ctemp2+coef[6]*v3sigma3[idx].y*2.0f;
-      Ctemp=Ctemp+coef[7]*v3rhosigma2[idx].y*2.0f;
-      Ctemp1=Ctemp1+coef[7]*2.0f*v3sigma3[idx].y*2.0f;
-      Ctemp2=Ctemp2+coef[7]*v3sigma3[idx].y*4.0f;
-      Ctemp=Ctemp+coef[8]*v3rhosigma2[idx].y*2.0f;
-      Ctemp1=Ctemp1+coef[8]*2.0f*v3sigma3[idx].y*2.0f;
-      Ctemp2=Ctemp2+coef[8]*v3sigma3[idx].y*4.0f;
-      Ctemp=Ctemp+coef[9]*v3rhosigma2[idx].y*4.0f;
-      Ctemp1=Ctemp1+coef[9]*2.0f*v3sigma3[idx].y*4.0f;
-      Ctemp2=Ctemp2+coef[9]*v3sigma3[idx].y*8.0f;
+    // CORRELATION
+    double Ctemp, Ctemp1, Ctemp2;
+    Ctemp = coef[0] * v2rhosigma[idx].y;
+    Ctemp1 = coef[0] * 2.0f * v2sigma2[idx].y;
+    Ctemp2 = coef[0] * v2sigma2[idx].y * 2.0f;
+    Ctemp = Ctemp + coef[1] * v3rho3[idx].y;
+    Ctemp1 = Ctemp1 + coef[1] * 2.0f * v3rho2sigma[idx].y;
+    Ctemp2 = Ctemp2 + coef[1] * v3rho2sigma[idx].y * 2.0f;
+    Ctemp = Ctemp + coef[2] * v3rho2sigma[idx].y;
+    Ctemp1 = Ctemp1 + coef[2] * 2.0f * v3rhosigma2[idx].y;
+    Ctemp2 = Ctemp2 + coef[2] * v3rhosigma2[idx].y * 2.0f;
+    Ctemp = Ctemp + coef[3] * v3rho2sigma[idx].y;
+    Ctemp1 = Ctemp1 + coef[3] * 2.0f * v3rhosigma2[idx].y;
+    Ctemp2 = Ctemp2 + coef[3] * v3rhosigma2[idx].y * 2.0f;
+    Ctemp = Ctemp + coef[4] * v3rho2sigma[idx].y * 2.0f;
+    Ctemp1 = Ctemp1 + coef[4] * 2.0f * v3rhosigma2[idx].y * 2.0f;
+    Ctemp2 = Ctemp2 + coef[4] * v3rhosigma2[idx].y * 4.0f;
+    Ctemp = Ctemp + coef[5] * v3rho2sigma[idx].y * 2.0f;
+    Ctemp1 = Ctemp1 + coef[5] * 2.0f * v3rhosigma2[idx].y * 2.0f;
+    Ctemp2 = Ctemp2 + coef[5] * v3rhosigma2[idx].y * 4.0f;
+    Ctemp = Ctemp + coef[6] * v3rhosigma2[idx].y;
+    Ctemp1 = Ctemp1 + coef[6] * 2.0f * v3sigma3[idx].y;
+    Ctemp2 = Ctemp2 + coef[6] * v3sigma3[idx].y * 2.0f;
+    Ctemp = Ctemp + coef[7] * v3rhosigma2[idx].y * 2.0f;
+    Ctemp1 = Ctemp1 + coef[7] * 2.0f * v3sigma3[idx].y * 2.0f;
+    Ctemp2 = Ctemp2 + coef[7] * v3sigma3[idx].y * 4.0f;
+    Ctemp = Ctemp + coef[8] * v3rhosigma2[idx].y * 2.0f;
+    Ctemp1 = Ctemp1 + coef[8] * 2.0f * v3sigma3[idx].y * 2.0f;
+    Ctemp2 = Ctemp2 + coef[8] * v3sigma3[idx].y * 4.0f;
+    Ctemp = Ctemp + coef[9] * v3rhosigma2[idx].y * 4.0f;
+    Ctemp1 = Ctemp1 + coef[9] * 2.0f * v3sigma3[idx].y * 4.0f;
+    Ctemp2 = Ctemp2 + coef[9] * v3sigma3[idx].y * 8.0f;
 
-      coef[10]=cont_grad[2];
-      coef[11]=tr_dens[0]*tr_dens[1];
-      coef[12]=2.0f*tr_dens[0]*grad_all[1];
-      coef[13]=2.0f*grad_all[0]*tr_dens[1];
-      coef[14]=tr_dens[0]*grad_all[3];
-      coef[15]=grad_all[2]*tr_dens[1];
-      coef[16]=4.0f*grad_all[0]*grad_all[1];
-      coef[17]=2.0f*grad_all[0]*grad_all[3];
-      coef[18]=2.0f*grad_all[2]*grad_all[1];
-      coef[19]=grad_all[2]*grad_all[3];
+    coef[0] = 2.0f * cont_grad[1];
+    coef[1] = tr_dens[1] * tr_dens[1];
+    coef[2] = 2.0f * tr_dens[1] * grad_all[1];
+    coef[3] = 2.0f * grad_all[1] * tr_dens[1];
+    coef[4] = grad_all[1] * tr_dens[1];
+    coef[5] = tr_dens[1] * grad_all[1];
+    coef[6] = 4.0f * grad_all[1] * grad_all[1];
+    coef[7] = 2.0f * grad_all[1] * grad_all[1];
+    coef[8] = 2.0f * grad_all[1] * grad_all[1];
+    coef[9] = grad_all[1] * grad_all[1];
 
-      Ctemp=Ctemp+coef[10]*v2rhosigma[idx].y*2.0f;
-      Ctemp1=Ctemp1+coef[10]*2.0f*v2sigma2[idx].y*2.0f;
-      Ctemp2=Ctemp2+coef[10]*v2sigma2[idx].y*4.0f;
-      Ctemp=Ctemp+coef[11]*v3rho3[idx].y;
-      Ctemp1=Ctemp1+coef[11]*2.0f*v3rho2sigma[idx].y;
-      Ctemp2=Ctemp2+coef[11]*v3rho2sigma[idx].y*2.0f;
-      Ctemp=Ctemp+coef[12]*v3rho2sigma[idx].y;
-      Ctemp1=Ctemp1+coef[12]*2.0f*v3rhosigma2[idx].y;
-      Ctemp2=Ctemp2+coef[12]*v3rhosigma2[idx].y*2.0f;
-      Ctemp=Ctemp+coef[13]*v3rho2sigma[idx].y;
-      Ctemp1=Ctemp1+coef[13]*2.0f*v3rhosigma2[idx].y;
-      Ctemp2=Ctemp2+coef[13]*v3rhosigma2[idx].y*2.0f;
-      Ctemp=Ctemp+coef[14]*v3rho2sigma[idx].y*2.0f;
-      Ctemp1=Ctemp1+coef[14]*2.0f*v3rhosigma2[idx].y*2.0f;
-      Ctemp2=Ctemp2+coef[14]*v3rhosigma2[idx].y*4.0f;
-      Ctemp=Ctemp+coef[15]*v3rho2sigma[idx].y*2.0f;
-      Ctemp1=Ctemp1+coef[15]*2.0f*v3rhosigma2[idx].y*2.0f;
-      Ctemp2=Ctemp2+coef[15]*v3rhosigma2[idx].y*4.0f;
-      Ctemp=Ctemp+coef[16]*v3rhosigma2[idx].y;
-      Ctemp1=Ctemp1+coef[16]*2.0f*v3sigma3[idx].y;
-      Ctemp2=Ctemp2+coef[16]*v3sigma3[idx].y*2.0f;
-      Ctemp=Ctemp+coef[17]*v3rhosigma2[idx].y*2.0f;
-      Ctemp1=Ctemp1+coef[17]*2.0f*v3sigma3[idx].y*2.0f;
-      Ctemp2=Ctemp2+coef[17]*v3sigma3[idx].y*4.0f;
-      Ctemp=Ctemp+coef[18]*v3rhosigma2[idx].y*2.0f;
-      Ctemp1=Ctemp1+coef[18]*2.0f*v3sigma3[idx].y*2.0f;
-      Ctemp2=Ctemp2+coef[18]*v3sigma3[idx].y*4.0f;
-      Ctemp=Ctemp+coef[19]*v3rhosigma2[idx].y*4.0f;
-      Ctemp1=Ctemp1+coef[19]*2.0f*v3sigma3[idx].y*4.0f;
-      Ctemp2=Ctemp2+coef[19]*v3sigma3[idx].y*8.0f;
+    Ctemp = Ctemp + coef[0] * v2rhosigma[idx].y;
+    Ctemp1 = Ctemp1 + coef[0] * 2.0f * v2sigma2[idx].y;
+    Ctemp2 = Ctemp2 + coef[0] * v2sigma2[idx].y * 2.0f;
+    Ctemp = Ctemp + coef[1] * v3rho3[idx].y;
+    Ctemp1 = Ctemp1 + coef[1] * 2.0f * v3rho2sigma[idx].y;
+    Ctemp2 = Ctemp2 + coef[1] * v3rho2sigma[idx].y * 2.0f;
+    Ctemp = Ctemp + coef[2] * v3rho2sigma[idx].y;
+    Ctemp1 = Ctemp1 + coef[2] * 2.0f * v3rhosigma2[idx].y;
+    Ctemp2 = Ctemp2 + coef[2] * v3rhosigma2[idx].y * 2.0f;
+    Ctemp = Ctemp + coef[3] * v3rho2sigma[idx].y;
+    Ctemp1 = Ctemp1 + coef[3] * 2.0f * v3rhosigma2[idx].y;
+    Ctemp2 = Ctemp2 + coef[3] * v3rhosigma2[idx].y * 2.0f;
+    Ctemp = Ctemp + coef[4] * v3rho2sigma[idx].y * 2.0f;
+    Ctemp1 = Ctemp1 + coef[4] * 2.0f * v3rhosigma2[idx].y * 2.0f;
+    Ctemp2 = Ctemp2 + coef[4] * v3rhosigma2[idx].y * 4.0f;
+    Ctemp = Ctemp + coef[5] * v3rho2sigma[idx].y * 2.0f;
+    Ctemp1 = Ctemp1 + coef[5] * 2.0f * v3rhosigma2[idx].y * 2.0f;
+    Ctemp2 = Ctemp2 + coef[5] * v3rhosigma2[idx].y * 4.0f;
+    Ctemp = Ctemp + coef[6] * v3rhosigma2[idx].y;
+    Ctemp1 = Ctemp1 + coef[6] * 2.0f * v3sigma3[idx].y;
+    Ctemp2 = Ctemp2 + coef[6] * v3sigma3[idx].y * 2.0f;
+    Ctemp = Ctemp + coef[7] * v3rhosigma2[idx].y * 2.0f;
+    Ctemp1 = Ctemp1 + coef[7] * 2.0f * v3sigma3[idx].y * 2.0f;
+    Ctemp2 = Ctemp2 + coef[7] * v3sigma3[idx].y * 4.0f;
+    Ctemp = Ctemp + coef[8] * v3rhosigma2[idx].y * 2.0f;
+    Ctemp1 = Ctemp1 + coef[8] * 2.0f * v3sigma3[idx].y * 2.0f;
+    Ctemp2 = Ctemp2 + coef[8] * v3sigma3[idx].y * 4.0f;
+    Ctemp = Ctemp + coef[9] * v3rhosigma2[idx].y * 4.0f;
+    Ctemp1 = Ctemp1 + coef[9] * 2.0f * v3sigma3[idx].y * 4.0f;
+    Ctemp2 = Ctemp2 + coef[9] * v3sigma3[idx].y * 8.0f;
 
-      // **BA_TERM=AB_TERM**
-      coef[10]=cont_grad[2];
-      coef[11]=tr_dens[0]*tr_dens[1];
-      coef[12]=2.0f*tr_dens[0]*grad_all[1];
-      coef[13]=2.0f*grad_all[0]*tr_dens[1];
-      coef[14]=tr_dens[0]*grad_all[3];
-      coef[15]=grad_all[2]*tr_dens[1];
-      coef[16]=4.0f*grad_all[0]*grad_all[1];
-      coef[17]=2.0f*grad_all[0]*grad_all[3];
-      coef[18]=2.0f*grad_all[2]*grad_all[1];
-      coef[19]=grad_all[2]*grad_all[3];
+    coef[10] = cont_grad[2];
+    coef[11] = tr_dens[0] * tr_dens[1];
+    coef[12] = 2.0f * tr_dens[0] * grad_all[1];
+    coef[13] = 2.0f * grad_all[0] * tr_dens[1];
+    coef[14] = tr_dens[0] * grad_all[3];
+    coef[15] = grad_all[2] * tr_dens[1];
+    coef[16] = 4.0f * grad_all[0] * grad_all[1];
+    coef[17] = 2.0f * grad_all[0] * grad_all[3];
+    coef[18] = 2.0f * grad_all[2] * grad_all[1];
+    coef[19] = grad_all[2] * grad_all[3];
 
-      Ctemp=Ctemp+coef[10]*v2rhosigma[idx].y*2.0f;
-      Ctemp1=Ctemp1+coef[10]*2.0f*v2sigma2[idx].y*2.0f;
-      Ctemp2=Ctemp2+coef[10]*v2sigma2[idx].y*4.0f;
-      Ctemp=Ctemp+coef[11]*v3rho3[idx].y;
-      Ctemp1=Ctemp1+coef[11]*2.0f*v3rho2sigma[idx].y;
-      Ctemp2=Ctemp2+coef[11]*v3rho2sigma[idx].y*2.0f;
-      Ctemp=Ctemp+coef[12]*v3rho2sigma[idx].y;
-      Ctemp1=Ctemp1+coef[12]*2.0f*v3rhosigma2[idx].y;
-      Ctemp2=Ctemp2+coef[12]*v3rhosigma2[idx].y*2.0f;
-      Ctemp=Ctemp+coef[13]*v3rho2sigma[idx].y;
-      Ctemp1=Ctemp1+coef[13]*2.0f*v3rhosigma2[idx].y;
-      Ctemp2=Ctemp2+coef[13]*v3rhosigma2[idx].y*2.0f;
-      Ctemp=Ctemp+coef[14]*v3rho2sigma[idx].y*2.0f;
-      Ctemp1=Ctemp1+coef[14]*2.0f*v3rhosigma2[idx].y*2.0f;
-      Ctemp2=Ctemp2+coef[14]*v3rhosigma2[idx].y*4.0f;
-      Ctemp=Ctemp+coef[15]*v3rho2sigma[idx].y*2.0f;
-      Ctemp1=Ctemp1+coef[15]*2.0f*v3rhosigma2[idx].y*2.0f;
-      Ctemp2=Ctemp2+coef[15]*v3rhosigma2[idx].y*4.0f;
-      Ctemp=Ctemp+coef[16]*v3rhosigma2[idx].y;
-      Ctemp1=Ctemp1+coef[16]*2.0f*v3sigma3[idx].y;
-      Ctemp2=Ctemp2+coef[16]*v3sigma3[idx].y*2.0f;
-      Ctemp=Ctemp+coef[17]*v3rhosigma2[idx].y*2.0f;
-      Ctemp1=Ctemp1+coef[17]*2.0f*v3sigma3[idx].y*2.0f;
-      Ctemp2=Ctemp2+coef[17]*v3sigma3[idx].y*4.0f;
-      Ctemp=Ctemp+coef[18]*v3rhosigma2[idx].y*2.0f;
-      Ctemp1=Ctemp1+coef[18]*2.0f*v3sigma3[idx].y*2.0f;
-      Ctemp2=Ctemp2+coef[18]*v3sigma3[idx].y*4.0f;
-      Ctemp=Ctemp+coef[19]*v3rhosigma2[idx].y*4.0f;
-      Ctemp1=Ctemp1+coef[19]*2.0f*v3sigma3[idx].y*4.0f;
-      Ctemp2=Ctemp2+coef[19]*v3sigma3[idx].y*8.0f;
+    Ctemp = Ctemp + coef[10] * v2rhosigma[idx].y * 2.0f;
+    Ctemp1 = Ctemp1 + coef[10] * 2.0f * v2sigma2[idx].y * 2.0f;
+    Ctemp2 = Ctemp2 + coef[10] * v2sigma2[idx].y * 4.0f;
+    Ctemp = Ctemp + coef[11] * v3rho3[idx].y;
+    Ctemp1 = Ctemp1 + coef[11] * 2.0f * v3rho2sigma[idx].y;
+    Ctemp2 = Ctemp2 + coef[11] * v3rho2sigma[idx].y * 2.0f;
+    Ctemp = Ctemp + coef[12] * v3rho2sigma[idx].y;
+    Ctemp1 = Ctemp1 + coef[12] * 2.0f * v3rhosigma2[idx].y;
+    Ctemp2 = Ctemp2 + coef[12] * v3rhosigma2[idx].y * 2.0f;
+    Ctemp = Ctemp + coef[13] * v3rho2sigma[idx].y;
+    Ctemp1 = Ctemp1 + coef[13] * 2.0f * v3rhosigma2[idx].y;
+    Ctemp2 = Ctemp2 + coef[13] * v3rhosigma2[idx].y * 2.0f;
+    Ctemp = Ctemp + coef[14] * v3rho2sigma[idx].y * 2.0f;
+    Ctemp1 = Ctemp1 + coef[14] * 2.0f * v3rhosigma2[idx].y * 2.0f;
+    Ctemp2 = Ctemp2 + coef[14] * v3rhosigma2[idx].y * 4.0f;
+    Ctemp = Ctemp + coef[15] * v3rho2sigma[idx].y * 2.0f;
+    Ctemp1 = Ctemp1 + coef[15] * 2.0f * v3rhosigma2[idx].y * 2.0f;
+    Ctemp2 = Ctemp2 + coef[15] * v3rhosigma2[idx].y * 4.0f;
+    Ctemp = Ctemp + coef[16] * v3rhosigma2[idx].y;
+    Ctemp1 = Ctemp1 + coef[16] * 2.0f * v3sigma3[idx].y;
+    Ctemp2 = Ctemp2 + coef[16] * v3sigma3[idx].y * 2.0f;
+    Ctemp = Ctemp + coef[17] * v3rhosigma2[idx].y * 2.0f;
+    Ctemp1 = Ctemp1 + coef[17] * 2.0f * v3sigma3[idx].y * 2.0f;
+    Ctemp2 = Ctemp2 + coef[17] * v3sigma3[idx].y * 4.0f;
+    Ctemp = Ctemp + coef[18] * v3rhosigma2[idx].y * 2.0f;
+    Ctemp1 = Ctemp1 + coef[18] * 2.0f * v3sigma3[idx].y * 2.0f;
+    Ctemp2 = Ctemp2 + coef[18] * v3sigma3[idx].y * 4.0f;
+    Ctemp = Ctemp + coef[19] * v3rhosigma2[idx].y * 4.0f;
+    Ctemp1 = Ctemp1 + coef[19] * 2.0f * v3sigma3[idx].y * 4.0f;
+    Ctemp2 = Ctemp2 + coef[19] * v3sigma3[idx].y * 8.0f;
 
-      // CONTRACTION OF FC
-      double fcdens,fcdensG1,fcdensG2,fcdgradX,fcdgradY,fcdgradZ;
-      fcdens=Xtemp+Ctemp;
-      fcdensG1=Xtemp1+Ctemp1;
-      fcdensG2=Ctemp2;
-      fcdgradX=fcdensG1*gdensX+fcdensG2*gdensX;
-      fcdgradY=fcdensG1*gdensY+fcdensG2*gdensY;
-      fcdgradZ=fcdensG1*gdensZ+fcdensG2*gdensZ;
+    // **BA_TERM=AB_TERM**
+    coef[10] = cont_grad[2];
+    coef[11] = tr_dens[0] * tr_dens[1];
+    coef[12] = 2.0f * tr_dens[0] * grad_all[1];
+    coef[13] = 2.0f * grad_all[0] * tr_dens[1];
+    coef[14] = tr_dens[0] * grad_all[3];
+    coef[15] = grad_all[2] * tr_dens[1];
+    coef[16] = 4.0f * grad_all[0] * grad_all[1];
+    coef[17] = 2.0f * grad_all[0] * grad_all[3];
+    coef[18] = 2.0f * grad_all[2] * grad_all[1];
+    coef[19] = grad_all[2] * grad_all[3];
 
-      // DENSITY FACTOR
-      dfac[idx]+=fcdens;
-      dfacxyz[idx].x+=fnctredX+fcdgradX;
-      dfacxyz[idx].y+=fnctredY+fcdgradY;
-      dfacxyz[idx].z+=fnctredZ+fcdgradZ;
+    Ctemp = Ctemp + coef[10] * v2rhosigma[idx].y * 2.0f;
+    Ctemp1 = Ctemp1 + coef[10] * 2.0f * v2sigma2[idx].y * 2.0f;
+    Ctemp2 = Ctemp2 + coef[10] * v2sigma2[idx].y * 4.0f;
+    Ctemp = Ctemp + coef[11] * v3rho3[idx].y;
+    Ctemp1 = Ctemp1 + coef[11] * 2.0f * v3rho2sigma[idx].y;
+    Ctemp2 = Ctemp2 + coef[11] * v3rho2sigma[idx].y * 2.0f;
+    Ctemp = Ctemp + coef[12] * v3rho2sigma[idx].y;
+    Ctemp1 = Ctemp1 + coef[12] * 2.0f * v3rhosigma2[idx].y;
+    Ctemp2 = Ctemp2 + coef[12] * v3rhosigma2[idx].y * 2.0f;
+    Ctemp = Ctemp + coef[13] * v3rho2sigma[idx].y;
+    Ctemp1 = Ctemp1 + coef[13] * 2.0f * v3rhosigma2[idx].y;
+    Ctemp2 = Ctemp2 + coef[13] * v3rhosigma2[idx].y * 2.0f;
+    Ctemp = Ctemp + coef[14] * v3rho2sigma[idx].y * 2.0f;
+    Ctemp1 = Ctemp1 + coef[14] * 2.0f * v3rhosigma2[idx].y * 2.0f;
+    Ctemp2 = Ctemp2 + coef[14] * v3rhosigma2[idx].y * 4.0f;
+    Ctemp = Ctemp + coef[15] * v3rho2sigma[idx].y * 2.0f;
+    Ctemp1 = Ctemp1 + coef[15] * 2.0f * v3rhosigma2[idx].y * 2.0f;
+    Ctemp2 = Ctemp2 + coef[15] * v3rhosigma2[idx].y * 4.0f;
+    Ctemp = Ctemp + coef[16] * v3rhosigma2[idx].y;
+    Ctemp1 = Ctemp1 + coef[16] * 2.0f * v3sigma3[idx].y;
+    Ctemp2 = Ctemp2 + coef[16] * v3sigma3[idx].y * 2.0f;
+    Ctemp = Ctemp + coef[17] * v3rhosigma2[idx].y * 2.0f;
+    Ctemp1 = Ctemp1 + coef[17] * 2.0f * v3sigma3[idx].y * 2.0f;
+    Ctemp2 = Ctemp2 + coef[17] * v3sigma3[idx].y * 4.0f;
+    Ctemp = Ctemp + coef[18] * v3rhosigma2[idx].y * 2.0f;
+    Ctemp1 = Ctemp1 + coef[18] * 2.0f * v3sigma3[idx].y * 2.0f;
+    Ctemp2 = Ctemp2 + coef[18] * v3sigma3[idx].y * 4.0f;
+    Ctemp = Ctemp + coef[19] * v3rhosigma2[idx].y * 4.0f;
+    Ctemp1 = Ctemp1 + coef[19] * 2.0f * v3sigma3[idx].y * 4.0f;
+    Ctemp2 = Ctemp2 + coef[19] * v3sigma3[idx].y * 8.0f;
 
-      // TRANSITION DENSITY FACTOR
-      tfac[idx]=fncdens;
-      tfacxyz[idx].x=fncdensX;
-      tfacxyz[idx].y=fncdensY;
-      tfacxyz[idx].z=fncdensZ;
-   }
+    // CONTRACTION OF FC
+    double fcdens, fcdensG1, fcdensG2, fcdgradX, fcdgradY, fcdgradZ;
+    fcdens = Xtemp + Ctemp;
+    fcdensG1 = Xtemp1 + Ctemp1;
+    fcdensG2 = Ctemp2;
+    fcdgradX = fcdensG1 * gdensX + fcdensG2 * gdensX;
+    fcdgradY = fcdensG1 * gdensY + fcdensG2 * gdensY;
+    fcdgradZ = fcdensG1 * gdensZ + fcdensG2 * gdensZ;
+
+    // DENSITY FACTOR
+    dfac[idx] += fcdens;
+    dfacxyz[idx].x += fnctredX + fcdgradX;
+    dfacxyz[idx].y += fnctredY + fcdgradY;
+    dfacxyz[idx].z += fnctredZ + fcdgradZ;
+
+    // TRANSITION DENSITY FACTOR
+    tfac[idx] = fncdens;
+    tfacxyz[idx].x = fncdensX;
+    tfacxyz[idx].y = fncdensY;
+    tfacxyz[idx].z = fncdensZ;
+  }
 }

--- a/g2g/excited/cuda/gpu_partial_forces.h
+++ b/g2g/excited/cuda/gpu_partial_forces.h
@@ -1,73 +1,76 @@
-template<class T, bool compute_energy, bool compute_factor, bool lda>
-__global__ void gpu_partial_forces(const T* fv, const vec_type<T, 4>* gv,
-	   const vec_type<T, 4>* hv, const T* mat_dens, const T* mat_tred,
-           const T* mat_diff, const T* dens, const T* tred, const T* diff,
-           const G2G::vec_type<T,4>* dxyz, const G2G::vec_type<T,4>* tredxyz, 
-           const G2G::vec_type<T,4>* diffxyz, G2G::vec_type<T,4>* force, 
-           int basis_tot, uint npoints, const T* const weights, int dim_block)
-{
-   int ii  = blockIdx.x;
-   int block_ii = threadIdx.x;
-   int start_point = block_ii * POINTS_BLOCK_SIZE;
-   int end_point = start_point + POINTS_BLOCK_SIZE;
-   int dim = basis_tot;
-   int element = ii * dim_block + block_ii;
+template <class T, bool compute_energy, bool compute_factor, bool lda>
+__global__ void gpu_partial_forces(
+    const T* fv, const vec_type<T, 4>* gv, const vec_type<T, 4>* hv,
+    const T* mat_dens, const T* mat_tred, const T* mat_diff, const T* dens,
+    const T* tred, const T* diff, const G2G::vec_type<T, 4>* dxyz,
+    const G2G::vec_type<T, 4>* tredxyz, const G2G::vec_type<T, 4>* diffxyz,
+    G2G::vec_type<T, 4>* force, int basis_tot, uint npoints,
+    const T* const weights, int dim_block) {
+  int ii = blockIdx.x;
+  int block_ii = threadIdx.x;
+  int start_point = block_ii * POINTS_BLOCK_SIZE;
+  int end_point = start_point + POINTS_BLOCK_SIZE;
+  int dim = basis_tot;
+  int element = ii * dim_block + block_ii;
 
-   double fvj;
-   double factor, temp[4];
-   double DJII, PJII, VJII;
-   double wp;
-   double grdx, grdy, grdz;
-   vec_type<T, 4> h1, h2; // h1 = hxx, hyy, hzz // h2 = hxy, hxz, hyz //
-   vec_type<T, 4> gfii, gfj;
+  double fvj;
+  double factor, temp[4];
+  double DJII, PJII, VJII;
+  double wp;
+  double grdx, grdy, grdz;
+  vec_type<T, 4> h1, h2;  // h1 = hxx, hyy, hzz // h2 = hxy, hxz, hyz //
+  vec_type<T, 4> gfii, gfj;
 
-   for(int point = start_point; point < end_point; point++) {
-      if ( point < npoints ) {
-         h1 = vec_type<T,4>(hv[basis_tot*2*point+(2*ii+0)]);
-         h2 = vec_type<T,4>(hv[basis_tot*2*point+(2*ii+1)]);
-         gfii = vec_type<T,4>(gv[basis_tot*point+ii]);
-         wp = weights[point];
-         grdx = grdy = grdz = 0.0f;
+  for (int point = start_point; point < end_point; point++) {
+    if (point < npoints) {
+      h1 = vec_type<T, 4>(hv[basis_tot * 2 * point + (2 * ii + 0)]);
+      h2 = vec_type<T, 4>(hv[basis_tot * 2 * point + (2 * ii + 1)]);
+      gfii = vec_type<T, 4>(gv[basis_tot * point + ii]);
+      wp = weights[point];
+      grdx = grdy = grdz = 0.0f;
 
-         for(int j = 0; j < basis_tot; j++) {
-            fvj = fv[basis_tot*point+j];
-            gfj = vec_type<T,4>(gv[basis_tot*point+j]);
-            factor = ( ii == j ? 2.0f:1.0f);
-            DJII = mat_dens[j+ii*dim] * factor * 0.5f;
-            PJII = mat_diff[j+ii*dim] * factor;
-            VJII = mat_tred[j+ii*dim] * factor;
-            temp[0] = 2.0f * (dens[point]*DJII   + diff[point]*PJII      + tred[point]*VJII);
-            temp[1] = 2.0f * (dxyz[point].x*DJII + diffxyz[point].x*PJII + tredxyz[point].x*VJII);
-            temp[2] = 2.0f * (dxyz[point].y*DJII + diffxyz[point].y*PJII + tredxyz[point].y*VJII);
-            temp[3] = 2.0f * (dxyz[point].z*DJII + diffxyz[point].z*PJII + tredxyz[point].z*VJII);
+      for (int j = 0; j < basis_tot; j++) {
+        fvj = fv[basis_tot * point + j];
+        gfj = vec_type<T, 4>(gv[basis_tot * point + j]);
+        factor = (ii == j ? 2.0f : 1.0f);
+        DJII = mat_dens[j + ii * dim] * factor * 0.5f;
+        PJII = mat_diff[j + ii * dim] * factor;
+        VJII = mat_tred[j + ii * dim] * factor;
+        temp[0] = 2.0f * (dens[point] * DJII + diff[point] * PJII +
+                          tred[point] * VJII);
+        temp[1] = 2.0f * (dxyz[point].x * DJII + diffxyz[point].x * PJII +
+                          tredxyz[point].x * VJII);
+        temp[2] = 2.0f * (dxyz[point].y * DJII + diffxyz[point].y * PJII +
+                          tredxyz[point].y * VJII);
+        temp[3] = 2.0f * (dxyz[point].z * DJII + diffxyz[point].z * PJII +
+                          tredxyz[point].z * VJII);
 
-            grdx += temp[0]*gfii.x*fvj;
-            grdx += temp[1]*( h1.x*fvj + gfii.x*gfj.x );
-            grdx += temp[2]*( h2.x*fvj + gfii.x*gfj.y );
-            grdx += temp[3]*( h2.y*fvj + gfii.x*gfj.z );
+        grdx += temp[0] * gfii.x * fvj;
+        grdx += temp[1] * (h1.x * fvj + gfii.x * gfj.x);
+        grdx += temp[2] * (h2.x * fvj + gfii.x * gfj.y);
+        grdx += temp[3] * (h2.y * fvj + gfii.x * gfj.z);
 
-            grdy += temp[0]*gfii.y*fvj;
-            grdy += temp[1]*( h2.x*fvj + gfii.y*gfj.x );
-            grdy += temp[2]*( h1.y*fvj + gfii.y*gfj.y );
-            grdy += temp[3]*( h2.z*fvj + gfii.y*gfj.z );
+        grdy += temp[0] * gfii.y * fvj;
+        grdy += temp[1] * (h2.x * fvj + gfii.y * gfj.x);
+        grdy += temp[2] * (h1.y * fvj + gfii.y * gfj.y);
+        grdy += temp[3] * (h2.z * fvj + gfii.y * gfj.z);
 
-            grdz += temp[0]*gfii.z*fvj;
-            grdz += temp[1]*( h2.y*fvj + gfii.z*gfj.x );
-            grdz += temp[2]*( h2.z*fvj + gfii.z*gfj.y );
-            grdz += temp[3]*( h1.z*fvj + gfii.z*gfj.z );
-         } // end j
-         force[element] += G2G::vec_type<T,WIDTH>(grdx*wp,grdy*wp,grdz*wp,0.0f);
-      } // end if point
-   } // end point
+        grdz += temp[0] * gfii.z * fvj;
+        grdz += temp[1] * (h2.y * fvj + gfii.z * gfj.x);
+        grdz += temp[2] * (h2.z * fvj + gfii.z * gfj.y);
+        grdz += temp[3] * (h1.z * fvj + gfii.z * gfj.z);
+      }  // end j
+      force[element] +=
+          G2G::vec_type<T, WIDTH>(grdx * wp, grdy * wp, grdz * wp, 0.0f);
+    }  // end if point
+  }    // end point
 }
 
-template<class T, bool compute_energy, bool compute_factor, bool lda>
-__global__ void gpu_accum_forces(const G2G::vec_type<T,4>* force_in, G2G::vec_type<T,4>* force_out,
-                                 int dim_block, int M)
-{
-   int ii  = blockIdx.x;
-   for (int jj=0; jj<dim_block; jj++)
-      force_out[ii] += force_in[ii*dim_block+jj];
+template <class T, bool compute_energy, bool compute_factor, bool lda>
+__global__ void gpu_accum_forces(const G2G::vec_type<T, 4>* force_in,
+                                 G2G::vec_type<T, 4>* force_out, int dim_block,
+                                 int M) {
+  int ii = blockIdx.x;
+  for (int jj = 0; jj < dim_block; jj++)
+    force_out[ii] += force_in[ii * dim_block + jj];
 }
-
-

--- a/g2g/excited/cuda/gpu_vxc.h
+++ b/g2g/excited/cuda/gpu_vxc.h
@@ -1,115 +1,115 @@
-template<class T, bool compute_energy, bool compute_factor, bool lda>
-__global__ void gpu_calc_VXC(uint points, T* diff, G2G::vec_type<T,WIDTH>* dxyz, 
-              G2G::vec_type<T,WIDTH>* diffxyz, G2G::vec_type<T,2>* vrho, 
-              G2G::vec_type<T,2>* vsigma, G2G::vec_type<T,2>* v2rho2,
-              G2G::vec_type<T,2>* v2rhosigma, G2G::vec_type<T,2>* v2sigma2,
-              // OUTPUTS //
-              T* dfac, T* pfac, G2G::vec_type<T,WIDTH>* dfacxyz, G2G::vec_type<T,WIDTH>* pfacxyz,
-              int gamma)
-{
-   uint idx = blockDim.x * blockIdx.x + threadIdx.x;
-   if ( idx < points ) {
+template <class T, bool compute_energy, bool compute_factor, bool lda>
+__global__ void gpu_calc_VXC(
+    uint points, T* diff, G2G::vec_type<T, WIDTH>* dxyz,
+    G2G::vec_type<T, WIDTH>* diffxyz, G2G::vec_type<T, 2>* vrho,
+    G2G::vec_type<T, 2>* vsigma, G2G::vec_type<T, 2>* v2rho2,
+    G2G::vec_type<T, 2>* v2rhosigma, G2G::vec_type<T, 2>* v2sigma2,
+    // OUTPUTS //
+    T* dfac, T* pfac, G2G::vec_type<T, WIDTH>* dfacxyz,
+    G2G::vec_type<T, WIDTH>* pfacxyz, int gamma) {
+  uint idx = blockDim.x * blockIdx.x + threadIdx.x;
+  if (idx < points) {
+    // DIFFERENCE RELAXED DENSITY
+    double coef[6];
 
-      // DIFFERENCE RELAXED DENSITY
-      double coef[6];
+    double dd = diff[idx];
+    double diff_derX, diff_derY, diff_derZ;
+    double dens_derX, dens_derY, dens_derZ;
 
-      double dd = diff[idx];
-      double diff_derX, diff_derY, diff_derZ;
-      double dens_derX, dens_derY, dens_derZ;
+    diff_derX = diffxyz[idx].x;
+    diff_derY = diffxyz[idx].y;
+    diff_derZ = diffxyz[idx].z;
+    dens_derX = dxyz[idx].x * 0.5f;
+    dens_derY = dxyz[idx].y * 0.5f;
+    dens_derZ = dxyz[idx].z * 0.5f;
 
-      diff_derX = diffxyz[idx].x;
-      diff_derY = diffxyz[idx].y;
-      diff_derZ = diffxyz[idx].z;
-      dens_derX = dxyz[idx].x * 0.5f;
-      dens_derY = dxyz[idx].y * 0.5f;
-      dens_derZ = dxyz[idx].z * 0.5f;
+    double grad;
+    grad =
+        diff_derX * dens_derX + diff_derY * dens_derY + diff_derZ * dens_derZ;
 
-      double grad;
-      grad=diff_derX*dens_derX+diff_derY*dens_derY+diff_derZ*dens_derZ;
+    // GROUND STATE
+    double gdens, gdensG1, gdensG2;
+    gdens = vrho[idx].x + vrho[idx].y;
+    gdensG1 = 2.0f * (vsigma[idx].x * 2.0f + vsigma[idx].y);
+    gdensG2 = vsigma[idx].y * 2.0f;
 
-      // GROUND STATE
-      double gdens,gdensG1,gdensG2;
-      gdens=vrho[idx].x+vrho[idx].y;
-      gdensG1=2.0f*(vsigma[idx].x*2.0f+vsigma[idx].y);
-      gdensG2=vsigma[idx].y*2.0f;
+    // CONTRACTION
+    double gdensX, gdensY, gdensZ;
+    gdensX = gdensG1 * dens_derX + gdensG2 * dens_derX;
+    gdensY = gdensG1 * dens_derY + gdensG2 * dens_derY;
+    gdensZ = gdensG1 * dens_derZ + gdensG2 * dens_derZ;
 
-      // CONTRACTION
-      double gdensX,gdensY,gdensZ;
-      gdensX=gdensG1*dens_derX+gdensG2*dens_derX;
-      gdensY=gdensG1*dens_derY+gdensG2*dens_derY;
-      gdensZ=gdensG1*dens_derZ+gdensG2*dens_derZ;
+    // V NON CORE CONTRIBUTION
+    double dncV1;
+    double grad1, grad2, grad3;
+    dncV1 = vrho[idx].x + vrho[idx].y;
+    grad1 = 2.0f * (vsigma[idx].x * 2.0f + vsigma[idx].y);
+    grad2 = vsigma[idx].y * 2.0f;
+    grad3 = vsigma[idx].y * 2.0f;
 
-      // V NON CORE CONTRIBUTION
-      double dncV1;
-      double grad1,grad2,grad3;
-      dncV1=vrho[idx].x+vrho[idx].y;
-      grad1=2.0f*(vsigma[idx].x*2.0f+vsigma[idx].y);
-      grad2=vsigma[idx].y*2.0f;
-      grad3=vsigma[idx].y*2.0f;
+    double Vncdens, VncdensX, VncdensY, VncdensZ;
+    double VncdiffX, VncdiffY, VncdiffZ;
+    Vncdens = dncV1;
+    VncdensX = grad1 * dens_derX + grad2 * dens_derX;
+    VncdensY = grad1 * dens_derY + grad2 * dens_derY;
+    VncdensZ = grad1 * dens_derZ + grad2 * dens_derZ;
 
-      double Vncdens,VncdensX,VncdensY,VncdensZ;
-      double VncdiffX,VncdiffY,VncdiffZ;
-      Vncdens=dncV1;
-      VncdensX=grad1*dens_derX+grad2*dens_derX;
-      VncdensY=grad1*dens_derY+grad2*dens_derY;
-      VncdensZ=grad1*dens_derZ+grad2*dens_derZ;
-     
-      VncdiffX=grad1*diff_derX+grad3*diff_derX;
-      VncdiffY=grad1*diff_derY+grad3*diff_derY;
-      VncdiffZ=grad1*diff_derZ+grad3*diff_derZ;
+    VncdiffX = grad1 * diff_derX + grad3 * diff_derX;
+    VncdiffY = grad1 * diff_derY + grad3 * diff_derY;
+    VncdiffZ = grad1 * diff_derZ + grad3 * diff_derZ;
 
-      // V CORE CONTRIBUTION
-      coef[0]=dd;
-      coef[1]=2.0f*grad;
-      coef[2]=grad;
-      coef[3]=dd;
-      coef[4]=2.0f*grad;
-      coef[5]=grad;
+    // V CORE CONTRIBUTION
+    coef[0] = dd;
+    coef[1] = 2.0f * grad;
+    coef[2] = grad;
+    coef[3] = dd;
+    coef[4] = 2.0f * grad;
+    coef[5] = grad;
 
-      double term1,term2,term3;
-      term1=coef[0]*v2rho2[idx].x*2.0f;
-      term2=2.0f*coef[0]*(v2rhosigma[idx].x*4.0f+v2rhosigma[idx].y);
-      term3=coef[0]*v2rhosigma[idx].y*2.0f;
-      term1=term1+coef[1]*(v2rhosigma[idx].x*4.0f+v2rhosigma[idx].y);
-      term2=term2+2.0f*coef[1]*(v2sigma2[idx].x*8.0f+v2sigma2[idx].y);
-      term3=term3+coef[1]*v2sigma2[idx].y*2.0f;
-      term1=term1+coef[2]*v2rhosigma[idx].y*2.0f;
-      term2=term2+2.0f*coef[2]*v2sigma2[idx].y*2.0f;
-      term3=term3+coef[2]*v2sigma2[idx].y*4.0f;
-      term1=term1+coef[3]*v2rho2[idx].y*2.0f;
-      term2=term2+2.0f*coef[3]*v2rhosigma[idx].y;
-      term3=term3+coef[3]*v2rhosigma[idx].y*2.0f;
-      term1=term1+coef[4]*v2rhosigma[idx].y;
-      term2=term2+2.0f*coef[4]*v2sigma2[idx].y;
-      term3=term3+coef[4]*v2sigma2[idx].y*2.0f;
-      term1=term1+coef[5]*v2rhosigma[idx].y*2.0f;
-      term2=term2+2.0f*coef[5]*v2sigma2[idx].y*2.0f;
-      term3=term3+coef[5]*v2sigma2[idx].y*4.0f;
+    double term1, term2, term3;
+    term1 = coef[0] * v2rho2[idx].x * 2.0f;
+    term2 = 2.0f * coef[0] * (v2rhosigma[idx].x * 4.0f + v2rhosigma[idx].y);
+    term3 = coef[0] * v2rhosigma[idx].y * 2.0f;
+    term1 = term1 + coef[1] * (v2rhosigma[idx].x * 4.0f + v2rhosigma[idx].y);
+    term2 = term2 + 2.0f * coef[1] * (v2sigma2[idx].x * 8.0f + v2sigma2[idx].y);
+    term3 = term3 + coef[1] * v2sigma2[idx].y * 2.0f;
+    term1 = term1 + coef[2] * v2rhosigma[idx].y * 2.0f;
+    term2 = term2 + 2.0f * coef[2] * v2sigma2[idx].y * 2.0f;
+    term3 = term3 + coef[2] * v2sigma2[idx].y * 4.0f;
+    term1 = term1 + coef[3] * v2rho2[idx].y * 2.0f;
+    term2 = term2 + 2.0f * coef[3] * v2rhosigma[idx].y;
+    term3 = term3 + coef[3] * v2rhosigma[idx].y * 2.0f;
+    term1 = term1 + coef[4] * v2rhosigma[idx].y;
+    term2 = term2 + 2.0f * coef[4] * v2sigma2[idx].y;
+    term3 = term3 + coef[4] * v2sigma2[idx].y * 2.0f;
+    term1 = term1 + coef[5] * v2rhosigma[idx].y * 2.0f;
+    term2 = term2 + 2.0f * coef[5] * v2sigma2[idx].y * 2.0f;
+    term3 = term3 + coef[5] * v2sigma2[idx].y * 4.0f;
 
-      // CONTRACTION OF VC
-      double Vcdiff,VcdiffX,VcdiffY,VcdiffZ;
-      Vcdiff=term1;
-      VcdiffX=term2*dens_derX+term3*dens_derX;
-      VcdiffY=term2*dens_derY+term3*dens_derY;
-      VcdiffZ=term2*dens_derZ+term3*dens_derZ;
-      // END V CORE
+    // CONTRACTION OF VC
+    double Vcdiff, VcdiffX, VcdiffY, VcdiffZ;
+    Vcdiff = term1;
+    VcdiffX = term2 * dens_derX + term3 * dens_derX;
+    VcdiffY = term2 * dens_derY + term3 * dens_derY;
+    VcdiffZ = term2 * dens_derZ + term3 * dens_derZ;
+    // END V CORE
 
-      if (gamma == 1) {
-        gdens=0.0f;
-        gdensX=0.0f;
-        gdensY=0.0f;
-        gdensZ=0.0f;
-      }
+    if (gamma == 1) {
+      gdens = 0.0f;
+      gdensX = 0.0f;
+      gdensY = 0.0f;
+      gdensZ = 0.0f;
+    }
 
-      dfac[idx]=gdens+Vcdiff;
-      dfacxyz[idx].x=gdensX+VncdiffX+VcdiffX;
-      dfacxyz[idx].y=gdensY+VncdiffY+VcdiffY;
-      dfacxyz[idx].z=gdensZ+VncdiffZ+VcdiffZ;
+    dfac[idx] = gdens + Vcdiff;
+    dfacxyz[idx].x = gdensX + VncdiffX + VcdiffX;
+    dfacxyz[idx].y = gdensY + VncdiffY + VcdiffY;
+    dfacxyz[idx].z = gdensZ + VncdiffZ + VcdiffZ;
 
-      // PA
-      pfac[idx]=Vncdens;
-      pfacxyz[idx].x=VncdensX;
-      pfacxyz[idx].y=VncdensY;
-      pfacxyz[idx].z=VncdensZ;
-   }
+    // PA
+    pfac[idx] = Vncdens;
+    pfacxyz[idx].x = VncdensX;
+    pfacxyz[idx].y = VncdensY;
+    pfacxyz[idx].z = VncdensZ;
+  }
 }

--- a/g2g/excited/cuda/obtain_fock_cuda.h
+++ b/g2g/excited/cuda/obtain_fock_cuda.h
@@ -1,30 +1,27 @@
 template <class scalar_type, bool compute_energy, bool compute_factor, bool lda>
-__global__ void gpu_obtain_fock(uint npoints, uint M, const scalar_type* const weights,
-                               const scalar_type* function_values, 
-                               const scalar_type* factor,
-                               scalar_type* Fock)
-{
+__global__ void gpu_obtain_fock(uint npoints, uint M,
+                                const scalar_type* const weights,
+                                const scalar_type* function_values,
+                                const scalar_type* factor, scalar_type* Fock) {
+  int temp = int(sqrtf(1 + 8 * blockIdx.x));
+  temp -= (1 - temp % 2);
+  int block_row = (temp - 1) / 2;
+  int block_col = blockIdx.x - ((block_row + 1) * block_row / 2);
+  int first_row = block_row * blockDim.x;
+  int first_col = block_col * blockDim.y;
+  int row = first_row + threadIdx.x;
+  int col = first_col + threadIdx.y;
+  bool valid_thread = (row < M && col < M && row >= col);
 
-   int temp = int(sqrtf(1 + 8 * blockIdx.x));
-   temp -= (1 - temp % 2);
-   int block_row = ( temp - 1 ) / 2;
-   int block_col = blockIdx.x - ( (block_row+1) * block_row / 2 );
-   int first_row = block_row * blockDim.x;
-   int first_col = block_col * blockDim.y;
-   int row = first_row + threadIdx.x;
-   int col = first_col + threadIdx.y;
-   bool valid_thread = ( row < M && col < M && row >= col );
+  scalar_type term1, term2;
+  scalar_type result = 0.0f;
 
-   scalar_type term1, term2;
-   scalar_type result=0.0f;
-
-   if ( valid_thread ) {
-     for(uint point=0; point<npoints;point++) {
-        term1 = function_values[point*M+col]*factor[point*M+row];
-        term2 = function_values[point*M+row]*factor[point*M+col];
-        result += (term1+term2);
-     }
-     Fock[row*M+col] = result;
-   } // end valid thread
+  if (valid_thread) {
+    for (uint point = 0; point < npoints; point++) {
+      term1 = function_values[point * M + col] * factor[point * M + row];
+      term2 = function_values[point * M + row] * factor[point * M + col];
+      result += (term1 + term2);
+    }
+    Fock[row * M + col] = result;
+  }  // end valid thread
 }
-

--- a/g2g/excited/cuda/obtain_terms.h
+++ b/g2g/excited/cuda/obtain_terms.h
@@ -1,34 +1,34 @@
 template <class scalar_type, bool compute_energy, bool compute_factor, bool lda>
-__global__ void gpu_obtain_term(uint npoints, uint M, const scalar_type* const weights,
-                               const scalar_type* function_values,
-                               const vec_type<scalar_type, 4>* gradient_values,
-                               const scalar_type* factorF,const vec_type<scalar_type, 4>* factorD,
-                               const vec_type<scalar_type, 4>* factorT,
-                               scalar_type* terms)
-{
-   uint point = blockIdx.x;
-   uint func  = threadIdx.x;
-   bool valid_thread = (point < npoints) && (func < M);
- 
-   __shared__ scalar_type wp;
-   scalar_type term1, term2, term3, term4;
+__global__ void gpu_obtain_term(uint npoints, uint M,
+                                const scalar_type* const weights,
+                                const scalar_type* function_values,
+                                const vec_type<scalar_type, 4>* gradient_values,
+                                const scalar_type* factorF,
+                                const vec_type<scalar_type, 4>* factorD,
+                                const vec_type<scalar_type, 4>* factorT,
+                                scalar_type* terms) {
+  uint point = blockIdx.x;
+  uint func = threadIdx.x;
+  bool valid_thread = (point < npoints) && (func < M);
 
-   if (func == 0) wp = weights[point];
-   __syncthreads();
+  __shared__ scalar_type wp;
+  scalar_type term1, term2, term3, term4;
 
-   if ( valid_thread ) {
-      term1  = factorF[point]   * function_values[point*M+func];
-      term1 += factorD[point].x * gradient_values[point*M+func].x;
+  if (func == 0) wp = weights[point];
+  __syncthreads();
 
-      term2  = factorD[point].y * gradient_values[point*M+func].y;
-      term2 += factorD[point].z * gradient_values[point*M+func].z;
+  if (valid_thread) {
+    term1 = factorF[point] * function_values[point * M + func];
+    term1 += factorD[point].x * gradient_values[point * M + func].x;
 
-      term3  = factorT[point].x * gradient_values[point*M+func].x;
-      term3 += factorT[point].y * gradient_values[point*M+func].y;
+    term2 = factorD[point].y * gradient_values[point * M + func].y;
+    term2 += factorD[point].z * gradient_values[point * M + func].z;
 
-      term4  = factorT[point].z * gradient_values[point*M+func].z;
+    term3 = factorT[point].x * gradient_values[point * M + func].x;
+    term3 += factorT[point].y * gradient_values[point * M + func].y;
 
-      terms[point*M+func]   = (term1+term2+term3+term4) * wp;
-   }
+    term4 = factorT[point].z * gradient_values[point * M + func].z;
+
+    terms[point * M + func] = (term1 + term2 + term3 + term4) * wp;
+  }
 }
-

--- a/g2g/excited/fake_subs.cpp
+++ b/g2g/excited/fake_subs.cpp
@@ -9,41 +9,37 @@
 using namespace G2G;
 using namespace std;
 
-extern "C" void g2g_calculatexc_(double* Tmat,double* Fv)
-{
-   cout << " " << endl;
-   cout << " LIBXC was not installed. Compile LIO with libxc=1 or 2" << endl;
-   cout << " " << endl;
-   exit(-1);
+extern "C" void g2g_calculatexc_(double* Tmat, double* Fv) {
+  cout << " " << endl;
+  cout << " LIBXC was not installed. Compile LIO with libxc=1 or 2" << endl;
+  cout << " " << endl;
+  exit(-1);
 }
 
-extern "C" void g2g_calculateg_(double* Tmat,double* F,int& DER)
-{
+extern "C" void g2g_calculateg_(double* Tmat, double* F, int& DER) {}
 
-}
-
-extern "C" void g2g_calcgradxc_(double* P,double* V, double* F)
-{
-
-}
+extern "C" void g2g_calcgradxc_(double* P, double* V, double* F) {}
 
 namespace G2G {
 
-void Partition::solve_lr(double* T,double* F) { }
+void Partition::solve_lr(double* T, double* F) {}
 
-template<class scalar_type> void PointGroupCPU<scalar_type>::
-               solve_closed_lr(double* T,HostMatrix<double>& Fock) { }
+template <class scalar_type>
+void PointGroupCPU<scalar_type>::solve_closed_lr(double* T,
+                                                 HostMatrix<double>& Fock) {}
 
 template <class scalar_type>
 void PointGroupCPU<scalar_type>::get_tred_input(
-     HostMatrix<scalar_type>& tred_input, HostMatrix<double>& source) const { }
+    HostMatrix<scalar_type>& tred_input, HostMatrix<double>& source) const {}
 
-template<class scalar_type> void PointGroupCPU<scalar_type>::
-               solve_3rd_der(double* Tmat,HostMatrix<double>& Fock,int DER) { }
+template <class scalar_type>
+void PointGroupCPU<scalar_type>::solve_3rd_der(double* Tmat,
+                                               HostMatrix<double>& Fock,
+                                               int DER) {}
 
-template <class scalar_type> void PointGroupCPU<scalar_type>::
-               solve_for_exc(double*, double*, G2G::HostMatrix<double>&, int) { }
-
+template <class scalar_type>
+void PointGroupCPU<scalar_type>::solve_for_exc(double*, double*,
+                                               G2G::HostMatrix<double>&, int) {}
 
 #if FULL_DOUBLE
 template class PointGroup<double>;
@@ -52,5 +48,4 @@ template class PointGroupCPU<double>;
 template class PointGroup<float>;
 template class PointGroupCPU<float>;
 #endif
-}
-
+}  // namespace G2G

--- a/g2g/excited/g2g_calcgradXC.cpp
+++ b/g2g/excited/g2g_calcgradXC.cpp
@@ -11,177 +11,188 @@
 using namespace G2G;
 extern Partition partition;
 
-void calc_gradients(double* dens, double* diff, double* trad,
-                    double sigma, double* dfac, double* pfac,
-                    double* tfac, int calc_fxc);
+void calc_gradients(double* dens, double* diff, double* trad, double sigma,
+                    double* dfac, double* pfac, double* tfac, int calc_fxc);
 
-
-extern "C" void g2g_calcgradxc_(double* P,double* V, double* F, int& met)
-{
-   partition.solveForcesExc(P,V,F,met);
+extern "C" void g2g_calcgradxc_(double* P, double* V, double* F, int& met) {
+  partition.solveForcesExc(P, V, F, met);
 }
 
 namespace G2G {
 
-void Partition::solveForcesExc(double* P,double* V,double* F,int met)
-{
-    std::vector< HostMatrix<double> > forces;
-    forces.resize(G2G::cpu_threads + G2G::gpu_threads);
+void Partition::solveForcesExc(double* P, double* V, double* F, int met) {
+  std::vector<HostMatrix<double> > forces;
+  forces.resize(G2G::cpu_threads + G2G::gpu_threads);
 
 #pragma omp parallel for num_threads(cpu_threads + gpu_threads) schedule(static)
-    for(uint i=0;i<work.size();i++) {
+  for (uint i = 0; i < work.size(); i++) {
 #if GPU_KERNELS
-       bool gpu_thread = false;
-       if (i >= cpu_threads) {
-          gpu_thread = true;
-          cudaSetDevice(i - cpu_threads);
-       }
+    bool gpu_thread = false;
+    if (i >= cpu_threads) {
+      gpu_thread = true;
+      cudaSetDevice(i - cpu_threads);
+    }
 #endif
 
-      forces[i].resize(fortran_vars.max_atoms, 3); // max_atoms = atoms (atomos qm)
-      forces[i].zero();
+    forces[i].resize(fortran_vars.max_atoms,
+                     3);  // max_atoms = atoms (atomos qm)
+    forces[i].zero();
 
-      for(uint j=0;j<work[i].size();j++) {
-         int ind = work[i][j];
-         if(ind >= cubes.size()) {
-           spheres[ind - cubes.size()]->solve_for_exc(P,V,forces[i],met);
-         } else {
-           cubes[ind]->solve_for_exc(P,V,forces[i],met);
-         }
+    for (uint j = 0; j < work[i].size(); j++) {
+      int ind = work[i][j];
+      if (ind >= cubes.size()) {
+        spheres[ind - cubes.size()]->solve_for_exc(P, V, forces[i], met);
+      } else {
+        cubes[ind]->solve_for_exc(P, V, forces[i], met);
+      }
 #if GPU_KERNELS
-         if (gpu_thread) {
-           cudaDeviceSynchronize();
-         }
+      if (gpu_thread) {
+        cudaDeviceSynchronize();
+      }
 #endif
-      }
-   }
+    }
+  }
 
-   for(int k=0; k<forces.size(); k++) {
-      for(int i=0; i<fortran_vars.atoms; i++) {
-         F[i*3]   += forces[k](i,0);
-         F[i*3+1] += forces[k](i,1);
-         F[i*3+2] += forces[k](i,2);
-      }
-   }
-   std::vector<HostMatrix<double> >().swap(forces);
-   fflush(stdout);
+  for (int k = 0; k < forces.size(); k++) {
+    for (int i = 0; i < fortran_vars.atoms; i++) {
+      F[i * 3] += forces[k](i, 0);
+      F[i * 3 + 1] += forces[k](i, 1);
+      F[i * 3 + 2] += forces[k](i, 2);
+    }
+  }
+  std::vector<HostMatrix<double> >().swap(forces);
+  fflush(stdout);
 }
 
-template<class scalar_type> void PointGroupCPU<scalar_type>::
-               solve_for_exc(double*P,double*V,HostMatrix<double>& F,int MET)
-{
-   const uint group_m = this->total_functions();
-   const int npoints = this->points.size();
-   bool lda = false;
-   bool compute_forces = true;
+template <class scalar_type>
+void PointGroupCPU<scalar_type>::solve_for_exc(double* P, double* V,
+                                               HostMatrix<double>& F, int MET) {
+  const uint group_m = this->total_functions();
+  const int npoints = this->points.size();
+  bool lda = false;
+  bool compute_forces = true;
 
-   compute_functions(compute_forces,!lda);
+  compute_functions(compute_forces, !lda);
 
-   int M = fortran_vars.m;
-   int natom = fortran_vars.atoms;
-   int local_atoms = this->total_nucleii();
-   double* dens = (double*) malloc(4*sizeof(double));
-   double* trad = (double*) malloc(4*sizeof(double));
-   double* diff = (double*) malloc(4*sizeof(double));
-   double* dfac = (double*) malloc(4*sizeof(double));
-   double* pfac = (double*) malloc(4*sizeof(double));
-   double* tfac = (double*) malloc(4*sizeof(double));
+  int M = fortran_vars.m;
+  int natom = fortran_vars.atoms;
+  int local_atoms = this->total_nucleii();
+  double* dens = (double*)malloc(4 * sizeof(double));
+  double* trad = (double*)malloc(4 * sizeof(double));
+  double* diff = (double*)malloc(4 * sizeof(double));
+  double* dfac = (double*)malloc(4 * sizeof(double));
+  double* pfac = (double*)malloc(4 * sizeof(double));
+  double* tfac = (double*)malloc(4 * sizeof(double));
 
-// Force for this group
-   int dim = 3*local_atoms;
-   double* sForce = (double*) malloc(dim*sizeof(double));
-   memset(sForce,0.0f,dim*sizeof(double));
+  // Force for this group
+  int dim = 3 * local_atoms;
+  double* sForce = (double*)malloc(dim * sizeof(double));
+  memset(sForce, 0.0f, dim * sizeof(double));
 
-// Reduced Matrix for this group
-   HostMatrix<scalar_type> rmm_input(group_m,group_m);
-   HostMatrix<scalar_type> Pred(group_m,group_m);
-   HostMatrix<scalar_type> Vred(group_m,group_m);
-   HostMatrix<scalar_type> Pbig(M*(M+1)/2);
-   HostMatrix<scalar_type> Vbig(M*(M+1)/2);
+  // Reduced Matrix for this group
+  HostMatrix<scalar_type> rmm_input(group_m, group_m);
+  HostMatrix<scalar_type> Pred(group_m, group_m);
+  HostMatrix<scalar_type> Vred(group_m, group_m);
+  HostMatrix<scalar_type> Pbig(M * (M + 1) / 2);
+  HostMatrix<scalar_type> Vbig(M * (M + 1) / 2);
 
-   get_rmm_input(rmm_input);
-   int index = 0;
-   for(int row=0; row<M; row++) {
-     Pbig(index) = P[row*M+row];
-     Vbig(index) = V[row*M+row];
-     index += 1;
-     for(int col=row+1; col<M; col++) {
-       Pbig(index) = P[row*M+col] + P[col*M+row];
-       Vbig(index) = V[row*M+col] + V[col*M+row];
-       index += 1;
-     }
-   }
-   get_tred_input(Pred,Pbig);
-   get_tred_input(Vred,Vbig);
-   Pbig.deallocate();
-   Vbig.deallocate();
+  get_rmm_input(rmm_input);
+  int index = 0;
+  for (int row = 0; row < M; row++) {
+    Pbig(index) = P[row * M + row];
+    Vbig(index) = V[row * M + row];
+    index += 1;
+    for (int col = row + 1; col < M; col++) {
+      Pbig(index) = P[row * M + col] + P[col * M + row];
+      Vbig(index) = V[row * M + col] + V[col * M + row];
+      index += 1;
+    }
+  }
+  get_tred_input(Pred, Pbig);
+  get_tred_input(Vred, Vbig);
+  Pbig.deallocate();
+  Vbig.deallocate();
 
-   // Gradients for nuclei
-   HostMatrix<scalar_type> ddx, ddy, ddz;
-   ddx.resize(local_atoms, 1);
-   ddy.resize(local_atoms, 1);
-   ddz.resize(local_atoms, 1);
+  // Gradients for nuclei
+  HostMatrix<scalar_type> ddx, ddy, ddz;
+  ddx.resize(local_atoms, 1);
+  ddy.resize(local_atoms, 1);
+  ddz.resize(local_atoms, 1);
 
-   for(int point=0;point<npoints;point++) {
-    double pd, pdx, pdy, pdz; pd = pdx = pdy = pdz = 0.0f;
-    double pp, ppx, ppy, ppz; pp = ppx = ppy = ppz = 0.0f;
-    double pt, ptx, pty, ptz; pt = ptx = pty = ptz = 0.0f;
+  for (int point = 0; point < npoints; point++) {
+    double pd, pdx, pdy, pdz;
+    pd = pdx = pdy = pdz = 0.0f;
+    double pp, ppx, ppy, ppz;
+    pp = ppx = ppy = ppz = 0.0f;
+    double pt, ptx, pty, ptz;
+    pt = ptx = pty = ptz = 0.0f;
     // functions and gradients values
     const scalar_type* fv = function_values.row(point);
     const scalar_type* gfx = gX.row(point);
     const scalar_type* gfy = gY.row(point);
     const scalar_type* gfz = gZ.row(point);
     // Hessianos de las funciones bases
-    const scalar_type* hxx = hPX.row(point); //XX
-    const scalar_type* hyy = hPY.row(point); //YY
-    const scalar_type* hzz = hPZ.row(point); //ZZ
-    const scalar_type* hxy = hIX.row(point); //XY
-    const scalar_type* hxz = hIY.row(point); //XZ
-    const scalar_type* hyz = hIZ.row(point); //YZ
+    const scalar_type* hxx = hPX.row(point);  // XX
+    const scalar_type* hyy = hPY.row(point);  // YY
+    const scalar_type* hzz = hPZ.row(point);  // ZZ
+    const scalar_type* hxy = hIX.row(point);  // XY
+    const scalar_type* hxz = hIY.row(point);  // XZ
+    const scalar_type* hyz = hIZ.row(point);  // YZ
 
-    for(int i=0;i<group_m;i++) {
-       double z3xc, z3yc, z3zc, z; z3xc = z3yc = z3zc = z = 0.0f;
-       double q3xc, q3yc, q3zc, q; q3xc = q3yc = q3zc = q = 0.0f;
-       const scalar_type* rm = rmm_input.row(i);
-       for(int j=0;j<=i;j++) {
-          const scalar_type rmj = rm[j];
-          // Difference Relaxed Excited State Density
-          z += fv[j] * Pred(i,j);
-          z3xc += gfx[j] * Pred(i,j);
-          z3yc += gfy[j] * Pred(i,j);
-          z3zc += gfz[j] * Pred(i,j);
-          // Transition Density
-          q += fv[j] * Vred(i,j);
-          q3xc += gfx[j] * Vred(i,j);
-          q3yc += gfy[j] * Vred(i,j);
-          q3zc += gfz[j] * Vred(i,j);
-       }
-       const double Fi = fv[i];
-       const double gx = gfx[i], gy = gfy[i], gz = gfz[i];
-       // Difference Relaxed Excited State Density
-       pp += Fi * z;
-       ppx += gx * z + z3xc * Fi;
-       ppy += gy * z + z3yc * Fi;
-       ppz += gz * z + z3zc * Fi;
-       // Transition Density
-       pt += Fi * q;
-       ptx += gx * q + q3xc * Fi;
-       pty += gy * q + q3yc * Fi;
-       ptz += gz * q + q3zc * Fi;
+    for (int i = 0; i < group_m; i++) {
+      double z3xc, z3yc, z3zc, z;
+      z3xc = z3yc = z3zc = z = 0.0f;
+      double q3xc, q3yc, q3zc, q;
+      q3xc = q3yc = q3zc = q = 0.0f;
+      const scalar_type* rm = rmm_input.row(i);
+      for (int j = 0; j <= i; j++) {
+        const scalar_type rmj = rm[j];
+        // Difference Relaxed Excited State Density
+        z += fv[j] * Pred(i, j);
+        z3xc += gfx[j] * Pred(i, j);
+        z3yc += gfy[j] * Pred(i, j);
+        z3zc += gfz[j] * Pred(i, j);
+        // Transition Density
+        q += fv[j] * Vred(i, j);
+        q3xc += gfx[j] * Vred(i, j);
+        q3yc += gfy[j] * Vred(i, j);
+        q3zc += gfz[j] * Vred(i, j);
+      }
+      const double Fi = fv[i];
+      const double gx = gfx[i], gy = gfy[i], gz = gfz[i];
+      // Difference Relaxed Excited State Density
+      pp += Fi * z;
+      ppx += gx * z + z3xc * Fi;
+      ppy += gy * z + z3yc * Fi;
+      ppz += gz * z + z3zc * Fi;
+      // Transition Density
+      pt += Fi * q;
+      ptx += gx * q + q3xc * Fi;
+      pty += gy * q + q3yc * Fi;
+      ptz += gz * q + q3zc * Fi;
     }
     // Ground State Density
-    pd  = rho_values(0,point);
-    pdx = rho_values(1,point);
-    pdy = rho_values(2,point);
-    pdz = rho_values(3,point);
+    pd = rho_values(0, point);
+    pdx = rho_values(1, point);
+    pdy = rho_values(2, point);
+    pdz = rho_values(3, point);
 
     double sigma = (pdx * pdx) + (pdy * pdy) + (pdz * pdz);
-    dens[0] = pd; dens[1] = pdx; dens[2] = pdy; dens[3] = pdz;
-    diff[0] = pp; diff[1] = ppx; diff[2] = ppy; diff[3] = ppz;
-    trad[0] = pt; trad[1] = ptx; trad[2] = pty; trad[3] = ptz;
+    dens[0] = pd;
+    dens[1] = pdx;
+    dens[2] = pdy;
+    dens[3] = pdz;
+    diff[0] = pp;
+    diff[1] = ppx;
+    diff[2] = ppy;
+    diff[3] = ppz;
+    trad[0] = pt;
+    trad[1] = ptx;
+    trad[2] = pty;
+    trad[3] = ptz;
 
     // Terms Calculate
-    calc_gradients(dens,diff,trad,sigma,dfac,pfac,tfac,MET);
+    calc_gradients(dens, diff, trad, sigma, dfac, pfac, tfac, MET);
 
     // FORCES CALCULATE
     double DJII, PJII, VJII;
@@ -193,65 +204,77 @@ template<class scalar_type> void PointGroupCPU<scalar_type>::
 
     const scalar_type wp = this->points[point].weight;
 
-    for (int i = 0, ii = 0; i < this->total_functions_simple(); i++) {// cantidad de bases, s+p+d (sin tener en cuenta las 3p y 5d
-       uint nuc = this->func2local_nuc(ii);// da a que nucleo LOCAL pertenece la base ii
-       uint inc_i = this->small_function_type(i);// da cuantas funciones tiene ese tipo: s->1, p->3, d->5
-       double grdx, grdy, grdz; grdx = grdy = grdz = 0.0f;
+    for (int i = 0, ii = 0; i < this->total_functions_simple();
+         i++) {  // cantidad de bases, s+p+d (sin tener en cuenta las 3p y 5d
+      uint nuc = this->func2local_nuc(
+          ii);  // da a que nucleo LOCAL pertenece la base ii
+      uint inc_i = this->small_function_type(
+          i);  // da cuantas funciones tiene ese tipo: s->1, p->3, d->5
+      double grdx, grdy, grdz;
+      grdx = grdy = grdz = 0.0f;
 
-       for (uint k = 0; k < inc_i; k++, ii++) {
-          for (uint j = 0; j < group_m; j++) { 
-             double factor = (ii == j ? 2.0f : 1.0f);
-             DJII = rmm_input(j,ii) * factor * 0.5f;
-             PJII = Pred(j,ii) * factor;
-             VJII = Vred(j,ii) * factor;
-             temp[0] = 2.0f * (dfac[0]*DJII + pfac[0]*PJII + tfac[0]*VJII);
-             temp[1] = 2.0f * (dfac[1]*DJII + pfac[1]*PJII + tfac[1]*VJII);
-             temp[2] = 2.0f * (dfac[2]*DJII + pfac[2]*PJII + tfac[2]*VJII);
-             temp[3] = 2.0f * (dfac[3]*DJII + pfac[3]*PJII + tfac[3]*VJII);
+      for (uint k = 0; k < inc_i; k++, ii++) {
+        for (uint j = 0; j < group_m; j++) {
+          double factor = (ii == j ? 2.0f : 1.0f);
+          DJII = rmm_input(j, ii) * factor * 0.5f;
+          PJII = Pred(j, ii) * factor;
+          VJII = Vred(j, ii) * factor;
+          temp[0] = 2.0f * (dfac[0] * DJII + pfac[0] * PJII + tfac[0] * VJII);
+          temp[1] = 2.0f * (dfac[1] * DJII + pfac[1] * PJII + tfac[1] * VJII);
+          temp[2] = 2.0f * (dfac[2] * DJII + pfac[2] * PJII + tfac[2] * VJII);
+          temp[3] = 2.0f * (dfac[3] * DJII + pfac[3] * PJII + tfac[3] * VJII);
 
-             grdx += temp[0]*gfx[ii]*fv[j];
-             grdx += temp[1]*( hxx[ii]*fv[j] + gfx[ii]*gfx[j] );
-             grdx += temp[2]*( hxy[ii]*fv[j] + gfx[ii]*gfy[j] );
-             grdx += temp[3]*( hxz[ii]*fv[j] + gfx[ii]*gfz[j] );
+          grdx += temp[0] * gfx[ii] * fv[j];
+          grdx += temp[1] * (hxx[ii] * fv[j] + gfx[ii] * gfx[j]);
+          grdx += temp[2] * (hxy[ii] * fv[j] + gfx[ii] * gfy[j]);
+          grdx += temp[3] * (hxz[ii] * fv[j] + gfx[ii] * gfz[j]);
 
-             grdy += temp[0]*gfy[ii]*fv[j];
-             grdy += temp[1]*( hxy[ii]*fv[j] + gfy[ii]*gfx[j] );
-             grdy += temp[2]*( hyy[ii]*fv[j] + gfy[ii]*gfy[j] );
-             grdy += temp[3]*( hyz[ii]*fv[j] + gfy[ii]*gfz[j] );
+          grdy += temp[0] * gfy[ii] * fv[j];
+          grdy += temp[1] * (hxy[ii] * fv[j] + gfy[ii] * gfx[j]);
+          grdy += temp[2] * (hyy[ii] * fv[j] + gfy[ii] * gfy[j]);
+          grdy += temp[3] * (hyz[ii] * fv[j] + gfy[ii] * gfz[j]);
 
-             grdz += temp[0]*gfz[ii]*fv[j];
-             grdz += temp[1]*( hxz[ii]*fv[j] + gfz[ii]*gfx[j] );
-             grdz += temp[2]*( hyz[ii]*fv[j] + gfz[ii]*gfy[j] );
-             grdz += temp[3]*( hzz[ii]*fv[j] + gfz[ii]*gfz[j] );
-          }
-       }
-       ddx(nuc) += grdx;
-       ddy(nuc) += grdy;
-       ddz(nuc) += grdz;
+          grdz += temp[0] * gfz[ii] * fv[j];
+          grdz += temp[1] * (hxz[ii] * fv[j] + gfz[ii] * gfx[j]);
+          grdz += temp[2] * (hyz[ii] * fv[j] + gfz[ii] * gfy[j]);
+          grdz += temp[3] * (hzz[ii] * fv[j] + gfz[ii] * gfz[j]);
+        }
+      }
+      ddx(nuc) += grdx;
+      ddy(nuc) += grdy;
+      ddz(nuc) += grdz;
     }
     for (int i = 0; i < local_atoms; i++) {
-       sForce[i*3] -= ddx(i) * wp;
-       sForce[i*3+1] -= ddy(i) * wp;
-       sForce[i*3+2] -= ddz(i) * wp;
+      sForce[i * 3] -= ddx(i) * wp;
+      sForce[i * 3 + 1] -= ddy(i) * wp;
+      sForce[i * 3 + 2] -= ddz(i) * wp;
     }
-   } // END POINTS
+  }  // END POINTS
 
-   // Acumulate forces for this group
-   for (int i = 0; i < local_atoms; i++) {
-      uint global_atom = this->local2global_nuc[i]; // da el indice del atomo LOCAL al GLOBAL
-      F(global_atom,0) += sForce[i*3];
-      F(global_atom,1) += sForce[i*3+1];
-      F(global_atom,2) += sForce[i*3+2];
-   }
+  // Acumulate forces for this group
+  for (int i = 0; i < local_atoms; i++) {
+    uint global_atom =
+        this->local2global_nuc[i];  // da el indice del atomo LOCAL al GLOBAL
+    F(global_atom, 0) += sForce[i * 3];
+    F(global_atom, 1) += sForce[i * 3 + 1];
+    F(global_atom, 2) += sForce[i * 3 + 2];
+  }
 
-   // Free Memory
-   free(dens); dens = NULL;
-   free(diff); diff = NULL;
-   free(trad); trad = NULL;
-   free(dfac); dfac = NULL;
-   free(pfac); pfac = NULL;
-   free(tfac); tfac = NULL;
-   free(sForce); sForce = NULL;
+  // Free Memory
+  free(dens);
+  dens = NULL;
+  free(diff);
+  diff = NULL;
+  free(trad);
+  trad = NULL;
+  free(dfac);
+  dfac = NULL;
+  free(pfac);
+  pfac = NULL;
+  free(tfac);
+  tfac = NULL;
+  free(sForce);
+  sForce = NULL;
 }
 
 #if FULL_DOUBLE
@@ -261,16 +284,4 @@ template class PointGroupCPU<double>;
 template class PointGroup<float>;
 template class PointGroupCPU<float>;
 #endif
-}
-
-
-    
-
-
-
-
-
-
-
-
-
+}  // namespace G2G

--- a/g2g/excited/g2g_calculateG.cpp
+++ b/g2g/excited/g2g_calculateG.cpp
@@ -2,7 +2,7 @@
 #include <omp.h>
 
 #include <stdio.h>
-#include <string.h> 
+#include <string.h>
 
 #include "../common.h"
 #include "../init.h"
@@ -12,172 +12,181 @@
 using namespace G2G;
 extern Partition partition;
 
-extern "C" void g2g_calculateg_(double* Tmat,double* F,int& DER)
-{
-   partition.solve_Gxc(Tmat,F,DER);
+extern "C" void g2g_calculateg_(double* Tmat, double* F, int& DER) {
+  partition.solve_Gxc(Tmat, F, DER);
 }
 
 namespace G2G {
 
-void Partition::solve_Gxc(double* Tmat,double* F,int DER)
-{
-   int M = fortran_vars.m;
-   std::vector< HostMatrix<double> > Fock_output(G2G::cpu_threads + G2G::gpu_threads);
+void Partition::solve_Gxc(double* Tmat, double* F, int DER) {
+  int M = fortran_vars.m;
+  std::vector<HostMatrix<double> > Fock_output(G2G::cpu_threads +
+                                               G2G::gpu_threads);
 
-#pragma omp parallel for num_threads(cpu_threads+gpu_threads) schedule(static)
-   for(uint i=0;i<work.size();i++) {
+#pragma omp parallel for num_threads(cpu_threads + gpu_threads) schedule(static)
+  for (uint i = 0; i < work.size(); i++) {
 #if GPU_KERNELS
-      bool gpu_thread = false;
-      if (i >= cpu_threads) {
-         gpu_thread = true;
-         cudaSetDevice(i - cpu_threads);
-      }
+    bool gpu_thread = false;
+    if (i >= cpu_threads) {
+      gpu_thread = true;
+      cudaSetDevice(i - cpu_threads);
+    }
 #endif
-      Fock_output[i].resize(fortran_vars.rmm_output.width,fortran_vars.rmm_output.height);
-      Fock_output[i].zero();
-      for(uint j=0;j<work[i].size();j++) {
-         Timer element;
-         element.start_and_sync();
-         int ind = work[i][j];
-         if(ind >= cubes.size()) {
-           spheres[ind-cubes.size()]->solve_3rd_der(Tmat,Fock_output[i],DER);
-         } else {
-           cubes[ind]->solve_3rd_der(Tmat,Fock_output[i],DER);
-         }
+    Fock_output[i].resize(fortran_vars.rmm_output.width,
+                          fortran_vars.rmm_output.height);
+    Fock_output[i].zero();
+    for (uint j = 0; j < work[i].size(); j++) {
+      Timer element;
+      element.start_and_sync();
+      int ind = work[i][j];
+      if (ind >= cubes.size()) {
+        spheres[ind - cubes.size()]->solve_3rd_der(Tmat, Fock_output[i], DER);
+      } else {
+        cubes[ind]->solve_3rd_der(Tmat, Fock_output[i], DER);
+      }
 #if GPU_KERNELS
-        if (gpu_thread) cudaDeviceSynchronize();
+      if (gpu_thread) cudaDeviceSynchronize();
 #endif
-        element.stop_and_sync();
+      element.stop_and_sync();
+    }
+  }
+  // Join results of threads
+  for (uint i = 0; i < work.size(); i++) {
+    int index = 0;
+    for (uint j = 0; j < M; j++) {
+      F[j * M + j] += Fock_output[i](index, 0);
+      index += 1;
+      for (uint k = j + 1; k < M; k++) {
+        F[j * M + k] += Fock_output[i](index, 0);
+        F[k * M + j] = F[j * M + k];
+        index += 1;
       }
-   }
-   // Join results of threads
-   for(uint i=0; i<work.size(); i++) {
-     int index = 0;
-     for(uint j=0; j<M; j++) {
-       F[j*M+j] += Fock_output[i](index,0);
-       index += 1;
-       for(uint k=j+1; k<M; k++) {
-           F[j*M+k] += Fock_output[i](index,0);
-           F[k*M+j] = F[j*M+k];
-           index += 1;
-       }
-     }
-   }
-   std::vector<HostMatrix<double> >().swap(Fock_output);
-} // END solve_Gxc
+    }
+  }
+  std::vector<HostMatrix<double> >().swap(Fock_output);
+}  // END solve_Gxc
 
-template<class scalar_type> void PointGroupCPU<scalar_type>::
-               solve_3rd_der(double* Tmat,HostMatrix<double>& Fock,int DER)
-{
-   const uint group_m = this->total_functions();
-   const int npoints = this->points.size();
-   bool lda = false;
-   bool compute_forces = true;
-   compute_functions(compute_forces,!lda);
-   HostMatrix<scalar_type> rmm_input(group_m,group_m);
+template <class scalar_type>
+void PointGroupCPU<scalar_type>::solve_3rd_der(double* Tmat,
+                                               HostMatrix<double>& Fock,
+                                               int DER) {
+  const uint group_m = this->total_functions();
+  const int npoints = this->points.size();
+  bool lda = false;
+  bool compute_forces = true;
+  compute_functions(compute_forces, !lda);
+  HostMatrix<scalar_type> rmm_input(group_m, group_m);
 
-   int M = fortran_vars.m;
-   get_rmm_input(rmm_input);
+  int M = fortran_vars.m;
+  get_rmm_input(rmm_input);
 
-   double* zcoef = (double*) malloc(3*sizeof(double));
-   double* precond = (double*) malloc(group_m*sizeof(double));
-   double* smallFock = (double*) malloc(group_m*group_m*sizeof(double));
-   memset(smallFock,0.0f,group_m*group_m*sizeof(double));
+  double* zcoef = (double*)malloc(3 * sizeof(double));
+  double* precond = (double*)malloc(group_m * sizeof(double));
+  double* smallFock = (double*)malloc(group_m * group_m * sizeof(double));
+  memset(smallFock, 0.0f, group_m * group_m * sizeof(double));
 
-// Obtain reduced matrix for this group
-   HostMatrix<double> tred(group_m,group_m);
-   HostMatrix<double> Tbig(M*(M+1)/2);
-   int index = 0;
-   for(int row=0; row<M; row++) {
-     Tbig(index) = Tmat[row*M+row];
-     index += 1;
-     for(int col=row+1; col<M; col++) {
-       Tbig(index) = Tmat[row*M+col] + Tmat[col*M+row];
-       index += 1;
-     }
-   }
-   get_tred_input(tred,Tbig); Tbig.deallocate();
+  // Obtain reduced matrix for this group
+  HostMatrix<double> tred(group_m, group_m);
+  HostMatrix<double> Tbig(M * (M + 1) / 2);
+  int index = 0;
+  for (int row = 0; row < M; row++) {
+    Tbig(index) = Tmat[row * M + row];
+    index += 1;
+    for (int col = row + 1; col < M; col++) {
+      Tbig(index) = Tmat[row * M + col] + Tmat[col * M + row];
+      index += 1;
+    }
+  }
+  get_tred_input(tred, Tbig);
+  Tbig.deallocate();
 
 // INITIALIZATION LIBXC
-#define libxc_init_param \
+#define libxc_init_param                                              \
   fortran_vars.func_id, fortran_vars.func_coef, fortran_vars.nx_func, \
-  fortran_vars.nc_func, fortran_vars.nsr_id, fortran_vars.screen, \
-  XC_UNPOLARIZED
-  LibxcProxy<scalar_type,3> libxcProxy(libxc_init_param);
+      fortran_vars.nc_func, fortran_vars.nsr_id, fortran_vars.screen, \
+      XC_UNPOLARIZED
+  LibxcProxy<scalar_type, 3> libxcProxy(libxc_init_param);
 #undef libxc_init_param
 
-   for(int point=0;point<npoints;point++) {
-      scalar_type pd, pdx, pdy, pdz; pd = pdx = pdy = pdz = 0.0f;
-      scalar_type red, redx, redy, redz; red = redx = redy = redz = 0.0f;
-      const scalar_type* fv = function_values.row(point);
-      const scalar_type* gxv = gX.row(point);
-      const scalar_type* gyv = gY.row(point);
-      const scalar_type* gzv = gZ.row(point);
-      for(int i=0;i<group_m;i++) {
-         double z3xc, z3yc, z3zc, z; z3xc = z3yc = z3zc = z = 0.0f;
-         const scalar_type* rm = rmm_input.row(i);
-         for(int j=0;j<=i;j++) {
-            const double rmj = rm[j];
-            // Transition Density
-            z += fv[j] * tred(i,j);
-            z3xc += gxv[j] * tred(i,j);
-            z3yc += gyv[j] * tred(i,j);
-            z3zc += gzv[j] * tred(i,j);
-         }
-         const double Fi = fv[i];
-         const double gx = gxv[i], gy = gyv[i], gz = gzv[i];
-         // Transition Density
-         red += Fi * z;
-         redx += gx * z + z3xc * Fi;
-         redy += gy * z + z3yc * Fi;
-         redz += gz * z + z3zc * Fi;
+  for (int point = 0; point < npoints; point++) {
+    scalar_type pd, pdx, pdy, pdz;
+    pd = pdx = pdy = pdz = 0.0f;
+    scalar_type red, redx, redy, redz;
+    red = redx = redy = redz = 0.0f;
+    const scalar_type* fv = function_values.row(point);
+    const scalar_type* gxv = gX.row(point);
+    const scalar_type* gyv = gY.row(point);
+    const scalar_type* gzv = gZ.row(point);
+    for (int i = 0; i < group_m; i++) {
+      double z3xc, z3yc, z3zc, z;
+      z3xc = z3yc = z3zc = z = 0.0f;
+      const scalar_type* rm = rmm_input.row(i);
+      for (int j = 0; j <= i; j++) {
+        const double rmj = rm[j];
+        // Transition Density
+        z += fv[j] * tred(i, j);
+        z3xc += gxv[j] * tred(i, j);
+        z3yc += gyv[j] * tred(i, j);
+        z3zc += gzv[j] * tred(i, j);
       }
-      // Ground State Density
-      pd = rho_values(0,point);
-      pdx = rho_values(1,point);
-      pdy = rho_values(2,point);
-      pdz = rho_values(3,point);
+      const double Fi = fv[i];
+      const double gx = gxv[i], gy = gyv[i], gz = gzv[i];
+      // Transition Density
+      red += Fi * z;
+      redx += gx * z + z3xc * Fi;
+      redy += gy * z + z3yc * Fi;
+      redz += gz * z + z3zc * Fi;
+    }
+    // Ground State Density
+    pd = rho_values(0, point);
+    pdx = rho_values(1, point);
+    pdy = rho_values(2, point);
+    pdz = rho_values(3, point);
 
-      double sigma = pdx * pdx + pdy * pdy + pdz * pdz;
+    double sigma = pdx * pdx + pdy * pdy + pdz * pdz;
 
-      // obtain derivatives terms
-      if (DER == 2 ) {
-          double cruz = (redx * pdx + redy * pdy + redz * pdz) * 0.5f;
-          libxcProxy.coefLR(&pd,&sigma,red,cruz,zcoef);
-      } else {
-          libxcProxy.coefZv(pd,sigma,pdx,pdy,pdz,red,redx,redy,
-                            redz, zcoef);
+    // obtain derivatives terms
+    if (DER == 2) {
+      double cruz = (redx * pdx + redy * pdy + redz * pdz) * 0.5f;
+      libxcProxy.coefLR(&pd, &sigma, red, cruz, zcoef);
+    } else {
+      libxcProxy.coefZv(pd, sigma, pdx, pdy, pdz, red, redx, redy, redz, zcoef);
+    }
+    pdx *= 0.5f;
+    pdy *= 0.5f;
+    pdz *= 0.5f;
+
+    const scalar_type wp = this->points[point].weight;
+    double term1, term2, term3, term4, precondii, result;
+    for (int i = 0; i < group_m; i++) {
+      term1 = zcoef[0] * 0.5f * fv[i] + zcoef[1] * pdx * gxv[i];
+      term2 = zcoef[1] * pdy * gyv[i] + zcoef[1] * pdz * gzv[i];
+      term3 = zcoef[2] * redx * gxv[i] + zcoef[2] * redy * gyv[i];
+      term4 = zcoef[2] * redz * gzv[i];
+      precond[i] = (term1 + term2 + term3 + term4) * wp;
+      precondii = precond[i];
+      for (int j = 0; j <= i; j++) {
+        result = fv[i] * precond[j] + precondii * fv[j];
+        smallFock[i * group_m + j] += result;
       }
-      pdx *= 0.5f; pdy *= 0.5f; pdz *= 0.5f;
+    }
 
-      const scalar_type wp = this->points[point].weight;
-      double term1, term2, term3, term4, precondii, result;
-      for(int i=0; i<group_m; i++) {
-        term1 = zcoef[0] * 0.5f * fv[i] + zcoef[1] * pdx * gxv[i];
-        term2 = zcoef[1] * pdy * gyv[i] + zcoef[1] * pdz * gzv[i];
-        term3 = zcoef[2] * redx * gxv[i] + zcoef[2] * redy * gyv[i];
-        term4 = zcoef[2] * redz * gzv[i];
-        precond[i] = (term1 + term2 + term3 + term4) * wp;
-        precondii = precond[i];
-        for(int j=0; j<=i; j++) {
-           result = fv[i] * precond[j] + precondii * fv[j];
-           smallFock[i*group_m+j] += result;
-        }
-      }
+  }  // END points loop
 
-   }  // END points loop
+  const int indexes = this->rmm_bigs.size();
+  for (int i = 0; i < indexes; i++) {
+    int bi = this->rmm_bigs[i], row = this->rmm_rows[i],
+        col = this->rmm_cols[i];
+    Fock(bi) += smallFock[col * group_m + row];
+  }
 
-   const int indexes = this->rmm_bigs.size();
-   for (int i = 0; i < indexes; i++) {
-      int bi = this->rmm_bigs[i], row = this->rmm_rows[i],
-          col = this->rmm_cols[i];
-          Fock(bi) += smallFock[col*group_m+row];
-   }
-
-   // Free Memory
-   free(smallFock); smallFock = NULL;
-   free(precond); precond = NULL;
-   free(zcoef); zcoef = NULL;
+  // Free Memory
+  free(smallFock);
+  smallFock = NULL;
+  free(precond);
+  precond = NULL;
+  free(zcoef);
+  zcoef = NULL;
 }
 
 #if FULL_DOUBLE
@@ -187,4 +196,4 @@ template class PointGroupCPU<double>;
 template class PointGroup<float>;
 template class PointGroupCPU<float>;
 #endif
-}
+}  // namespace G2G

--- a/g2g/excited/g2g_calculateXC.cpp
+++ b/g2g/excited/g2g_calculateXC.cpp
@@ -12,20 +12,19 @@
 using namespace G2G;
 extern Partition partition;
 
-extern "C" void g2g_calculatexc_(double* Tmat,double* Fv)
-{
-   partition.solve_lr(Tmat,Fv);
+extern "C" void g2g_calculatexc_(double* Tmat, double* Fv) {
+  partition.solve_lr(Tmat, Fv);
 }
 
 namespace G2G {
 
-void Partition::solve_lr(double* T,double* F)
-{
-   int M = fortran_vars.m;
-   std::vector< HostMatrix<double> > Fock_output(G2G::cpu_threads + G2G::gpu_threads);
+void Partition::solve_lr(double* T, double* F) {
+  int M = fortran_vars.m;
+  std::vector<HostMatrix<double> > Fock_output(G2G::cpu_threads +
+                                               G2G::gpu_threads);
 
-#pragma omp parallel for num_threads(cpu_threads+gpu_threads) schedule(static)
-   for(uint i=0;i<work.size();i++) {
+#pragma omp parallel for num_threads(cpu_threads + gpu_threads) schedule(static)
+  for (uint i = 0; i < work.size(); i++) {
 #if GPU_KERNELS
     bool gpu_thread = false;
     if (i >= cpu_threads) {
@@ -34,152 +33,161 @@ void Partition::solve_lr(double* T,double* F)
     }
 #endif
 
-     Fock_output[i].resize(fortran_vars.rmm_output.width,fortran_vars.rmm_output.height);
-     // height es siempre 1: es un vector en realidad
-     Fock_output[i].zero();
-     for(uint j=0;j<work[i].size();j++) {
-        Timer element;
-        element.start_and_sync();
-        int ind = work[i][j];
-        if(ind >= cubes.size()) {
-          spheres[ind - cubes.size()]->solve_closed_lr(T,Fock_output[i]);
-        } else {
-          cubes[ind]->solve_closed_lr(T,Fock_output[i]);
-        }
+    Fock_output[i].resize(fortran_vars.rmm_output.width,
+                          fortran_vars.rmm_output.height);
+    // height es siempre 1: es un vector en realidad
+    Fock_output[i].zero();
+    for (uint j = 0; j < work[i].size(); j++) {
+      Timer element;
+      element.start_and_sync();
+      int ind = work[i][j];
+      if (ind >= cubes.size()) {
+        spheres[ind - cubes.size()]->solve_closed_lr(T, Fock_output[i]);
+      } else {
+        cubes[ind]->solve_closed_lr(T, Fock_output[i]);
+      }
 #if GPU_KERNELS
-    if (gpu_thread) cudaDeviceSynchronize();
+      if (gpu_thread) cudaDeviceSynchronize();
 #endif
-        element.stop_and_sync();
-     }
-   }
+      element.stop_and_sync();
+    }
+  }
 
-   for(uint i=0; i<work.size(); i++) {
-     int index = 0;
-     for(uint j=0; j<M; j++) {
-       F[j*M+j] += Fock_output[i](index,0);
-       index += 1;
-       for(uint k=j+1; k<M; k++) {
-           F[j*M+k] += Fock_output[i](index,0);
-           F[k*M+j] = F[j*M+k];
-           index += 1;
-       }
-     }
-   }
-   vector< HostMatrix<double> >().swap(Fock_output);
+  for (uint i = 0; i < work.size(); i++) {
+    int index = 0;
+    for (uint j = 0; j < M; j++) {
+      F[j * M + j] += Fock_output[i](index, 0);
+      index += 1;
+      for (uint k = j + 1; k < M; k++) {
+        F[j * M + k] += Fock_output[i](index, 0);
+        F[k * M + j] = F[j * M + k];
+        index += 1;
+      }
+    }
+  }
+  vector<HostMatrix<double> >().swap(Fock_output);
 }
 
-template<class scalar_type> void PointGroupCPU<scalar_type>::
-               solve_closed_lr(double* T,HostMatrix<double>& Fock)
-{
-// aqui T no es la transicion density, sino es B * C**T
-   const uint group_m = this->total_functions();
-   const int npoints = this->points.size();
-   bool lda = false;
-   bool compute_forces = false;
-   compute_functions(compute_forces,!lda);
-   HostMatrix<scalar_type> rmm_input(group_m,group_m);
+template <class scalar_type>
+void PointGroupCPU<scalar_type>::solve_closed_lr(double* T,
+                                                 HostMatrix<double>& Fock) {
+  // aqui T no es la transicion density, sino es B * C**T
+  const uint group_m = this->total_functions();
+  const int npoints = this->points.size();
+  bool lda = false;
+  bool compute_forces = false;
+  compute_functions(compute_forces, !lda);
+  HostMatrix<scalar_type> rmm_input(group_m, group_m);
 
-   int M = fortran_vars.m;
-   get_rmm_input(rmm_input);
+  int M = fortran_vars.m;
+  get_rmm_input(rmm_input);
 
-   double* smallFock  = (double*)malloc(group_m*group_m*sizeof(double));
-   memset(smallFock,0.0f,group_m*group_m*sizeof(double));
+  double* smallFock = (double*)malloc(group_m * group_m * sizeof(double));
+  memset(smallFock, 0.0f, group_m * group_m * sizeof(double));
 
-// FORMAMOS LA TRANSITION DENSITY REDUCIDA
-   HostMatrix<double> tred(group_m,group_m);
-   HostMatrix<double> Tbig(M*(M+1)/2);
-   int index = 0;
-   for(int row=0;row<M;row++) {
-     Tbig(index) = T[row*M+row];
-     index += 1;
-     for(int col=row+1;col<M;col++) {
-        Tbig(index) = T[row*M+col] + T[col*M+row];
-        index += 1;
-     }
-   }
-   get_tred_input(tred,Tbig);
-   Tbig.deallocate();
+  // FORMAMOS LA TRANSITION DENSITY REDUCIDA
+  HostMatrix<double> tred(group_m, group_m);
+  HostMatrix<double> Tbig(M * (M + 1) / 2);
+  int index = 0;
+  for (int row = 0; row < M; row++) {
+    Tbig(index) = T[row * M + row];
+    index += 1;
+    for (int col = row + 1; col < M; col++) {
+      Tbig(index) = T[row * M + col] + T[col * M + row];
+      index += 1;
+    }
+  }
+  get_tred_input(tred, Tbig);
+  Tbig.deallocate();
 
-//LIBXC INITIALIZATION
-#define libxc_init_param \
+// LIBXC INITIALIZATION
+#define libxc_init_param                                              \
   fortran_vars.func_id, fortran_vars.func_coef, fortran_vars.nx_func, \
-  fortran_vars.nc_func, fortran_vars.nsr_id, fortran_vars.screen, \
-  XC_UNPOLARIZED
-  LibxcProxy<scalar_type,3> libxcProxy(libxc_init_param);
+      fortran_vars.nc_func, fortran_vars.nsr_id, fortran_vars.screen, \
+      XC_UNPOLARIZED
+  LibxcProxy<scalar_type, 3> libxcProxy(libxc_init_param);
 #undef libxc_init_param
 
-   double* lrCoef = new double[3];
-   double* tot_term = new double[group_m];
+  double* lrCoef = new double[3];
+  double* tot_term = new double[group_m];
 
-   for(int point=0;point<npoints;point++) {
-      scalar_type pd, fxc, tdx, tdy, tdz; pd = fxc = tdx = tdy = tdz = 0.0f;
-      scalar_type red, redx, redy, redz; red = redx = redy = redz = 0.0f;
-      const scalar_type* fv = function_values.row(point);
-      const scalar_type* gxv = gX.row(point);
-      const scalar_type* gyv = gY.row(point);
-      const scalar_type* gzv = gZ.row(point);
-      for(int i=0;i<group_m;i++) {
-         double z3xc, z3yc, z3zc, z; z3xc = z3yc = z3zc = z = 0.0f;
-         for(int j=0;j<=i;j++) {
-            // Transition Density
-            z += fv[j] * tred(i,j);
-            z3xc += gxv[j] * tred(i,j);
-            z3yc += gyv[j] * tred(i,j);
-            z3zc += gzv[j] * tred(i,j);
-         }
-         const double Fi = fv[i];
-         const double gx = gxv[i], gy = gyv[i], gz = gzv[i];
-         // Transition Density
-         red += Fi * z;
-         redx += gx * z + z3xc * Fi;
-         redy += gy * z + z3yc * Fi;
-         redz += gz * z + z3zc * Fi;
+  for (int point = 0; point < npoints; point++) {
+    scalar_type pd, fxc, tdx, tdy, tdz;
+    pd = fxc = tdx = tdy = tdz = 0.0f;
+    scalar_type red, redx, redy, redz;
+    red = redx = redy = redz = 0.0f;
+    const scalar_type* fv = function_values.row(point);
+    const scalar_type* gxv = gX.row(point);
+    const scalar_type* gyv = gY.row(point);
+    const scalar_type* gzv = gZ.row(point);
+    for (int i = 0; i < group_m; i++) {
+      double z3xc, z3yc, z3zc, z;
+      z3xc = z3yc = z3zc = z = 0.0f;
+      for (int j = 0; j <= i; j++) {
+        // Transition Density
+        z += fv[j] * tred(i, j);
+        z3xc += gxv[j] * tred(i, j);
+        z3yc += gyv[j] * tred(i, j);
+        z3zc += gzv[j] * tred(i, j);
       }
+      const double Fi = fv[i];
+      const double gx = gxv[i], gy = gyv[i], gz = gzv[i];
+      // Transition Density
+      red += Fi * z;
+      redx += gx * z + z3xc * Fi;
+      redy += gy * z + z3yc * Fi;
+      redz += gz * z + z3zc * Fi;
+    }
 
-      // Ground State Density
-      pd = rho_values(0,point);
-      tdx = rho_values(1,point);
-      tdy = rho_values(2,point);
-      tdz = rho_values(3,point);
+    // Ground State Density
+    pd = rho_values(0, point);
+    tdx = rho_values(1, point);
+    tdy = rho_values(2, point);
+    tdz = rho_values(3, point);
 
-      double sigma = tdx * tdx + tdy * tdy + tdz * tdz;
-      double cruz = redx * tdx + redy * tdy + redz * tdz;
-      cruz *= 0.50f;tdx *= 0.5f;tdy *= 0.5f;tdz *= 0.5f;
+    double sigma = tdx * tdx + tdy * tdy + tdz * tdz;
+    double cruz = redx * tdx + redy * tdy + redz * tdz;
+    cruz *= 0.50f;
+    tdx *= 0.5f;
+    tdy *= 0.5f;
+    tdz *= 0.5f;
 
-      libxcProxy.coefLR(&pd,&sigma,red,cruz,lrCoef);
-      const scalar_type wp = this->points[point].weight;
-      double term1, term2, term3, term4, tot_term_ii, result;
+    libxcProxy.coefLR(&pd, &sigma, red, cruz, lrCoef);
+    const scalar_type wp = this->points[point].weight;
+    double term1, term2, term3, term4, tot_term_ii, result;
 
-      for(int i=0; i<group_m; i++) {
-        term1 = lrCoef[0] * 0.5f * fv[i] + lrCoef[1] * tdx * gxv[i];
-        term2 = lrCoef[1] * tdy * gyv[i] + lrCoef[1] * tdz * gzv[i];
-        term3 = lrCoef[2] * redx * gxv[i] + lrCoef[2] * redy * gyv[i];
-        term4 = lrCoef[2] * redz * gzv[i];
-        tot_term[i] = (term1 + term2 + term3 + term4) * wp;
-        tot_term_ii = tot_term[i];
-        for(int j=0; j<=i; j++) {
-           result = fv[i] * tot_term[j] + tot_term_ii * fv[j];
-           smallFock[i*group_m+j] += result;
-        }
+    for (int i = 0; i < group_m; i++) {
+      term1 = lrCoef[0] * 0.5f * fv[i] + lrCoef[1] * tdx * gxv[i];
+      term2 = lrCoef[1] * tdy * gyv[i] + lrCoef[1] * tdz * gzv[i];
+      term3 = lrCoef[2] * redx * gxv[i] + lrCoef[2] * redy * gyv[i];
+      term4 = lrCoef[2] * redz * gzv[i];
+      tot_term[i] = (term1 + term2 + term3 + term4) * wp;
+      tot_term_ii = tot_term[i];
+      for (int j = 0; j <= i; j++) {
+        result = fv[i] * tot_term[j] + tot_term_ii * fv[j];
+        smallFock[i * group_m + j] += result;
       }
+    }
 
-   }  // END points loop
+  }  // END points loop
 
-   const int indexes = this->rmm_bigs.size();
-   for (int i = 0; i < indexes; i++) {
-      int bi = this->rmm_bigs[i], row = this->rmm_rows[i],
-          col = this->rmm_cols[i];
-          Fock(bi) += smallFock[col*group_m+row];
-   }
-   // Free Memory
-   free(smallFock); smallFock  = NULL;
-   delete[] tot_term; tot_term = NULL;
-   delete[] lrCoef; lrCoef = NULL;
+  const int indexes = this->rmm_bigs.size();
+  for (int i = 0; i < indexes; i++) {
+    int bi = this->rmm_bigs[i], row = this->rmm_rows[i],
+        col = this->rmm_cols[i];
+    Fock(bi) += smallFock[col * group_m + row];
+  }
+  // Free Memory
+  free(smallFock);
+  smallFock = NULL;
+  delete[] tot_term;
+  tot_term = NULL;
+  delete[] lrCoef;
+  lrCoef = NULL;
 }
 template <class scalar_type>
 void PointGroupCPU<scalar_type>::get_tred_input(
-     HostMatrix<scalar_type>& tred_input, HostMatrix<double>& source) const
-{
+    HostMatrix<scalar_type>& tred_input, HostMatrix<double>& source) const {
   tred_input.zero();
   const int indexes = this->rmm_bigs.size();
   for (int i = 0; i < indexes; i++) {
@@ -195,4 +203,4 @@ template class PointGroupCPU<double>;
 template class PointGroup<float>;
 template class PointGroupCPU<float>;
 #endif
-}
+}  // namespace G2G

--- a/g2g/excited/saverho.cpp
+++ b/g2g/excited/saverho.cpp
@@ -2,7 +2,7 @@
 #include <omp.h>
 
 #include <stdio.h>
-#include <string.h> 
+#include <string.h>
 
 #include "../common.h"
 #include "../init.h"
@@ -13,11 +13,10 @@ extern Partition partition;
 
 //######################################################################
 //######################################################################
-extern "C" void g2g_saverho_()
-{
-   cout << " Saving density and derivatives of Ground State" << endl;
-   partition.lr_init();
-   fflush(stdout); // NOT BUFFERED
+extern "C" void g2g_saverho_() {
+  cout << " Saving density and derivatives of Ground State" << endl;
+  partition.lr_init();
+  fflush(stdout);  // NOT BUFFERED
 }
 
 //######################################################################
@@ -25,21 +24,19 @@ extern "C" void g2g_saverho_()
 
 namespace G2G {
 
-void Partition::lr_init()
-{
-
+void Partition::lr_init() {
 #pragma omp parallel for schedule(static)
-    for(uint i=0;i<work.size();i++) {
-      for(uint j=0;j<work[i].size();j++) {
-         int ind = work[i][j];
-         if(ind >= cubes.size()) {
-           spheres[ind - cubes.size()]->lr_closed_init();
-         } else {
-           cubes[ind]->lr_closed_init();
-         }
+  for (uint i = 0; i < work.size(); i++) {
+    for (uint j = 0; j < work[i].size(); j++) {
+      int ind = work[i][j];
+      if (ind >= cubes.size()) {
+        spheres[ind - cubes.size()]->lr_closed_init();
+      } else {
+        cubes[ind]->lr_closed_init();
       }
-   }
-   fflush(stdout);
+    }
+  }
+  fflush(stdout);
 }
 //######################################################################
 //######################################################################
@@ -47,49 +44,50 @@ void Partition::lr_init()
 //######################################################################
 //######################################################################
 
-template<class scalar_type> void PointGroupCPU<scalar_type>::
-               lr_closed_init()
-{
-   const uint group_m = this->total_functions();
-   const int npoints = this->points.size();
-   bool lda = false;
-   bool compute_forces = false;
-   compute_functions(compute_forces,!lda);
-   HostMatrix<scalar_type> rmm_input(group_m,group_m);
-   int* numeros = new int[group_m];
-   int M = fortran_vars.m;
-   get_rmm_input(rmm_input);
-   rho_values.resize(4, npoints);
+template <class scalar_type>
+void PointGroupCPU<scalar_type>::lr_closed_init() {
+  const uint group_m = this->total_functions();
+  const int npoints = this->points.size();
+  bool lda = false;
+  bool compute_forces = false;
+  compute_functions(compute_forces, !lda);
+  HostMatrix<scalar_type> rmm_input(group_m, group_m);
+  int* numeros = new int[group_m];
+  int M = fortran_vars.m;
+  get_rmm_input(rmm_input);
+  rho_values.resize(4, npoints);
 
-   for(int point=0; point<npoints; point++) {
-      scalar_type pd, tdx, tdy, tdz; pd = tdx = tdy = tdz = 0.0f;
-      const scalar_type* fv = function_values.row(point);
-      const scalar_type* gxv = gX.row(point);
-      const scalar_type* gyv = gY.row(point);
-      const scalar_type* gzv = gZ.row(point);
-      for(int i=0;i<group_m;i++) {
-         double w3xc, w3yc, w3zc, w; w3xc = w3yc = w3zc = w = 0.0f;
-         const scalar_type* rm = rmm_input.row(i);
-         for(int j=0;j<=i;j++) {
-            const double rmj = rm[j];
-            w += fv[j] * rmj;
-            w3xc += gxv[j] * rmj;
-            w3yc += gyv[j] * rmj;
-            w3zc += gzv[j] * rmj;
-         }
-         const double Fi = fv[i];
-         const double gx = gxv[i], gy = gyv[i], gz = gzv[i];
-         pd += Fi * w;
-         tdx += gx * w + w3xc * Fi;
-         tdy += gy * w + w3yc * Fi;
-         tdz += gz * w + w3zc * Fi;
+  for (int point = 0; point < npoints; point++) {
+    scalar_type pd, tdx, tdy, tdz;
+    pd = tdx = tdy = tdz = 0.0f;
+    const scalar_type* fv = function_values.row(point);
+    const scalar_type* gxv = gX.row(point);
+    const scalar_type* gyv = gY.row(point);
+    const scalar_type* gzv = gZ.row(point);
+    for (int i = 0; i < group_m; i++) {
+      double w3xc, w3yc, w3zc, w;
+      w3xc = w3yc = w3zc = w = 0.0f;
+      const scalar_type* rm = rmm_input.row(i);
+      for (int j = 0; j <= i; j++) {
+        const double rmj = rm[j];
+        w += fv[j] * rmj;
+        w3xc += gxv[j] * rmj;
+        w3yc += gyv[j] * rmj;
+        w3zc += gzv[j] * rmj;
       }
-      // Save Ground State Density and Derivatives
-      rho_values(0,point) = pd;
-      rho_values(1,point) = tdx;
-      rho_values(2,point) = tdy;
-      rho_values(3,point) = tdz;
-   }  // END points loop
+      const double Fi = fv[i];
+      const double gx = gxv[i], gy = gyv[i], gz = gzv[i];
+      pd += Fi * w;
+      tdx += gx * w + w3xc * Fi;
+      tdy += gy * w + w3yc * Fi;
+      tdz += gz * w + w3zc * Fi;
+    }
+    // Save Ground State Density and Derivatives
+    rho_values(0, point) = pd;
+    rho_values(1, point) = tdx;
+    rho_values(2, point) = tdy;
+    rho_values(3, point) = tdz;
+  }  // END points loop
 }
 //######################################################################
 //######################################################################
@@ -100,4 +98,4 @@ template class PointGroupCPU<double>;
 template class PointGroup<float>;
 template class PointGroupCPU<float>;
 #endif
-}
+}  // namespace G2G

--- a/g2g/extern_functional.cpp
+++ b/g2g/extern_functional.cpp
@@ -9,98 +9,110 @@
 
 using namespace G2G;
 
-
 #if USE_LIBXC
 #include "functional.h"
 
-extern "C" void g2g_extern_functional_(int& main_id, bool* externFunc,
-                              int* HF, double* HF_fac, double* screen)
-{
-   if ( *externFunc == 0 ) return;
-   cout << " " << endl;
-   cout << " Extern Functional Module " << endl;
+extern "C" void g2g_extern_functional_(int& main_id, bool* externFunc, int* HF,
+                                       double* HF_fac, double* screen) {
+  if (*externFunc == 0) return;
+  cout << " " << endl;
+  cout << " Extern Functional Module " << endl;
 
-   // Allocate and Free Memory
-   if ( fortran_vars.func_id != NULL ) {
-      free(fortran_vars.func_id); fortran_vars.func_id = NULL;
-   }
-   if ( fortran_vars.func_coef != NULL ) {
-      free(fortran_vars.func_coef); fortran_vars.func_coef = NULL;
-   }
-   if ( fortran_vars.HF != NULL ) {
-      free(fortran_vars.HF); fortran_vars.HF = NULL;
-   }
-   if ( fortran_vars.HF_fac != NULL ) {
-      free(fortran_vars.HF_fac); fortran_vars.HF_fac = NULL;
-   }
-   
-   switch (main_id) {
-      // PBE
-      case 101:
-           set_pbe(HF,HF_fac,screen); break;
+  // Allocate and Free Memory
+  if (fortran_vars.func_id != NULL) {
+    free(fortran_vars.func_id);
+    fortran_vars.func_id = NULL;
+  }
+  if (fortran_vars.func_coef != NULL) {
+    free(fortran_vars.func_coef);
+    fortran_vars.func_coef = NULL;
+  }
+  if (fortran_vars.HF != NULL) {
+    free(fortran_vars.HF);
+    fortran_vars.HF = NULL;
+  }
+  if (fortran_vars.HF_fac != NULL) {
+    free(fortran_vars.HF_fac);
+    fortran_vars.HF_fac = NULL;
+  }
 
-      case 130:
-           set_pbe(HF,HF_fac,screen); break;
+  switch (main_id) {
+    // PBE
+    case 101:
+      set_pbe(HF, HF_fac, screen);
+      break;
 
-      // PBE0
-      case 406:
-           set_pbe0(HF,HF_fac,screen); break;
+    case 130:
+      set_pbe(HF, HF_fac, screen);
+      break;
 
-      // B3LYP
-      case 402:
-           set_b3lyp(HF,HF_fac,screen); break;
+    // PBE0
+    case 406:
+      set_pbe0(HF, HF_fac, screen);
+      break;
 
-      // CAM-B3LYP
-      case 433:
-           set_cam_b3lyp(HF,HF_fac,screen); break;
+    // B3LYP
+    case 402:
+      set_b3lyp(HF, HF_fac, screen);
+      break;
 
-      // LC-WPBE
-      case 478:
-           set_lc_wpbe(HF,HF_fac,screen); break;
+    // CAM-B3LYP
+    case 433:
+      set_cam_b3lyp(HF, HF_fac, screen);
+      break;
 
-      // LC-BLYP
-      case 400:
-           set_lc_blyp(HF,HF_fac,screen); break;
-   
-      default:
-           cout << "The Functional id " << main_id << " doesn't implemented yet" << endl;
-           exit(-1); break;
-   }
-   cout << " " << endl;
+    // LC-WPBE
+    case 478:
+      set_lc_wpbe(HF, HF_fac, screen);
+      break;
+
+    // LC-BLYP
+    case 400:
+      set_lc_blyp(HF, HF_fac, screen);
+      break;
+
+    default:
+      cout << "The Functional id " << main_id << " doesn't implemented yet"
+           << endl;
+      exit(-1);
+      break;
+  }
+  cout << " " << endl;
 }
 #else
-extern "C" void g2g_extern_functional_(int& main_id, bool* externFunc,
-                              int* HF, double* HF_fac, double* screen)
-{
-   fortran_vars.fexc = 1.0f;
-   if ( *externFunc == 0 ) return;
-   cout << " " << endl;
-   cout << " Extern Functional Module " << endl;
+extern "C" void g2g_extern_functional_(int& main_id, bool* externFunc, int* HF,
+                                       double* HF_fac, double* screen) {
+  fortran_vars.fexc = 1.0f;
+  if (*externFunc == 0) return;
+  cout << " " << endl;
+  cout << " Extern Functional Module " << endl;
 
-   // Allocate and Free Memory
-   if ( fortran_vars.HF != NULL ) {
-      free(fortran_vars.HF); fortran_vars.HF = NULL;
-   }
-   if ( fortran_vars.HF_fac != NULL ) {
-      free(fortran_vars.HF_fac); fortran_vars.HF_fac = NULL;
-   }
-   fortran_vars.HF     = (int*   ) malloc(sizeof(double)*3);
-   fortran_vars.HF_fac = (double*) malloc(sizeof(double)*3);
+  // Allocate and Free Memory
+  if (fortran_vars.HF != NULL) {
+    free(fortran_vars.HF);
+    fortran_vars.HF = NULL;
+  }
+  if (fortran_vars.HF_fac != NULL) {
+    free(fortran_vars.HF_fac);
+    fortran_vars.HF_fac = NULL;
+  }
+  fortran_vars.HF = (int*)malloc(sizeof(double) * 3);
+  fortran_vars.HF_fac = (double*)malloc(sizeof(double) * 3);
 
-   if ( main_id == 406 ) {
-      fortran_vars.fexc = 0.75f;
-      fortran_vars.HF[0] = HF[0] = 1;
-      fortran_vars.HF[1] = HF[1] = 0;
-      fortran_vars.HF[2] = HF[2] = 0;
-      fortran_vars.HF_fac[0] = HF_fac[0] = 0.25f;
-      fortran_vars.HF_fac[1] = HF_fac[1] = 0.0f;
-      fortran_vars.HF_fac[2] = HF_fac[2] = 0.0f;
-      fortran_vars.screen = *screen = -1.0f;
-   } else {
-      cout << "In order to use external Functional you need to recompile ";
-      cout << "LIO with libxc=1 or 2" << endl;
-      fflush(stdout);
-      exit(-1);
-   }
+  if (main_id == 406) {
+    fortran_vars.fexc = 0.75f;
+    fortran_vars.HF[0] = HF[0] = 1;
+    fortran_vars.HF[1] = HF[1] = 0;
+    fortran_vars.HF[2] = HF[2] = 0;
+    fortran_vars.HF_fac[0] = HF_fac[0] = 0.25f;
+    fortran_vars.HF_fac[1] = HF_fac[1] = 0.0f;
+    fortran_vars.HF_fac[2] = HF_fac[2] = 0.0f;
+    fortran_vars.screen = *screen = -1.0f;
+  } else {
+    cout << "In order to use external Functional you need to recompile ";
+    cout << "LIO with libxc=1 or 2" << endl;
+    fflush(stdout);
+    exit(-1);
+  }
 }
 #endif

--- a/g2g/fix_compile.h
+++ b/g2g/fix_compile.h
@@ -9,25 +9,25 @@
 #endif
 
 #ifdef __CUDACC__
-    // Nothing
+// Nothing
 #else
-    // Fake definitions for the kernels so they'll
-    // compile under gcc or cc
-    struct fake_blockDim {
-	int x;
-    };
+// Fake definitions for the kernels so they'll
+// compile under gcc or cc
+struct fake_blockDim {
+  int x;
+};
 
-    struct fake_blockIdx {
-	int x;
-    };
+struct fake_blockIdx {
+  int x;
+};
 
-    struct fake_threadIdx {
-	int x;
-    };
+struct fake_threadIdx {
+  int x;
+};
 
-    extern fake_blockDim blockDim;
-    extern fake_blockIdx blockIdx;
-    extern fake_threadIdx threadIdx;
+extern fake_blockDim blockDim;
+extern fake_blockIdx blockIdx;
+extern fake_threadIdx threadIdx;
 #endif
 
 #endif

--- a/g2g/functional.h
+++ b/g2g/functional.h
@@ -1,250 +1,247 @@
 #include <xc.h>
 
-int print_info(int func_id) 
-{
-   xc_func_type *func=(xc_func_type*)malloc(sizeof(xc_func_type));
-   if(xc_func_init(func, func_id, XC_UNPOLARIZED) != 0) {
-     fprintf(stderr, "Functional %d not found\n", func_id);
-     return -1;
-   }
+int print_info(int func_id) {
+  xc_func_type* func = (xc_func_type*)malloc(sizeof(xc_func_type));
+  if (xc_func_init(func, func_id, XC_UNPOLARIZED) != 0) {
+    fprintf(stderr, "Functional %d not found\n", func_id);
+    return -1;
+  }
 
-   int value = 0;
-   printf("  The functional '%s' is ", func->info->name);
-   switch (func->info->kind) {
-       case (XC_EXCHANGE):
-           printf("an exchange functional");
-       break;
-       case (XC_CORRELATION):
-           printf("a correlation functional");
-       break;
-       case (XC_EXCHANGE_CORRELATION):
-           printf("an exchange-correlation functional");
-       break;
-       case (XC_KINETIC):
-           printf("a kinetic energy functional");
-       break;
-       default:
-           value = -1;
-           printf("of unknown kind");
-       break;
-   }
+  int value = 0;
+  printf("  The functional '%s' is ", func->info->name);
+  switch (func->info->kind) {
+    case (XC_EXCHANGE):
+      printf("an exchange functional");
+      break;
+    case (XC_CORRELATION):
+      printf("a correlation functional");
+      break;
+    case (XC_EXCHANGE_CORRELATION):
+      printf("an exchange-correlation functional");
+      break;
+    case (XC_KINETIC):
+      printf("a kinetic energy functional");
+      break;
+    default:
+      value = -1;
+      printf("of unknown kind");
+      break;
+  }
 
-   printf(",\n  it belongs to the ");
-   switch (func->info->family) {
-      case (XC_FAMILY_LDA):
-          printf("LDA"); break;
-      case (XC_FAMILY_GGA):
-          printf("GGA"); break;
-      case (XC_FAMILY_HYB_GGA):
-          printf("Hybrid GGA"); break;
-      case (XC_FAMILY_MGGA):
-          printf("MGGA"); break;
-      case (XC_FAMILY_HYB_MGGA):
-          printf("Hybrid MGGA");; break;
-      default:
-          value = -1;
-          printf("Family Unknown"); break;
-   }
+  printf(",\n  it belongs to the ");
+  switch (func->info->family) {
+    case (XC_FAMILY_LDA):
+      printf("LDA");
+      break;
+    case (XC_FAMILY_GGA):
+      printf("GGA");
+      break;
+    case (XC_FAMILY_HYB_GGA):
+      printf("Hybrid GGA");
+      break;
+    case (XC_FAMILY_MGGA):
+      printf("MGGA");
+      break;
+    case (XC_FAMILY_HYB_MGGA):
+      printf("Hybrid MGGA");
+      ;
+      break;
+    default:
+      value = -1;
+      printf("Family Unknown");
+      break;
+  }
 
-   printf("' family and is defined in the reference(s):\n");
-   for (int ii = 0; func->info->refs[ii] != NULL; ii++) {
-       printf ("  [%d] %s\n", ii+1, func->info->refs[ii]->ref);
-   }
-   xc_func_end(func);
+  printf("' family and is defined in the reference(s):\n");
+  for (int ii = 0; func->info->refs[ii] != NULL; ii++) {
+    printf("  [%d] %s\n", ii + 1, func->info->refs[ii]->ref);
+  }
+  xc_func_end(func);
 
-   return value;
+  return value;
 }
 
+void set_pbe(int* HF, double* HF_fac, double* screen) {
+  int err = -1;
+  fortran_vars.nx_func = 1;
+  fortran_vars.nc_func = 1;
+  fortran_vars.func_id = (int*)malloc(sizeof(int) * 2);
+  fortran_vars.func_coef = (double*)malloc(sizeof(double) * 2);
+  fortran_vars.HF = (int*)malloc(sizeof(double) * 3);
+  fortran_vars.HF_fac = (double*)malloc(sizeof(double) * 3);
 
-void set_pbe(int* HF, double* HF_fac, double* screen)
-{
-   int err = -1;
-   fortran_vars.nx_func=1;
-   fortran_vars.nc_func=1;
-   fortran_vars.func_id  = (int*) malloc(sizeof(int)*2);
-   fortran_vars.func_coef= (double*) malloc(sizeof(double)*2);
-   fortran_vars.HF = (int*) malloc(sizeof(double)*3);
-   fortran_vars.HF_fac = (double*) malloc(sizeof(double)*3);
+  // Internal variables for LIBXC
+  fortran_vars.func_id[0] = XC_GGA_X_PBE;
+  fortran_vars.func_id[1] = XC_GGA_C_PBE;
+  fortran_vars.func_coef[0] = 1.0f;  // X
+  fortran_vars.func_coef[1] = 1.0f;  // C
+  fortran_vars.nsr_id = -1;
 
-   // Internal variables for LIBXC
-   fortran_vars.func_id[0] = XC_GGA_X_PBE;
-   fortran_vars.func_id[1] = XC_GGA_C_PBE;
-   fortran_vars.func_coef[0]=1.0f; // X
-   fortran_vars.func_coef[1]=1.0f; // C
-   fortran_vars.nsr_id = -1;
+  // Internal variables for exact HF terms
+  fortran_vars.HF[0] = HF[0] = 0;
+  fortran_vars.HF[1] = HF[1] = 0;
+  fortran_vars.HF[2] = HF[2] = 0;
+  fortran_vars.HF_fac[0] = HF_fac[0] = 0.0f;
+  fortran_vars.HF_fac[1] = HF_fac[1] = 0.0f;
+  fortran_vars.HF_fac[2] = HF_fac[2] = 0.0f;
+  fortran_vars.screen = *screen = -1.0f;
 
-   // Internal variables for exact HF terms
-   fortran_vars.HF[0] = HF[0] = 0;
-   fortran_vars.HF[1] = HF[1] = 0;
-   fortran_vars.HF[2] = HF[2] = 0;
-   fortran_vars.HF_fac[0] = HF_fac[0] = 0.0f;
-   fortran_vars.HF_fac[1] = HF_fac[1] = 0.0f;
-   fortran_vars.HF_fac[2] = HF_fac[2] = 0.0f;
-   fortran_vars.screen = *screen = -1.0f;
-
-   err = print_info(XC_GGA_X_PBE);
-   if ( err != 0 ) exit(-1);
-   err = print_info(XC_GGA_C_PBE);
-   if ( err != 0 ) exit(-1);
+  err = print_info(XC_GGA_X_PBE);
+  if (err != 0) exit(-1);
+  err = print_info(XC_GGA_C_PBE);
+  if (err != 0) exit(-1);
 }
 
-void set_pbe0(int* HF, double* HF_fac, double* screen)
-{
-   int err = -1;
-   fortran_vars.nx_func=1;
-   fortran_vars.nc_func=1;
-   fortran_vars.func_id = (int*) malloc(sizeof(int)*2);
-   fortran_vars.func_coef= (double*) malloc(sizeof(double)*2);
-   fortran_vars.HF = (int*) malloc(sizeof(double)*3);
-   fortran_vars.HF_fac = (double*) malloc(sizeof(double)*3);
+void set_pbe0(int* HF, double* HF_fac, double* screen) {
+  int err = -1;
+  fortran_vars.nx_func = 1;
+  fortran_vars.nc_func = 1;
+  fortran_vars.func_id = (int*)malloc(sizeof(int) * 2);
+  fortran_vars.func_coef = (double*)malloc(sizeof(double) * 2);
+  fortran_vars.HF = (int*)malloc(sizeof(double) * 3);
+  fortran_vars.HF_fac = (double*)malloc(sizeof(double) * 3);
 
-   // Internal variables for LIBXC
-   fortran_vars.func_id[0] = XC_GGA_X_PBE;
-   fortran_vars.func_id[1] = XC_GGA_C_PBE;
-   fortran_vars.func_coef[0]=0.75f; // X
-   fortran_vars.func_coef[1]=1.0f; // C
-   fortran_vars.nsr_id = -1;
+  // Internal variables for LIBXC
+  fortran_vars.func_id[0] = XC_GGA_X_PBE;
+  fortran_vars.func_id[1] = XC_GGA_C_PBE;
+  fortran_vars.func_coef[0] = 0.75f;  // X
+  fortran_vars.func_coef[1] = 1.0f;   // C
+  fortran_vars.nsr_id = -1;
 
-   // Internal variables for LIBINT
-   fortran_vars.HF[0] = HF[0] = 1;
-   fortran_vars.HF[1] = HF[1] = 0;
-   fortran_vars.HF[2] = HF[2] = 0;
-   fortran_vars.HF_fac[0] = HF_fac[0] = 0.25f;
-   fortran_vars.HF_fac[1] = HF_fac[1] = 0.0f;
-   fortran_vars.HF_fac[2] = HF_fac[2] = 0.0f;
-   fortran_vars.screen = *screen = -1.0f;
+  // Internal variables for LIBINT
+  fortran_vars.HF[0] = HF[0] = 1;
+  fortran_vars.HF[1] = HF[1] = 0;
+  fortran_vars.HF[2] = HF[2] = 0;
+  fortran_vars.HF_fac[0] = HF_fac[0] = 0.25f;
+  fortran_vars.HF_fac[1] = HF_fac[1] = 0.0f;
+  fortran_vars.HF_fac[2] = HF_fac[2] = 0.0f;
+  fortran_vars.screen = *screen = -1.0f;
 
-   err = print_info(XC_HYB_GGA_XC_PBEH);
-   if ( err != 0 ) exit(-1);
+  err = print_info(XC_HYB_GGA_XC_PBEH);
+  if (err != 0) exit(-1);
 }
 
-void set_b3lyp(int* HF, double* HF_fac, double* screen)
-{
-   int err = -1;
-   fortran_vars.nx_func=2;
-   fortran_vars.nc_func=2;
-   fortran_vars.func_id = (int*) malloc(sizeof(int)*4);
-   fortran_vars.func_coef= (double*) malloc(sizeof(double)*4);
-   fortran_vars.HF = (int*) malloc(sizeof(double)*3);
-   fortran_vars.HF_fac = (double*) malloc(sizeof(double)*3);
-   
-   // Internal variables for LIBXC
-   fortran_vars.func_id[0] = XC_LDA_X;
-   fortran_vars.func_id[1] = XC_GGA_X_B88;
-   fortran_vars.func_id[2] = XC_LDA_C_VWN_RPA;
-   fortran_vars.func_id[3] = XC_GGA_C_LYP;
-   fortran_vars.func_coef[0]=0.08f; // X
-   fortran_vars.func_coef[1]=0.72f; // X
-   fortran_vars.func_coef[2]=0.19f; // C
-   fortran_vars.func_coef[3]=0.81f; // C
-   fortran_vars.nsr_id = -1;
+void set_b3lyp(int* HF, double* HF_fac, double* screen) {
+  int err = -1;
+  fortran_vars.nx_func = 2;
+  fortran_vars.nc_func = 2;
+  fortran_vars.func_id = (int*)malloc(sizeof(int) * 4);
+  fortran_vars.func_coef = (double*)malloc(sizeof(double) * 4);
+  fortran_vars.HF = (int*)malloc(sizeof(double) * 3);
+  fortran_vars.HF_fac = (double*)malloc(sizeof(double) * 3);
 
-   // Internal variables for LIBINT
-   fortran_vars.HF[0] = HF[0] = 1;
-   fortran_vars.HF[1] = HF[1] = 0;
-   fortran_vars.HF[2] = HF[2] = 0;
-   fortran_vars.HF_fac[0] = HF_fac[0] = 0.2f;
-   fortran_vars.HF_fac[1] = HF_fac[1] = 0.0f;
-   fortran_vars.HF_fac[2] = HF_fac[2] = 0.0f;
-   fortran_vars.screen = *screen = -1.0f;
+  // Internal variables for LIBXC
+  fortran_vars.func_id[0] = XC_LDA_X;
+  fortran_vars.func_id[1] = XC_GGA_X_B88;
+  fortran_vars.func_id[2] = XC_LDA_C_VWN_RPA;
+  fortran_vars.func_id[3] = XC_GGA_C_LYP;
+  fortran_vars.func_coef[0] = 0.08f;  // X
+  fortran_vars.func_coef[1] = 0.72f;  // X
+  fortran_vars.func_coef[2] = 0.19f;  // C
+  fortran_vars.func_coef[3] = 0.81f;  // C
+  fortran_vars.nsr_id = -1;
 
-   err = print_info(XC_HYB_GGA_XC_B3LYP);
-   if ( err != 0 ) exit(-1);
-}  
+  // Internal variables for LIBINT
+  fortran_vars.HF[0] = HF[0] = 1;
+  fortran_vars.HF[1] = HF[1] = 0;
+  fortran_vars.HF[2] = HF[2] = 0;
+  fortran_vars.HF_fac[0] = HF_fac[0] = 0.2f;
+  fortran_vars.HF_fac[1] = HF_fac[1] = 0.0f;
+  fortran_vars.HF_fac[2] = HF_fac[2] = 0.0f;
+  fortran_vars.screen = *screen = -1.0f;
 
-void set_cam_b3lyp(int* HF, double* HF_fac, double* screen)
-{
-   int err = -1;
-   fortran_vars.nx_func=2;
-   fortran_vars.nc_func=2;
-   fortran_vars.func_id = (int*) malloc(sizeof(int)*4);
-   fortran_vars.func_coef= (double*) malloc(sizeof(double)*4);
-   fortran_vars.HF = (int*) malloc(sizeof(double)*3);
-   fortran_vars.HF_fac = (double*) malloc(sizeof(double)*3);
-
-   // Internal variables for LIBXC
-   fortran_vars.func_id[0] = XC_GGA_X_B88;
-   fortran_vars.func_id[1] = XC_GGA_X_ITYH;
-   fortran_vars.func_id[2] = XC_LDA_C_VWN;
-   fortran_vars.func_id[3] = XC_GGA_C_LYP;
-   fortran_vars.func_coef[0]=0.35f; // X
-   fortran_vars.func_coef[1]=0.46f; // X
-   fortran_vars.func_coef[2]=0.19f; // C
-   fortran_vars.func_coef[3]=0.81f; // C
-   fortran_vars.nsr_id = 1;
-
-   // Internal variables for LIBINT
-   fortran_vars.HF[0] = HF[0] = 1;
-   fortran_vars.HF[1] = HF[1] = 0;
-   fortran_vars.HF[2] = HF[2] = 1;
-   fortran_vars.HF_fac[0] = HF_fac[0] = 0.19f;
-   fortran_vars.HF_fac[1] = HF_fac[1] = 0.0f;
-   fortran_vars.HF_fac[2] = HF_fac[2] = 0.46f;
-   fortran_vars.screen = *screen = 0.33f;
-
-   err = print_info(XC_HYB_GGA_XC_CAM_B3LYP);
-   if ( err != 0 ) exit(-1);
+  err = print_info(XC_HYB_GGA_XC_B3LYP);
+  if (err != 0) exit(-1);
 }
 
-void set_lc_wpbe(int* HF, double* HF_fac, double* screen)
-{
-   int err = -1;
-   fortran_vars.nx_func=1;
-   fortran_vars.nc_func=1;
-   fortran_vars.func_id = (int*) malloc(sizeof(int)*2);
-   fortran_vars.func_coef= (double*) malloc(sizeof(double)*2);
-   fortran_vars.HF = (int*) malloc(sizeof(double)*3);
-   fortran_vars.HF_fac = (double*) malloc(sizeof(double)*3);
+void set_cam_b3lyp(int* HF, double* HF_fac, double* screen) {
+  int err = -1;
+  fortran_vars.nx_func = 2;
+  fortran_vars.nc_func = 2;
+  fortran_vars.func_id = (int*)malloc(sizeof(int) * 4);
+  fortran_vars.func_coef = (double*)malloc(sizeof(double) * 4);
+  fortran_vars.HF = (int*)malloc(sizeof(double) * 3);
+  fortran_vars.HF_fac = (double*)malloc(sizeof(double) * 3);
 
-   // Internal variables for LIBXC
-   fortran_vars.func_id[0] = XC_GGA_X_WPBEH;
-   fortran_vars.func_id[1] = XC_GGA_C_PBE;
-   fortran_vars.func_coef[0]=1.0f; // X
-   fortran_vars.func_coef[1]=1.0f; // C
-   fortran_vars.nsr_id = 0;
+  // Internal variables for LIBXC
+  fortran_vars.func_id[0] = XC_GGA_X_B88;
+  fortran_vars.func_id[1] = XC_GGA_X_ITYH;
+  fortran_vars.func_id[2] = XC_LDA_C_VWN;
+  fortran_vars.func_id[3] = XC_GGA_C_LYP;
+  fortran_vars.func_coef[0] = 0.35f;  // X
+  fortran_vars.func_coef[1] = 0.46f;  // X
+  fortran_vars.func_coef[2] = 0.19f;  // C
+  fortran_vars.func_coef[3] = 0.81f;  // C
+  fortran_vars.nsr_id = 1;
 
-   // Internal variables for LIBINT
-   fortran_vars.HF[0] = HF[0] = 0;
-   fortran_vars.HF[1] = HF[1] = 0;
-   fortran_vars.HF[2] = HF[2] = 1; // este es el tru d verdad
-   fortran_vars.HF_fac[0] = HF_fac[0] = 0.0f;
-   fortran_vars.HF_fac[1] = HF_fac[1] = 0.0f;
-   fortran_vars.HF_fac[2] = HF_fac[2] = 1.0f;
-   fortran_vars.screen = *screen = 0.4f;
+  // Internal variables for LIBINT
+  fortran_vars.HF[0] = HF[0] = 1;
+  fortran_vars.HF[1] = HF[1] = 0;
+  fortran_vars.HF[2] = HF[2] = 1;
+  fortran_vars.HF_fac[0] = HF_fac[0] = 0.19f;
+  fortran_vars.HF_fac[1] = HF_fac[1] = 0.0f;
+  fortran_vars.HF_fac[2] = HF_fac[2] = 0.46f;
+  fortran_vars.screen = *screen = 0.33f;
 
-   err = print_info(XC_HYB_GGA_XC_LC_WPBE);
-   if ( err != 0 ) exit(-1);
+  err = print_info(XC_HYB_GGA_XC_CAM_B3LYP);
+  if (err != 0) exit(-1);
 }
 
-void set_lc_blyp(int* HF, double* HF_fac, double* screen)
-{
+void set_lc_wpbe(int* HF, double* HF_fac, double* screen) {
+  int err = -1;
+  fortran_vars.nx_func = 1;
+  fortran_vars.nc_func = 1;
+  fortran_vars.func_id = (int*)malloc(sizeof(int) * 2);
+  fortran_vars.func_coef = (double*)malloc(sizeof(double) * 2);
+  fortran_vars.HF = (int*)malloc(sizeof(double) * 3);
+  fortran_vars.HF_fac = (double*)malloc(sizeof(double) * 3);
 
-   int err = -1;
-   fortran_vars.nx_func=1;
-   fortran_vars.nc_func=1;
-   fortran_vars.func_id = (int*) malloc(sizeof(int)*2);
-   fortran_vars.func_coef= (double*) malloc(sizeof(double)*2);
-   fortran_vars.HF = (int*) malloc(sizeof(double)*3);
-   fortran_vars.HF_fac = (double*) malloc(sizeof(double)*3);
+  // Internal variables for LIBXC
+  fortran_vars.func_id[0] = XC_GGA_X_WPBEH;
+  fortran_vars.func_id[1] = XC_GGA_C_PBE;
+  fortran_vars.func_coef[0] = 1.0f;  // X
+  fortran_vars.func_coef[1] = 1.0f;  // C
+  fortran_vars.nsr_id = 0;
 
-   // Internal variables for LIBXC
-   fortran_vars.func_id[0] = XC_GGA_X_ITYH;
-   fortran_vars.func_id[1] = XC_GGA_C_LYP;
-   fortran_vars.func_coef[0]=1.0f; // X
-   fortran_vars.func_coef[1]=1.0f; // C
-   fortran_vars.nsr_id = 0;
+  // Internal variables for LIBINT
+  fortran_vars.HF[0] = HF[0] = 0;
+  fortran_vars.HF[1] = HF[1] = 0;
+  fortran_vars.HF[2] = HF[2] = 1;  // este es el tru d verdad
+  fortran_vars.HF_fac[0] = HF_fac[0] = 0.0f;
+  fortran_vars.HF_fac[1] = HF_fac[1] = 0.0f;
+  fortran_vars.HF_fac[2] = HF_fac[2] = 1.0f;
+  fortran_vars.screen = *screen = 0.4f;
 
-   // Internal variables for LIBINT
-   fortran_vars.HF[0] = HF[0] = 0;
-   fortran_vars.HF[1] = HF[1] = 0;
-   fortran_vars.HF[2] = HF[2] = 1; // este es el tru d verdad
-   fortran_vars.HF_fac[0] = HF_fac[0] = 0.0f;
-   fortran_vars.HF_fac[1] = HF_fac[1] = 0.0f;
-   fortran_vars.HF_fac[2] = HF_fac[2] = 1.0f;
-   fortran_vars.screen = *screen = 0.47f;
-   //fortran_vars.screen = 0.33f; la otra opcion
-
-   err = print_info(XC_HYB_GGA_XC_LC_BLYP);
-   if ( err != 0 ) exit(-1);
+  err = print_info(XC_HYB_GGA_XC_LC_WPBE);
+  if (err != 0) exit(-1);
 }
 
+void set_lc_blyp(int* HF, double* HF_fac, double* screen) {
+  int err = -1;
+  fortran_vars.nx_func = 1;
+  fortran_vars.nc_func = 1;
+  fortran_vars.func_id = (int*)malloc(sizeof(int) * 2);
+  fortran_vars.func_coef = (double*)malloc(sizeof(double) * 2);
+  fortran_vars.HF = (int*)malloc(sizeof(double) * 3);
+  fortran_vars.HF_fac = (double*)malloc(sizeof(double) * 3);
+
+  // Internal variables for LIBXC
+  fortran_vars.func_id[0] = XC_GGA_X_ITYH;
+  fortran_vars.func_id[1] = XC_GGA_C_LYP;
+  fortran_vars.func_coef[0] = 1.0f;  // X
+  fortran_vars.func_coef[1] = 1.0f;  // C
+  fortran_vars.nsr_id = 0;
+
+  // Internal variables for LIBINT
+  fortran_vars.HF[0] = HF[0] = 0;
+  fortran_vars.HF[1] = HF[1] = 0;
+  fortran_vars.HF[2] = HF[2] = 1;  // este es el tru d verdad
+  fortran_vars.HF_fac[0] = HF_fac[0] = 0.0f;
+  fortran_vars.HF_fac[1] = HF_fac[1] = 0.0f;
+  fortran_vars.HF_fac[2] = HF_fac[2] = 1.0f;
+  fortran_vars.screen = *screen = 0.47f;
+  // fortran_vars.screen = 0.33f; la otra opcion
+
+  err = print_info(XC_HYB_GGA_XC_LC_BLYP);
+  if (err != 0) exit(-1);
+}

--- a/g2g/init.cpp
+++ b/g2g/init.cpp
@@ -16,11 +16,11 @@
 #endif
 
 //#include "qmmm_forces.h"
+using std::boolalpha;
 using std::cout;
 using std::endl;
-using std::boolalpha;
-using std::runtime_error;
 using std::ifstream;
+using std::runtime_error;
 using std::string;
 using namespace G2G;
 
@@ -28,10 +28,10 @@ Partition partition;
 
 /* global variables */
 namespace G2G {
-  FortranVars fortran_vars;
-  int cpu_threads=0;
-  int gpu_threads=0;
-}
+FortranVars fortran_vars;
+int cpu_threads = 0;
+int gpu_threads = 0;
+}  // namespace G2G
 
 /* methods */
 //===========================================================================================
@@ -61,16 +61,16 @@ extern "C" void g2g_init_(void) {
   if (G2G::gpu_threads == 0 && G2G::cpu_threads == 0)
     throw runtime_error(
         "  ERROR: Either a gpu or a cpu thread is needed to run G2G");
-  if (verbose > 2) cout << "  Using " << G2G::cpu_threads << " CPU Threads and "
-       << G2G::gpu_threads << " GPU Threads." << endl;
-
+  if (verbose > 2)
+    cout << "  Using " << G2G::cpu_threads << " CPU Threads and "
+         << G2G::gpu_threads << " GPU Threads." << endl;
 }
 //==========================================================================================
 namespace G2G {
 void gpu_set_variables(void);
 template <class T>
 void gpu_set_atom_positions(const HostMatrix<T>& m);
-}
+}  // namespace G2G
 //==========================================================================================
 extern "C" void g2g_parameter_init_(
     const unsigned int& norm, const unsigned int& natom,
@@ -79,13 +79,13 @@ extern "C" void g2g_parameter_init_(
     double* r, double* Rm, const unsigned int* Iz, const unsigned int* Nr,
     const unsigned int* Nr2, unsigned int* Nuc, const unsigned int& M,
     unsigned int* ncont, const unsigned int* nshell, double* c, double* a,
-    double* rho_vec, double* fock_vec, double* fockb_vec,
-    double* rhoalpha, double* rhobeta,
-    const unsigned int& nco, bool& OPEN, const unsigned int& nunp,
-    const unsigned int& nopt, const unsigned int& Iexch, double* e, double* e2,
-    double* e3, double* wang, double* wang2, double* wang3,
-    bool& use_libxc, const unsigned int& ex_functional_id, 
-    const unsigned int& ec_functional_id, bool& becke){
+    double* rho_vec, double* fock_vec, double* fockb_vec, double* rhoalpha,
+    double* rhobeta, const unsigned int& nco, bool& OPEN,
+    const unsigned int& nunp, const unsigned int& nopt,
+    const unsigned int& Iexch, double* e, double* e2, double* e3, double* wang,
+    double* wang2, double* wang3, bool& use_libxc,
+    const unsigned int& ex_functional_id, const unsigned int& ec_functional_id,
+    bool& becke) {
   fortran_vars.atoms = natom;
   fortran_vars.max_atoms = max_atoms;
   fortran_vars.gaussians = ngaussians;
@@ -98,7 +98,7 @@ extern "C" void g2g_parameter_init_(
 #ifdef _DEBUG
   // trap floating point exceptions on debug
   signal(SIGFPE, SIG_DFL);
-  //feenableexcept(FE_INVALID);
+  // feenableexcept(FE_INVALID);
   // This line interferes with Lapack routines on floating point error catching.
   // Commented out until a better solution is found.
 #endif
@@ -125,7 +125,7 @@ extern "C" void g2g_parameter_init_(
   fortran_vars.atom_Z.resize(fortran_vars.atoms);
   for (uint i = 0; i < fortran_vars.atoms; i++) {
     fortran_vars.atom_types(i) = Iz[i] - 1;
-    fortran_vars.atom_Z(i)     = Iz[i];
+    fortran_vars.atom_Z(i) = Iz[i];
   }
 
   fortran_vars.shells1.resize(fortran_vars.atoms);
@@ -161,18 +161,20 @@ extern "C" void g2g_parameter_init_(
   fortran_vars.OPEN = OPEN;
 
   if (verbose > 2) {
-     cout << "  QM atoms: " << fortran_vars.atoms;
-     cout << " - MM atoms: " << fortran_vars.max_atoms - fortran_vars.atoms << endl;
-     cout << "  Total number of basis: " << fortran_vars.gaussians;
-     cout << " (s: " << fortran_vars.s_funcs << " p: " << fortran_vars.p_funcs
-          << " d: "<< fortran_vars.d_funcs << ")" << endl;
+    cout << "  QM atoms: " << fortran_vars.atoms;
+    cout << " - MM atoms: " << fortran_vars.max_atoms - fortran_vars.atoms
+         << endl;
+    cout << "  Total number of basis: " << fortran_vars.gaussians;
+    cout << " (s: " << fortran_vars.s_funcs << " p: " << fortran_vars.p_funcs
+         << " d: " << fortran_vars.d_funcs << ")" << endl;
   }
 
   if (fortran_vars.OPEN) {
     fortran_vars.nunp = nunp;
-    if (verbose > 2) cout << "  Open shell calculation - Occupied MO(UP): "
-         << fortran_vars.nco << " - Occupied MO(DOWN): "
-         << fortran_vars.nco + fortran_vars.nunp << endl;
+    if (verbose > 2)
+      cout << "  Open shell calculation - Occupied MO(UP): " << fortran_vars.nco
+           << " - Occupied MO(DOWN): " << fortran_vars.nco + fortran_vars.nunp
+           << endl;
 
     fortran_vars.rmm_dens_a = FortranMatrix<double>(
         rhoalpha, fortran_vars.m, fortran_vars.m, fortran_vars.m);
@@ -183,18 +185,19 @@ extern "C" void g2g_parameter_init_(
 
     //  Matriz de fock
     fortran_vars.rmm_output_a = FortranMatrix<double>(
-        fock_vec,  (fortran_vars.m * (fortran_vars.m + 1) / 2));
+        fock_vec, (fortran_vars.m * (fortran_vars.m + 1) / 2));
     fortran_vars.rmm_output_b = FortranMatrix<double>(
         fockb_vec, (fortran_vars.m * (fortran_vars.m + 1) / 2));
   } else {
-    if (verbose > 2) cout << "  Closed shell calculation - Occupied MO: "
-         << fortran_vars.nco << endl;
+    if (verbose > 2)
+      cout << "  Closed shell calculation - Occupied MO: " << fortran_vars.nco
+           << endl;
     // matriz densidad
     fortran_vars.rmm_input_ndens1 = FortranMatrix<double>(
         rho_vec, fortran_vars.m, fortran_vars.m, fortran_vars.m);
     // matriz de Fock
     fortran_vars.rmm_output = FortranMatrix<double>(
-        fock_vec,  (fortran_vars.m * (fortran_vars.m + 1) / 2));
+        fock_vec, (fortran_vars.m * (fortran_vars.m + 1) / 2));
   }
 
   fortran_vars.e1 =
@@ -218,12 +221,12 @@ extern "C" void g2g_parameter_init_(
 
 /** Variables para configurar libxc **/
 #if USE_LIBXC
-    fortran_vars.use_libxc = use_libxc;
-    fortran_vars.ex_functional_id = ex_functional_id;
-    fortran_vars.ec_functional_id = ec_functional_id;
-    if (fortran_vars.use_libxc) {
-        cout << "*Using Libxc" << endl;
-    }
+  fortran_vars.use_libxc = use_libxc;
+  fortran_vars.ex_functional_id = ex_functional_id;
+  fortran_vars.ec_functional_id = ec_functional_id;
+  if (fortran_vars.use_libxc) {
+    cout << "*Using Libxc" << endl;
+  }
 #endif
 
 #if GPU_KERNELS
@@ -276,7 +279,7 @@ void compute_new_grid(const unsigned int grid_type) {
       fortran_vars.shells.resize(fortran_vars.atoms);
       for (int i = 0; i < fortran_vars.atoms; i++) {
         fortran_vars.shells(i) = fortran_vars.shells2(i) * 2;
-        fortran_vars.rm(i)     = fortran_vars.rm_base(i) * 0.5;
+        fortran_vars.rm(i) = fortran_vars.rm_base(i) * 0.5;
       }
       break;
     case 4:
@@ -287,7 +290,7 @@ void compute_new_grid(const unsigned int grid_type) {
       fortran_vars.shells.resize(fortran_vars.atoms);
       for (int i = 0; i < fortran_vars.atoms; i++) {
         fortran_vars.shells(i) = fortran_vars.shells2(i) * 4;
-        fortran_vars.rm(i)     = fortran_vars.rm_base(i) * 0.25;
+        fortran_vars.rm(i) = fortran_vars.rm_base(i) * 0.25;
       }
       break;
     default:
@@ -311,7 +314,7 @@ void compute_new_grid(const unsigned int grid_type) {
 #endif
 }
 //==============================================================================================================
-extern "C" void g2g_reload_atom_positions_(const unsigned int& grid_type, 
+extern "C" void g2g_reload_atom_positions_(const unsigned int& grid_type,
                                            unsigned int* atom_Z_in) {
   // IGRID indicates the grid type used.
   // atom_Z is updated in case Becke partition is desired.
@@ -324,7 +327,7 @@ extern "C" void g2g_reload_atom_positions_(const unsigned int& grid_type,
                                fortran_vars.atom_positions_pointer(i, 1),
                                fortran_vars.atom_positions_pointer(i, 2));
     fortran_vars.atom_positions(i) = pos;
-    fortran_vars.atom_Z(i)         = atom_Z_in[i];
+    fortran_vars.atom_Z(i) = atom_Z_in[i];
     atom_positions(i) = make_float3(pos.x, pos.y, pos.z);
   }
 
@@ -352,12 +355,12 @@ template <bool compute_rmm, bool lda, bool compute_forces>
 void g2g_iteration(bool compute_energy, double* fort_energy_ptr,
                    double* fort_forces_ptr) {
   Timers timers;
-#ifdef _DEBUG 
+#ifdef _DEBUG
   feenableexcept(FE_INVALID | FE_DIVBYZERO | FE_OVERFLOW);
 #endif
   partition.solve(timers, compute_rmm, lda, compute_forces, compute_energy,
                   fort_energy_ptr, fort_forces_ptr, fortran_vars.OPEN);
-#ifdef _DEBUG 
+#ifdef _DEBUG
   fedisableexcept(FE_INVALID | FE_DIVBYZERO | FE_OVERFLOW);
 #endif
 }
@@ -424,10 +427,10 @@ extern "C" void g2g_solve_groups_(const uint& computation_type,
   }
 }
 
-extern "C" void g2g_get_becke_dens_(double* fort_becke){
+extern "C" void g2g_get_becke_dens_(double* fort_becke) {
   // VERY dirty fix to becke charges...
   double total_dens = 0.0, factor = 1.0;
-  int    n_elecs    = fortran_vars.nco*2;
+  int n_elecs = fortran_vars.nco * 2;
   if (fortran_vars.OPEN) {
     n_elecs += fortran_vars.nunp;
   }
@@ -435,17 +438,18 @@ extern "C" void g2g_get_becke_dens_(double* fort_becke){
     total_dens += fortran_vars.becke_atom_dens(i);
   }
   if (total_dens > 1E-36) {
-    factor = (double) n_elecs / total_dens;
+    factor = (double)n_elecs / total_dens;
   } else {
     factor = 0.0;
-  };  
+  };
 
   for (int i = 0; i < fortran_vars.atoms; i++) {
-    fort_becke[i] = fortran_vars.atom_Z(i) - fortran_vars.becke_atom_dens(i) * factor;
+    fort_becke[i] =
+        fortran_vars.atom_Z(i) - fortran_vars.becke_atom_dens(i) * factor;
   }
 }
 
-extern "C" void g2g_get_becke_spin_(double* fort_becke){
+extern "C" void g2g_get_becke_spin_(double* fort_becke) {
   if (!fortran_vars.OPEN) return;
 
   for (int i = 0; i < fortran_vars.atoms; i++) {
@@ -467,7 +471,7 @@ double free_global_memory = 0.0;
 bool timer_single = false;
 bool timer_sum = false;
 uint verbose = 0;
-}
+}  // namespace G2G
 
 //=================================================================================================================
 extern "C" void g2g_set_options_(double* fort_fgm, double* fort_lcs,

--- a/g2g/init.h
+++ b/g2g/init.h
@@ -7,7 +7,8 @@
 #include <unordered_map>
 #include "libint/libintproxy.h"
 using shellpair_list_t = std::unordered_map<size_t, std::vector<size_t>>;
-using shellpair_data_t = std::vector<std::vector<std::shared_ptr<libint2::ShellPair>>>;
+using shellpair_data_t =
+    std::vector<std::vector<std::shared_ptr<libint2::ShellPair>>>;
 #endif
 
 using std::vector;
@@ -63,9 +64,11 @@ struct FortranVars {
 
   /////////////////////////////////////
   // Agregado para integrar con Libxc
-  bool use_libxc; // Si usa o no libxc
-  uint ex_functional_id; // Identificador del funcional de intercambio (exchange)
-  uint ec_functional_id; // Identificador del funcional de correlacion (correlation)
+  bool use_libxc;         // Si usa o no libxc
+  uint ex_functional_id;  // Identificador del funcional de intercambio
+                          // (exchange)
+  uint ec_functional_id;  // Identificador del funcional de correlacion
+                          // (correlation)
   /////////////////////////////////////
 
   // PBE0 factor
@@ -81,18 +84,19 @@ struct FortranVars {
 
   // LIBINT VARIABLES //
 #if USE_LIBINT
-  vector<libint2::Shell> obs; // Basis (in libint format)
-  vector<int> shell2bf;       // first basis function
-  vector<int> shell2atom;     // atom centre of shell
-  uint center4Recalc;  // Method
-  double* integrals;   // Integrals in memory HF FULL
-  double* shortrange;   // Integrals in memory HF short range correction
-  double* longrange;   // Integrals in memory HF long range correction
-  shellpair_list_t obs_shellpair_list;  // shellpair list for precalculated Integral
-  shellpair_data_t obs_shellpair_data;  // shellpair data for precalculated Integral
+  vector<libint2::Shell> obs;  // Basis (in libint format)
+  vector<int> shell2bf;        // first basis function
+  vector<int> shell2atom;      // atom centre of shell
+  uint center4Recalc;          // Method
+  double* integrals;           // Integrals in memory HF FULL
+  double* shortrange;          // Integrals in memory HF short range correction
+  double* longrange;           // Integrals in memory HF long range correction
+  shellpair_list_t
+      obs_shellpair_list;  // shellpair list for precalculated Integral
+  shellpair_data_t
+      obs_shellpair_data;  // shellpair data for precalculated Integral
 #endif
   /////////////////////
-  
 };
 
 struct CDFTVars {
@@ -102,12 +106,12 @@ struct CDFTVars {
   uint max_nat;
   HostMatrix<double> Vc;
   HostMatrix<double> Vs;
-  HostMatrix<uint>   natom;
-  HostMatrix<uint>   atoms;
+  HostMatrix<uint> natom;
+  HostMatrix<uint> atoms;
 };
 
 extern FortranVars fortran_vars;
-extern CDFTVars    cdft_vars;
+extern CDFTVars cdft_vars;
 
 extern uint max_function_exponent;
 extern double
@@ -124,6 +128,6 @@ extern double free_global_memory;
 extern bool timer_sum;
 extern bool timer_single;
 extern uint verbose;
-}
+}  // namespace G2G
 
 #endif

--- a/g2g/libint/g2g_libint.cpp
+++ b/g2g/libint/g2g_libint.cpp
@@ -9,69 +9,56 @@
 
 #include "libintproxy.h"
 
-
 using namespace G2G;
 
+extern "C" void g2g_libint_init_(double* Cbas, int& recalc, int& idd) {
+  // INITIALIZATION LIBINT
+  LIBINTproxy libintproxy;
+  libintproxy.init(  // inputs
+      fortran_vars.m, fortran_vars.atoms, &fortran_vars.contractions(0), Cbas,
+      &fortran_vars.a_values(0, 0), &fortran_vars.atom_positions_pointer(0, 0),
+      &fortran_vars.nucleii(0), fortran_vars.s_funcs, fortran_vars.p_funcs,
+      fortran_vars.d_funcs, recalc, idd);
 
-extern "C" void g2g_libint_init_(double* Cbas, int& recalc, int& idd)
-{
-   
-// INITIALIZATION LIBINT
-   LIBINTproxy libintproxy;
-   libintproxy.init( // inputs
-                    fortran_vars.m, fortran_vars.atoms,
-                    &fortran_vars.contractions(0),
-                    Cbas, &fortran_vars.a_values(0,0),
-                    &fortran_vars.atom_positions_pointer(0,0),
-                    &fortran_vars.nucleii(0),
-                    fortran_vars.s_funcs, fortran_vars.p_funcs,
-                    fortran_vars.d_funcs, recalc, idd);
-
-//  libintproxy.PrintBasis();
+  //  libintproxy.PrintBasis();
 }
 
 // CLOSED SHELL
-extern "C" void g2g_exact_exchange_(double* rho, double* fock, int* op)
-{
+extern "C" void g2g_exact_exchange_(double* rho, double* fock, int* op) {
   LIBINTproxy libintproxy;
-  libintproxy.do_exchange(rho,fock,op);
+  libintproxy.do_exchange(rho, fock, op);
 }
 
-extern "C" void g2g_exact_exchange_gradient_(double* rho, double* frc, int* op)
-{
+extern "C" void g2g_exact_exchange_gradient_(double* rho, double* frc,
+                                             int* op) {
   LIBINTproxy libintproxy;
-  libintproxy.do_ExchangeForces(rho,frc,op);
+  libintproxy.do_ExchangeForces(rho, frc, op);
 }
 
 // Excited State
-extern "C" void g2g_calculate2e_(double* tao, double* fock, int& vecdim)
-{
+extern "C" void g2g_calculate2e_(double* tao, double* fock, int& vecdim) {
   LIBINTproxy libintproxy;
-  libintproxy.do_CoulombExchange(tao,fock,vecdim);
+  libintproxy.do_CoulombExchange(tao, fock, vecdim);
 }
 
 // Exact Exchange Gradients in Excited States
-extern "C" void g2g_exacgrad_excited_(double* rhoG,double* DiffExc,
-                                     double* Xmat,double* fEE)
-{
+extern "C" void g2g_exacgrad_excited_(double* rhoG, double* DiffExc,
+                                      double* Xmat, double* fEE) {
   LIBINTproxy libintproxy;
-  libintproxy.do_ExacGradient(rhoG,DiffExc,Xmat,fEE);
+  libintproxy.do_ExacGradient(rhoG, DiffExc, Xmat, fEE);
 }
 
 // Gamma of Coulomb and Exchange
-extern "C" void g2g_calcgammcou_(double* rhoG, double* Zmat, double* gamm)
-{
+extern "C" void g2g_calcgammcou_(double* rhoG, double* Zmat, double* gamm) {
   LIBINTproxy libintproxy;
-  libintproxy.do_GammaCou(rhoG,Zmat,gamm);
+  libintproxy.do_GammaCou(rhoG, Zmat, gamm);
 }
 ////////////////////////////////////////////////////////////////////////
 
 // OPEN SHELL
 extern "C" void g2g_exact_exchange_open_(double* rhoA, double* rhoB,
-                                         double* fockA, double* fockB)
-{
+                                         double* fockA, double* fockB) {
   LIBINTproxy libintproxy;
-  libintproxy.do_exchange(rhoA,rhoB,fockA,fockB);
+  libintproxy.do_exchange(rhoA, rhoB, fockA, fockB);
 }
 ////////////////////////////////////////////////////////////////////////
-

--- a/g2g/libint/g2g_libint_fake.cpp
+++ b/g2g/libint/g2g_libint_fake.cpp
@@ -4,51 +4,39 @@
 
 using namespace std;
 
-
-extern "C" void g2g_libint_init_(double* Cbas)
-{
+extern "C" void g2g_libint_init_(double* Cbas) {
   cout << "  Please compile LIO with option: libint=1" << endl;
   exit(-1);
 }
 
-extern "C" void g2g_exact_exchange_(double* rho, double* fock)
-{
+extern "C" void g2g_exact_exchange_(double* rho, double* fock) {
   cout << "  Please compile LIO with option: libint=1" << endl;
   exit(-1);
 }
 
-extern "C" void g2g_exact_exchange_gradient_(double* rho, double* frc)
-{
+extern "C" void g2g_exact_exchange_gradient_(double* rho, double* frc) {
   cout << "  Please compile LIO with option: libint=1" << endl;
   exit(-1);
 }
 
-extern "C" void g2g_calculate2e_(double* tao, double* fock, int& vecdim)
-{
+extern "C" void g2g_calculate2e_(double* tao, double* fock, int& vecdim) {
   cout << "  Please compile LIO with option: libint=1" << endl;
   exit(-1);
 }
 
-extern "C" void g2g_exacgrad_excited_(double* rhoG,double* DiffExc,
-                                     double* Xmat,double* fEE)
-{
-  cout << "  Please compile LIO with option: libint=1" << endl;
-  exit(-1);
-
-}
-
-extern "C" void g2g_calcgammcou_(double* rhoG, double* Zmat, double* gamm)
-{
+extern "C" void g2g_exacgrad_excited_(double* rhoG, double* DiffExc,
+                                      double* Xmat, double* fEE) {
   cout << "  Please compile LIO with option: libint=1" << endl;
   exit(-1);
 }
 
+extern "C" void g2g_calcgammcou_(double* rhoG, double* Zmat, double* gamm) {
+  cout << "  Please compile LIO with option: libint=1" << endl;
+  exit(-1);
+}
 
 extern "C" void g2g_exact_exchange_open_(double* rhoA, double* fockA,
-                                         double* rhoB, double* fockB)
-{
+                                         double* rhoB, double* fockB) {
   cout << "  Please compile LIO with option: libint=1" << endl;
   exit(-1);
 }
-
-

--- a/g2g/libint/libintproxy.h
+++ b/g2g/libint/libintproxy.h
@@ -6,24 +6,26 @@
 #include <unordered_map>
 #include <string>
 
-typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> Matrix_E;
+typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
+    Matrix_E;
 
 // namespace LIBINT
 using libint2::Atom;
 using libint2::BasisSet;
-using libint2::Shell;
+using libint2::BraKet;
 using libint2::Engine;
 using libint2::Operator;
-using libint2::BraKet;
+using libint2::Shell;
 using libint2::svector;
 
 // namespace STD
-using std::vector;
 using std::string;
+using std::vector;
 
 // Precalculated Integrals
 using shellpair_list_t = std::unordered_map<size_t, std::vector<size_t>>;
-using shellpair_data_t = std::vector<std::vector<std::shared_ptr<libint2::ShellPair>>>;
+using shellpair_data_t =
+    std::vector<std::vector<std::shared_ptr<libint2::ShellPair>>>;
 
 typedef unsigned int uint;
 
@@ -42,114 +44,111 @@ void parallel_do(Lambda& lambda) {
   }
 #endif
 }
-}
+}  // namespace libint2
 
-class LIBINTproxy
-{
-private:
-       // Variables
-       vector<Atom> atoms;         // atoms cordinates
+class LIBINTproxy {
+ private:
+  // Variables
+  vector<Atom> atoms;  // atoms cordinates
 
-       // Common Functions
-       int libint_geom(double*,int);
+  // Common Functions
+  int libint_geom(double*, int);
 
-       int make_basis(const
-            vector<Atom>&,double*,double*,uint*,
-            uint*,int,int,int,int);
+  int make_basis(const vector<Atom>&, double*, double*, uint*, uint*, int, int,
+                 int, int);
 
-       std::tuple<shellpair_list_t,shellpair_data_t>
-       compute_shellpairs(vector<Shell>&,
-                          double threshold = 1e-12);
+  std::tuple<shellpair_list_t, shellpair_data_t> compute_shellpairs(
+      vector<Shell>&, double threshold = 1e-12);
 
-       int map_shell();
+  int map_shell();
 
-       Matrix_E order_dfunc_rho(double*,int,int,int,int);
+  Matrix_E order_dfunc_rho(double*, int, int, int, int);
 
-       void order_dfunc_fock(double*,Matrix_E&,
-                             int,int,int,int);
+  void order_dfunc_fock(double*, Matrix_E&, int, int, int, int);
 
-       int error(string);
+  int error(string);
 
-       size_t max_nprim();
+  size_t max_nprim();
 
-       int max_l();
+  int max_l();
 
-       // Save Integrals
-       int save_ints(vector<Shell>& ,vector<int>&,int);
-       long int count_ints(vector<Shell>&);
-       template<Operator obtype>
-       int save_calculated(vector<Shell>&, vector<int>&, double*, long int&, string);
+  // Save Integrals
+  int save_ints(vector<Shell>&, vector<int>&, int);
+  long int count_ints(vector<Shell>&);
+  template <Operator obtype>
+  int save_calculated(vector<Shell>&, vector<int>&, double*, long int&, string);
 
-       // Write Integrals
-       int write_ints(vector<Shell>&,vector<int>&,int);
-       template<Operator obtype>
-       int write_calculated(vector<Shell>& ,vector<int>&, string );
+  // Write Integrals
+  int write_ints(vector<Shell>&, vector<int>&, int);
+  template <Operator obtype>
+  int write_calculated(vector<Shell>&, vector<int>&, string);
 
-       // Recalculated Integrals
-       Matrix_E exchange_method(vector<Shell>&,int,vector<int>&,Matrix_E&,int*);
-       template<Operator obtype>
-       Matrix_E exchange(vector<Shell>&,int,vector<int>&,Matrix_E&);
+  // Recalculated Integrals
+  Matrix_E exchange_method(vector<Shell>&, int, vector<int>&, Matrix_E&, int*);
+  template <Operator obtype>
+  Matrix_E exchange(vector<Shell>&, int, vector<int>&, Matrix_E&);
 
-       Matrix_E exchange_method_saving(vector<Shell>&,int,vector<int>&,Matrix_E&,int*);
-       Matrix_E exchange_saving(vector<Shell>&,int,vector<int>&,double*,Matrix_E&,string);
+  Matrix_E exchange_method_saving(vector<Shell>&, int, vector<int>&, Matrix_E&,
+                                  int*);
+  Matrix_E exchange_saving(vector<Shell>&, int, vector<int>&, double*,
+                           Matrix_E&, string);
 
-       Matrix_E exchange_method_reading(vector<Shell>&,int,vector<int>&,Matrix_E&,int*);
-       Matrix_E exchange_reading(vector<Shell>&,int,vector<int>&,Matrix_E&,string);
+  Matrix_E exchange_method_reading(vector<Shell>&, int, vector<int>&, Matrix_E&,
+                                   int*);
+  Matrix_E exchange_reading(vector<Shell>&, int, vector<int>&, Matrix_E&,
+                            string);
 
-       template<Operator obtype>
-       vector<Matrix_E> CoulombExchange(vector<Shell>&,int,vector<int>&,double,int,vector<Matrix_E>&);
+  template <Operator obtype>
+  vector<Matrix_E> CoulombExchange(vector<Shell>&, int, vector<int>&, double,
+                                   int, vector<Matrix_E>&);
 
-       template<Operator obtype>
-       vector<Matrix_E> CoulombExchange_saving(vector<Shell>&,int,vector<int>&,double,
-                                               int,double*,vector<Matrix_E>&);
+  template <Operator obtype>
+  vector<Matrix_E> CoulombExchange_saving(vector<Shell>&, int, vector<int>&,
+                                          double, int, double*,
+                                          vector<Matrix_E>&);
 
-       template<Operator obtype>
-       vector<Matrix_E> CoulombExchange_reading(vector<Shell>&,int,vector<int>&,double,
-                                               int,vector<Matrix_E>&);
+  template <Operator obtype>
+  vector<Matrix_E> CoulombExchange_reading(vector<Shell>&, int, vector<int>&,
+                                           double, int, vector<Matrix_E>&);
 
-       template<Operator obtype>
-       vector<Matrix_E> compute_deriv(vector<Shell>&,vector<int>&,vector<int>&,
-                              int,int,Matrix_E&);
+  template <Operator obtype>
+  vector<Matrix_E> compute_deriv(vector<Shell>&, vector<int>&, vector<int>&,
+                                 int, int, Matrix_E&);
 
-       template<Operator obtype>
-       vector<Matrix_E> compute_gamma(vector<Shell>&,vector<int>&,vector<int>&,
-                              int,int,Matrix_E&,double);
+  template <Operator obtype>
+  vector<Matrix_E> compute_gamma(vector<Shell>&, vector<int>&, vector<int>&,
+                                 int, int, Matrix_E&, double);
 
-       void get_forcesHF(double*, vector<Matrix_E>&,
-                  vector<Matrix_E>&, Matrix_E&, Matrix_E&,
-                  Matrix_E&, int&, double&);
+  void get_forcesHF(double*, vector<Matrix_E>&, vector<Matrix_E>&, Matrix_E&,
+                    Matrix_E&, Matrix_E&, int&, double&);
 
-       // Open shell
-       vector<Matrix_E> exchange(vector<Shell>&,int,vector<int>&,Matrix_E&,Matrix_E&);
+  // Open shell
+  vector<Matrix_E> exchange(vector<Shell>&, int, vector<int>&, Matrix_E&,
+                            Matrix_E&);
 
-public:
-       // General routines
-       int init(int,uint,uint*,double*,double*,
-                   double*,uint*,int,int,int,int,int); // Constructor
+ public:
+  // General routines
+  int init(int, uint, uint*, double*, double*, double*, uint*, int, int, int,
+           int, int);  // Constructor
 
-       ~LIBINTproxy(); // Destructor
+  ~LIBINTproxy();  // Destructor
 
-       void PrintBasis(); // Print basis in libint format
+  void PrintBasis();  // Print basis in libint format
 
-       // Closed shell
-       int do_exchange(double*, double*, int*); // Energy calc.
+  // Closed shell
+  int do_exchange(double*, double*, int*);  // Energy calc.
 
-       int do_ExchangeForces(double*, double*, int*); // Gradients calc.
+  int do_ExchangeForces(double*, double*, int*);  // Gradients calc.
 
-       int do_CoulombExchange(double*, double*, int); // Energy calc.
+  int do_CoulombExchange(double*, double*, int);  // Energy calc.
 
-       // Open shell
-       int do_exchange(double*, double*, double*, double*); // Energy calc.
+  // Open shell
+  int do_exchange(double*, double*, double*, double*);  // Energy calc.
 
-       // Excited States Gradients with Exact Exchange
-       int do_ExacGradient(double*,double*,double*,double*);
+  // Excited States Gradients with Exact Exchange
+  int do_ExacGradient(double*, double*, double*, double*);
 
-       int do_GammaCou(double*, double*, double*);
-
+  int do_GammaCou(double*, double*, double*);
 };
 
 #endif
-
-
-
-

--- a/g2g/libxc/libxc_accumulate_point.h
+++ b/g2g/libxc/libxc_accumulate_point.h
@@ -4,9 +4,12 @@
 #include "libxcproxy_cuda.h"
 #include "../timer.h"
 
-extern "C" void g2g_timer_sum_start_(const char* timer_name, unsigned int length_arg);
-extern "C" void g2g_timer_sum_stop_(const char* timer_name, unsigned int length_arg);
-extern "C" void g2g_timer_sum_pause_(const char* timer_name, unsigned int length_arg);
+extern "C" void g2g_timer_sum_start_(const char* timer_name,
+                                     unsigned int length_arg);
+extern "C" void g2g_timer_sum_stop_(const char* timer_name,
+                                    unsigned int length_arg);
+extern "C" void g2g_timer_sum_pause_(const char* timer_name,
+                                     unsigned int length_arg);
 
 //////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////
@@ -23,31 +26,26 @@ extern "C" void g2g_timer_sum_pause_(const char* timer_name, unsigned int length
 // dxyz_accum:
 // dd1_accum:
 // dd2_accum:
-// 
-template<class T, bool compute_energy, bool compute_factor, bool lda>
-__global__ void gpu_accumulate_point_for_libxc(T* const point_weights,
-                uint points, int block_height, 
-		T* partial_density_in,
-		G2G::vec_type<T,WIDTH>* dxyz_in,
-                G2G::vec_type<T,WIDTH>* dd1_in,
-		G2G::vec_type<T,WIDTH>* dd2_in,
-		T* accumulated_density,
-		G2G::vec_type<T,WIDTH>* dxyz_accum,
-                G2G::vec_type<T,WIDTH>* dd1_accum,
-		G2G::vec_type<T,WIDTH>* dd2_accum) {
-
+//
+template <class T, bool compute_energy, bool compute_factor, bool lda>
+__global__ void gpu_accumulate_point_for_libxc(
+    T* const point_weights, uint points, int block_height,
+    T* partial_density_in, G2G::vec_type<T, WIDTH>* dxyz_in,
+    G2G::vec_type<T, WIDTH>* dd1_in, G2G::vec_type<T, WIDTH>* dd2_in,
+    T* accumulated_density, G2G::vec_type<T, WIDTH>* dxyz_accum,
+    G2G::vec_type<T, WIDTH>* dd1_accum, G2G::vec_type<T, WIDTH>* dd2_accum) {
   uint point = blockIdx.x * DENSITY_ACCUM_BLOCK_SIZE + threadIdx.x;
-  //uint point = blockIdx.x * blockDim.x + threadIdx.x;
+  // uint point = blockIdx.x * blockDim.x + threadIdx.x;
 
   T _partial_density(0.0f);
-  G2G::vec_type<T,WIDTH> _dxyz, _dd1, _dd2;
-  _dxyz = _dd1 = _dd2 = G2G::vec_type<T,WIDTH>(0.0f,0.0f,0.0f,0.0f);
+  G2G::vec_type<T, WIDTH> _dxyz, _dd1, _dd2;
+  _dxyz = _dd1 = _dd2 = G2G::vec_type<T, WIDTH>(0.0f, 0.0f, 0.0f, 0.0f);
 
   bool valid_thread = (point < points);
 
   if (valid_thread) {
-    for(int j =0 ; j<block_height; j++) {
-      const int this_row = j*points+point;
+    for (int j = 0; j < block_height; j++) {
+      const int this_row = j * points + point;
       _partial_density += partial_density_in[this_row];
       _dxyz += dxyz_in[this_row];
       _dd1 += dd1_in[this_row];
@@ -57,38 +55,33 @@ __global__ void gpu_accumulate_point_for_libxc(T* const point_weights,
     // Accumulate the data for libxc.
     accumulated_density[point] = _partial_density;
     /*printf("point:%i %lf %lf %lf %lf %lf %lf %lf %lf %lf \n", point,
-	_dxyz.x, _dxyz.y, _dxyz.z,
-	_dd1.x, _dd1.y, _dd1.z,
-	_dd2.x, _dd2.y, _dd2.z);*/
-    
+        _dxyz.x, _dxyz.y, _dxyz.z,
+        _dd1.x, _dd1.y, _dd1.z,
+        _dd2.x, _dd2.y, _dd2.z);*/
+
     dxyz_accum[point] = _dxyz;
     dd1_accum[point] = _dd1;
     dd2_accum[point] = _dd2;
-    
   }
-
 }
 
 //////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////
 // gpu_accumulate_energy_and_forces_from_libxc
-// 
+//
 // energy: array of energy points,
-// factor: 
+// factor:
 // point_weights:
 // points: the size of the arrays.
 // accumulated_density:
 //
 //
-template<class T, bool compute_energy, bool compute_factor, bool lda>
-__global__ void gpu_accumulate_energy_and_forces_from_libxc (T* const energy, 
-		    T* const factor, 
-		    T* const point_weights, 
-		    uint points, 
-		    T* accumulated_density)
-{
+template <class T, bool compute_energy, bool compute_factor, bool lda>
+__global__ void gpu_accumulate_energy_and_forces_from_libxc(
+    T* const energy, T* const factor, T* const point_weights, uint points,
+    T* accumulated_density) {
   uint point = blockIdx.x * DENSITY_ACCUM_BLOCK_SIZE + threadIdx.x;
-  //uint point = blockIdx.x * blockDim.x + threadIdx.x;
+  // uint point = blockIdx.x * blockDim.x + threadIdx.x;
 
   T point_weight = 0.0f;
 
@@ -98,19 +91,18 @@ __global__ void gpu_accumulate_energy_and_forces_from_libxc (T* const energy,
   }
 
   if (compute_energy && valid_thread && energy != NULL) {
-        energy[point] *= (accumulated_density[point] * point_weight);
+    energy[point] *= (accumulated_density[point] * point_weight);
   }
 
   if (compute_factor && valid_thread && factor != NULL) {
     factor[point] *= point_weight;
   }
-
 }
 
 //////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////
 // libxc_exchange_correlation_cpu
-// Use the libxc cpu version to compute the exchange-correlation values 
+// Use the libxc cpu version to compute the exchange-correlation values
 //
 // energy_gpu: array of energy points,
 // factor_gpu: array of factors points.
@@ -123,321 +115,320 @@ __global__ void gpu_accumulate_energy_and_forces_from_libxc (T* const energy,
 // Note: all the pointer data are pointers in CUDA memory.
 //
 
-template<class T, bool compute_energy, bool compute_factor, bool lda>
-    void libxc_exchange_correlation_cpu (LibxcProxy_cuda<T, WIDTH>* libxcProxy,
-	T* energy_gpu,
-	T* factor_gpu,
-	uint points,
-	T* accumulated_density_gpu,
-	G2G::vec_type<T,WIDTH>* dxyz_gpu_accum,
-        G2G::vec_type<T,WIDTH>* dd1_gpu_accum,
-	G2G::vec_type<T,WIDTH>* dd2_gpu_accum)
-{
-    //printf("libxc_exchage_correlation_cpu (...) \n");
+template <class T, bool compute_energy, bool compute_factor, bool lda>
+void libxc_exchange_correlation_cpu(LibxcProxy_cuda<T, WIDTH>* libxcProxy,
+                                    T* energy_gpu, T* factor_gpu, uint points,
+                                    T* accumulated_density_gpu,
+                                    G2G::vec_type<T, WIDTH>* dxyz_gpu_accum,
+                                    G2G::vec_type<T, WIDTH>* dd1_gpu_accum,
+                                    G2G::vec_type<T, WIDTH>* dd2_gpu_accum) {
+  // printf("libxc_exchage_correlation_cpu (...) \n");
 
-    cudaError_t err = cudaSuccess;
+  cudaError_t err = cudaSuccess;
 
-    // Copy to host the matrix data in gpu memory and
-    // call the new libxcProxy.
-    G2G::vec_type<T,WIDTH>* dxyz_cpu;
-    G2G::vec_type<T,WIDTH>* dd1_cpu;
-    G2G::vec_type<T,WIDTH>* dd2_cpu;
+  // Copy to host the matrix data in gpu memory and
+  // call the new libxcProxy.
+  G2G::vec_type<T, WIDTH>* dxyz_cpu;
+  G2G::vec_type<T, WIDTH>* dd1_cpu;
+  G2G::vec_type<T, WIDTH>* dd2_cpu;
 
-    // Alloc memory in the host for the gpu data
-    uint size = points * sizeof(G2G::vec_type<T,WIDTH>);
-    dxyz_cpu = (G2G::vec_type<T,WIDTH> *)malloc(size);
-    dd1_cpu = (G2G::vec_type<T,WIDTH> *)malloc(size);
-    dd2_cpu = (G2G::vec_type<T,WIDTH> *)malloc(size);
+  // Alloc memory in the host for the gpu data
+  uint size = points * sizeof(G2G::vec_type<T, WIDTH>);
+  dxyz_cpu = (G2G::vec_type<T, WIDTH>*)malloc(size);
+  dd1_cpu = (G2G::vec_type<T, WIDTH>*)malloc(size);
+  dd2_cpu = (G2G::vec_type<T, WIDTH>*)malloc(size);
 
-    // Copy data from device to host.
-    err = cudaMemcpy(dxyz_cpu, dxyz_gpu_accum, size, cudaMemcpyDeviceToHost);
-    if (err != cudaSuccess)
-    {
-        //printf("Failed to copy vector dxyz_gpu from device to host!\n");
-        exit(EXIT_FAILURE);
-    }
+  // Copy data from device to host.
+  err = cudaMemcpy(dxyz_cpu, dxyz_gpu_accum, size, cudaMemcpyDeviceToHost);
+  if (err != cudaSuccess) {
+    // printf("Failed to copy vector dxyz_gpu from device to host!\n");
+    exit(EXIT_FAILURE);
+  }
 
-    err = cudaMemcpy(dd1_cpu, dd1_gpu_accum, size, cudaMemcpyDeviceToHost);
-    if (err != cudaSuccess)
-    {
-        //printf("Failed to copy vector dd1_gpu from device to host!\n");
-        exit(EXIT_FAILURE);
-    }
+  err = cudaMemcpy(dd1_cpu, dd1_gpu_accum, size, cudaMemcpyDeviceToHost);
+  if (err != cudaSuccess) {
+    // printf("Failed to copy vector dd1_gpu from device to host!\n");
+    exit(EXIT_FAILURE);
+  }
 
-    err = cudaMemcpy(dd2_cpu, dd2_gpu_accum, size, cudaMemcpyDeviceToHost);
-    if (err != cudaSuccess)
-    {
-        //printf("Failed to copy vector dd2_gpu from device to host!\n");
-        exit(EXIT_FAILURE);
-    }
+  err = cudaMemcpy(dd2_cpu, dd2_gpu_accum, size, cudaMemcpyDeviceToHost);
+  if (err != cudaSuccess) {
+    // printf("Failed to copy vector dd2_gpu from device to host!\n");
+    exit(EXIT_FAILURE);
+  }
 
-    // Allocate the host input vectors
-    uint array_size = sizeof(T)*points;
-    T *energy_cpu = NULL;
-    if (compute_energy) 
-    { 
-	energy_cpu = (T *)malloc(array_size);
-    }
-    
-    T *factor_cpu = NULL;
-    if (compute_factor) 
-    {
-	factor_cpu = (T *)malloc(array_size);
-    }
+  // Allocate the host input vectors
+  uint array_size = sizeof(T) * points;
+  T* energy_cpu = NULL;
+  if (compute_energy) {
+    energy_cpu = (T*)malloc(array_size);
+  }
 
-    T *accumulated_density_cpu = (T*)malloc(array_size);
+  T* factor_cpu = NULL;
+  if (compute_factor) {
+    factor_cpu = (T*)malloc(array_size);
+  }
 
-    // Copy the vectors from gpu to cpu
-    // Be aware that energy_gpu can be NULL.
-    if (compute_energy) 
-    {
-	err = cudaMemcpy(energy_cpu, energy_gpu, array_size, cudaMemcpyDeviceToHost);
-        if (err != cudaSuccess)
-	{
-    	    //printf("Failed to copy vector energy_gpu from device to host!\n");
-    	    exit(EXIT_FAILURE);
-	}
-    }
+  T* accumulated_density_cpu = (T*)malloc(array_size);
 
-    if (compute_factor) 
-    {
-	err = cudaMemcpy(factor_cpu, factor_gpu, array_size, cudaMemcpyDeviceToHost);
-	if (err != cudaSuccess)
-	{
-    	    //printf("Failed to copy vector factor_gpu from device to host!\n");
-    	    exit(EXIT_FAILURE);
-	}
-    }
-
-    err = cudaMemcpy(accumulated_density_cpu, accumulated_density_gpu, array_size, cudaMemcpyDeviceToHost);
+  // Copy the vectors from gpu to cpu
+  // Be aware that energy_gpu can be NULL.
+  if (compute_energy) {
+    err =
+        cudaMemcpy(energy_cpu, energy_gpu, array_size, cudaMemcpyDeviceToHost);
     if (err != cudaSuccess) {
-	//printf("Failed to copy vector accumulated_density_gpu to host!\n");
+      // printf("Failed to copy vector energy_gpu from device to host!\n");
+      exit(EXIT_FAILURE);
     }
+  }
 
-    /////////////////////
-    // Libxc proxy
-    /////////////////////
-    // Parameters
-    T* exc;
-    T* corr;
-    T* y2a;
-
-    // Now alloc memory for the data
-    exc  = (T*)malloc(array_size);
-    corr = (T*)malloc(array_size);
-    y2a  = (T*)malloc(array_size);
-
-    if (libxcProxy != NULL) {
-        libxcProxy->doGGA (accumulated_density_cpu, points, dxyz_cpu, dd1_cpu, dd2_cpu, exc, corr, y2a);
-	// Join the results.
-	for (unsigned int i=0; i<points; i++) {
-	    if (compute_energy) 
-	    {
-		energy_cpu[i] = exc[i] + corr[i];
-	    }
-	    if (compute_factor)
-	    {
-		factor_cpu[i] = y2a[i];
-	    }
-	}
+  if (compute_factor) {
+    err =
+        cudaMemcpy(factor_cpu, factor_gpu, array_size, cudaMemcpyDeviceToHost);
+    if (err != cudaSuccess) {
+      // printf("Failed to copy vector factor_gpu from device to host!\n");
+      exit(EXIT_FAILURE);
     }
+  }
 
-    // Now copy back the results to the gpu.
-    if (compute_energy) {
-	err = cudaMemcpy(energy_gpu, energy_cpu, array_size, cudaMemcpyHostToDevice);
-	if (err != cudaSuccess)
-	{
-    	    //printf("Failed to copy vector energy_gpu from host to device!\n");
-    	    exit(EXIT_FAILURE);
-	}
+  err = cudaMemcpy(accumulated_density_cpu, accumulated_density_gpu, array_size,
+                   cudaMemcpyDeviceToHost);
+  if (err != cudaSuccess) {
+    // printf("Failed to copy vector accumulated_density_gpu to host!\n");
+  }
+
+  /////////////////////
+  // Libxc proxy
+  /////////////////////
+  // Parameters
+  T* exc;
+  T* corr;
+  T* y2a;
+
+  // Now alloc memory for the data
+  exc = (T*)malloc(array_size);
+  corr = (T*)malloc(array_size);
+  y2a = (T*)malloc(array_size);
+
+  if (libxcProxy != NULL) {
+    libxcProxy->doGGA(accumulated_density_cpu, points, dxyz_cpu, dd1_cpu,
+                      dd2_cpu, exc, corr, y2a);
+    // Join the results.
+    for (unsigned int i = 0; i < points; i++) {
+      if (compute_energy) {
+        energy_cpu[i] = exc[i] + corr[i];
+      }
+      if (compute_factor) {
+        factor_cpu[i] = y2a[i];
+      }
     }
+  }
 
-    if (compute_factor) {
-	err = cudaMemcpy(factor_gpu, factor_cpu, array_size, cudaMemcpyHostToDevice);
-	if (err != cudaSuccess)
-	{
-    	    //printf("Failed to copy vector factor_cpu from host to device!\n");
-    	    exit(EXIT_FAILURE);
-	}
+  // Now copy back the results to the gpu.
+  if (compute_energy) {
+    err =
+        cudaMemcpy(energy_gpu, energy_cpu, array_size, cudaMemcpyHostToDevice);
+    if (err != cudaSuccess) {
+      // printf("Failed to copy vector energy_gpu from host to device!\n");
+      exit(EXIT_FAILURE);
     }
+  }
 
-    // Free memory.
-    if (compute_energy) {
-        free(energy_cpu);
+  if (compute_factor) {
+    err =
+        cudaMemcpy(factor_gpu, factor_cpu, array_size, cudaMemcpyHostToDevice);
+    if (err != cudaSuccess) {
+      // printf("Failed to copy vector factor_cpu from host to device!\n");
+      exit(EXIT_FAILURE);
     }
-    if (compute_factor) {
-	free(factor_cpu);
-    }
+  }
 
-    free(accumulated_density_cpu);
-    free(exc);
-    free(corr);
-    free(y2a);
+  // Free memory.
+  if (compute_energy) {
+    free(energy_cpu);
+  }
+  if (compute_factor) {
+    free(factor_cpu);
+  }
 
-    free(dd1_cpu);
-    free(dd2_cpu);
-    free(dxyz_cpu);
+  free(accumulated_density_cpu);
+  free(exc);
+  free(corr);
+  free(y2a);
+
+  free(dd1_cpu);
+  free(dd2_cpu);
+  free(dxyz_cpu);
 }
 
-template<class T>
-__global__ void all_ContractGradients(G2G::vec_type<T,WIDTH>* dxyz, G2G::vec_type<T,WIDTH>* tredxyz,
-                                      T* sigma, T* cruz, uint points)
-{
-    uint i = blockDim.x * blockIdx.x + threadIdx.x;
+template <class T>
+__global__ void all_ContractGradients(G2G::vec_type<T, WIDTH>* dxyz,
+                                      G2G::vec_type<T, WIDTH>* tredxyz,
+                                      T* sigma, T* cruz, uint points) {
+  uint i = blockDim.x * blockIdx.x + threadIdx.x;
 
-    if (i < points) {
-
-       sigma[i] = ( dxyz[i].x*dxyz[i].x ) + ( dxyz[i].y*dxyz[i].y ) + ( dxyz[i].z*dxyz[i].z ); 
-       cruz[i]  = 0.5f * ( (tredxyz[i].x*dxyz[i].x)+(tredxyz[i].y*dxyz[i].y)+(tredxyz[i].z*dxyz[i].z) );
-
-    }
-
+  if (i < points) {
+    sigma[i] = (dxyz[i].x * dxyz[i].x) + (dxyz[i].y * dxyz[i].y) +
+               (dxyz[i].z * dxyz[i].z);
+    cruz[i] = 0.5f * ((tredxyz[i].x * dxyz[i].x) + (tredxyz[i].y * dxyz[i].y) +
+                      (tredxyz[i].z * dxyz[i].z));
+  }
 }
 
-template<class T>
-__global__ void group_coefficients(G2G::vec_type<T,WIDTH>* dxyz_in, G2G::vec_type<T,WIDTH>* txyz_in,
-                                   G2G::vec_type<T,WIDTH>* Dout, G2G::vec_type<T,WIDTH>* Tout,
-                                   T* C_out,T* C_local, uint points)
-{
+template <class T>
+__global__ void group_coefficients(G2G::vec_type<T, WIDTH>* dxyz_in,
+                                   G2G::vec_type<T, WIDTH>* txyz_in,
+                                   G2G::vec_type<T, WIDTH>* Dout,
+                                   G2G::vec_type<T, WIDTH>* Tout, T* C_out,
+                                   T* C_local, uint points) {
+  uint idx = blockDim.x * blockIdx.x + threadIdx.x;
 
-    uint idx = blockDim.x * blockIdx.x + threadIdx.x;
+  if (idx < points) {
+    C_out[idx] = C_local[idx] * 0.5f;
 
-    if ( idx < points ) {
+    Dout[idx] = G2G::vec_type<T, WIDTH>(
+        C_local[points + idx] * dxyz_in[idx].x * 0.5f,
+        C_local[points + idx] * dxyz_in[idx].y * 0.5f,
+        C_local[points + idx] * dxyz_in[idx].z * 0.5f, 0.0f);
 
-      C_out[idx] = C_local[idx] * 0.5f;
+    Tout[idx] = G2G::vec_type<T, WIDTH>(
+        C_local[2 * points + idx] * txyz_in[idx].x,
+        C_local[2 * points + idx] * txyz_in[idx].y,
+        C_local[2 * points + idx] * txyz_in[idx].z, 0.0f);
 
-      Dout[idx] = G2G::vec_type<T,WIDTH>(C_local[points+idx]*dxyz_in[idx].x*0.5f,
-                                         C_local[points+idx]*dxyz_in[idx].y*0.5f,
-                                         C_local[points+idx]*dxyz_in[idx].z*0.5f,0.0f);
-
-      Tout[idx] = G2G::vec_type<T,WIDTH>(C_local[2*points+idx]*txyz_in[idx].x,
-                                         C_local[2*points+idx]*txyz_in[idx].y,
-                                         C_local[2*points+idx]*txyz_in[idx].z,0.0f);
-
-
-   } // end if valid thread
-
+  }  // end if valid thread
 }
-
 
 // Call from gpu to libxc on gpu in LR
-template<class T, bool compute_energy, bool compute_factor, bool lda>
-void libxc_gpu_coefLR(LibxcProxy_cuda<T, WIDTH>* libxcProxy,
-                      uint points, T* dens_gpu, T* tred_gpu,
-                      G2G::vec_type<T,WIDTH>* dxyz_gpu, G2G::vec_type<T,WIDTH>* tredxyz_gpu,
+template <class T, bool compute_energy, bool compute_factor, bool lda>
+void libxc_gpu_coefLR(LibxcProxy_cuda<T, WIDTH>* libxcProxy, uint points,
+                      T* dens_gpu, T* tred_gpu,
+                      G2G::vec_type<T, WIDTH>* dxyz_gpu,
+                      G2G::vec_type<T, WIDTH>* tredxyz_gpu,
                       // outputs
-                      G2G::vec_type<T,WIDTH>* Dxyz, G2G::vec_type<T,WIDTH>* Txyz,
-                      T* coef_gpu)
-{
-   cudaError_t err = cudaSuccess;
+                      G2G::vec_type<T, WIDTH>* Dxyz,
+                      G2G::vec_type<T, WIDTH>* Txyz, T* coef_gpu) {
+  cudaError_t err = cudaSuccess;
 
-// CALCULATE GRADIENTS
-   T* sigma = NULL;
-   T* cruz  = NULL;
-   T* coef_local  = NULL;
-   int size = sizeof(T) * points;
+  // CALCULATE GRADIENTS
+  T* sigma = NULL;
+  T* cruz = NULL;
+  T* coef_local = NULL;
+  int size = sizeof(T) * points;
 
-   err = cudaMalloc((void**)&sigma, size);
-   if ( err != cudaSuccess ) cout << "Falied to allocate sigma on GPU" << endl;
+  err = cudaMalloc((void**)&sigma, size);
+  if (err != cudaSuccess) cout << "Falied to allocate sigma on GPU" << endl;
 
-   err = cudaMalloc((void**)&cruz, size);
-   if ( err != cudaSuccess ) cout << "Falied to allocate cruz on GPU" << endl;
+  err = cudaMalloc((void**)&cruz, size);
+  if (err != cudaSuccess) cout << "Falied to allocate cruz on GPU" << endl;
 
-   err = cudaMalloc((void**)&coef_local, 3*size);
-   if ( err != cudaSuccess ) cout << "Falied to allocate coef_local on GPU" << endl;
+  err = cudaMalloc((void**)&coef_local, 3 * size);
+  if (err != cudaSuccess)
+    cout << "Falied to allocate coef_local on GPU" << endl;
 
-   int threadsPerBlock = 256;
-   int blocksPerGrid = (points + threadsPerBlock - 1) / threadsPerBlock;
-   all_ContractGradients<<<blocksPerGrid,threadsPerBlock>>>(dxyz_gpu,tredxyz_gpu,
-                           sigma,cruz,points);
+  int threadsPerBlock = 256;
+  int blocksPerGrid = (points + threadsPerBlock - 1) / threadsPerBlock;
+  all_ContractGradients<<<blocksPerGrid, threadsPerBlock>>>(
+      dxyz_gpu, tredxyz_gpu, sigma, cruz, points);
 
-// LIBXC CALCULATE ALL POINTS
-   libxcProxy->coefLR(points,dens_gpu,sigma,tred_gpu,cruz,coef_local);
-   group_coefficients<<<blocksPerGrid,threadsPerBlock>>>(dxyz_gpu,tredxyz_gpu,
-                      Dxyz, Txyz, coef_gpu, coef_local, points);
+  // LIBXC CALCULATE ALL POINTS
+  libxcProxy->coefLR(points, dens_gpu, sigma, tred_gpu, cruz, coef_local);
+  group_coefficients<<<blocksPerGrid, threadsPerBlock>>>(
+      dxyz_gpu, tredxyz_gpu, Dxyz, Txyz, coef_gpu, coef_local, points);
 
-// Free memory
-   cudaFree(sigma);      sigma = NULL;
-   cudaFree(cruz);       cruz = NULL;
-   cudaFree(coef_local); coef_local = NULL;
+  // Free memory
+  cudaFree(sigma);
+  sigma = NULL;
+  cudaFree(cruz);
+  cruz = NULL;
+  cudaFree(coef_local);
+  coef_local = NULL;
 }
 
 // Call from gpu to libxc on gpu in Zvector
-template<class T, bool compute_energy, bool compute_factor, bool lda>
-void libxc_gpu_coefZv(LibxcProxy_cuda<T, WIDTH>* libxcProxy,
-                      uint points, T* dens_gpu, T* tred_gpu,
-                      G2G::vec_type<T,WIDTH>* dxyz_gpu, G2G::vec_type<T,WIDTH>* tredxyz_gpu,
+template <class T, bool compute_energy, bool compute_factor, bool lda>
+void libxc_gpu_coefZv(LibxcProxy_cuda<T, WIDTH>* libxcProxy, uint points,
+                      T* dens_gpu, T* tred_gpu,
+                      G2G::vec_type<T, WIDTH>* dxyz_gpu,
+                      G2G::vec_type<T, WIDTH>* tredxyz_gpu,
                       // outputs
-                      G2G::vec_type<T,WIDTH>* Dxyz, G2G::vec_type<T,WIDTH>* Txyz,
-                      T* coef_gpu)
-{
-   cudaError_t err = cudaSuccess;
+                      G2G::vec_type<T, WIDTH>* Dxyz,
+                      G2G::vec_type<T, WIDTH>* Txyz, T* coef_gpu) {
+  cudaError_t err = cudaSuccess;
 
-// CALCULATE CONTRACTED GRADIENTS
-   T* sigma = NULL;
-   T* cruz  = NULL;
-   T* coef_local  = NULL;
-   int size = sizeof(T) * points;
+  // CALCULATE CONTRACTED GRADIENTS
+  T* sigma = NULL;
+  T* cruz = NULL;
+  T* coef_local = NULL;
+  int size = sizeof(T) * points;
 
-   err = cudaMalloc((void**)&sigma, size);
-   if ( err != cudaSuccess ) cout << "Falied to allocate sigma on GPU" << endl;
+  err = cudaMalloc((void**)&sigma, size);
+  if (err != cudaSuccess) cout << "Falied to allocate sigma on GPU" << endl;
 
-   err = cudaMalloc((void**)&cruz, size);
-   if ( err != cudaSuccess ) cout << "Falied to allocate cruz on GPU" << endl;
+  err = cudaMalloc((void**)&cruz, size);
+  if (err != cudaSuccess) cout << "Falied to allocate cruz on GPU" << endl;
 
-   err = cudaMalloc((void**)&coef_local, 3*size);
-   if ( err != cudaSuccess ) cout << "Falied to allocate coef_local on GPU" << endl;
+  err = cudaMalloc((void**)&coef_local, 3 * size);
+  if (err != cudaSuccess)
+    cout << "Falied to allocate coef_local on GPU" << endl;
 
-   int threadsPerBlock = 256;
-   int blocksPerGrid = (points + threadsPerBlock - 1) / threadsPerBlock;
-   all_ContractGradients<<<blocksPerGrid,threadsPerBlock>>>(dxyz_gpu,tredxyz_gpu,
-                           sigma,cruz,points);
+  int threadsPerBlock = 256;
+  int blocksPerGrid = (points + threadsPerBlock - 1) / threadsPerBlock;
+  all_ContractGradients<<<blocksPerGrid, threadsPerBlock>>>(
+      dxyz_gpu, tredxyz_gpu, sigma, cruz, points);
 
-   cudaFree(cruz); cruz = NULL; // In this case, cruz is not referenced
-   libxcProxy->coefZv(points,dens_gpu,sigma,tred_gpu,dxyz_gpu,tredxyz_gpu,coef_local);
-   group_coefficients<<<blocksPerGrid,threadsPerBlock>>>(dxyz_gpu,tredxyz_gpu,
-                      Dxyz, Txyz, coef_gpu, coef_local, points);
+  cudaFree(cruz);
+  cruz = NULL;  // In this case, cruz is not referenced
+  libxcProxy->coefZv(points, dens_gpu, sigma, tred_gpu, dxyz_gpu, tredxyz_gpu,
+                     coef_local);
+  group_coefficients<<<blocksPerGrid, threadsPerBlock>>>(
+      dxyz_gpu, tredxyz_gpu, Dxyz, Txyz, coef_gpu, coef_local, points);
 
-   cudaFree(sigma); sigma = NULL;
-   cudaFree(coef_local); coef_local = NULL;
+  cudaFree(sigma);
+  sigma = NULL;
+  cudaFree(coef_local);
+  coef_local = NULL;
 }
 
-template<class T, bool compute_energy, bool compute_factor, bool lda>
-void libxc_gpu_derivs(LibxcProxy_cuda<T,WIDTH>* libxcProxy, uint points,
-               T* dens, G2G::vec_type<T,WIDTH>* dxyz,
-               // OUTPUTS //
-               G2G::vec_type<T,2>* vrho,
-               G2G::vec_type<T,2>* vsigma,
-               G2G::vec_type<T,2>* v2rho2,
-               G2G::vec_type<T,2>* v2rhosigma,
-               G2G::vec_type<T,2>* v2sigma2,
-               G2G::vec_type<T,2>* v3rho3,
-               G2G::vec_type<T,2>* v3rho2sigma,
-               G2G::vec_type<T,2>* v3rhosigma2,
-               G2G::vec_type<T,2>* v3sigma3)
-{
-   cudaError_t err = cudaSuccess;
-// CALCULATE CONTRACTED GRADIENTS
-   T* sigma = NULL;
-   T* cruz  = NULL; // is not referenced 
-   int size = sizeof(T) * points;
+template <class T, bool compute_energy, bool compute_factor, bool lda>
+void libxc_gpu_derivs(LibxcProxy_cuda<T, WIDTH>* libxcProxy, uint points,
+                      T* dens, G2G::vec_type<T, WIDTH>* dxyz,
+                      // OUTPUTS //
+                      G2G::vec_type<T, 2>* vrho, G2G::vec_type<T, 2>* vsigma,
+                      G2G::vec_type<T, 2>* v2rho2,
+                      G2G::vec_type<T, 2>* v2rhosigma,
+                      G2G::vec_type<T, 2>* v2sigma2,
+                      G2G::vec_type<T, 2>* v3rho3,
+                      G2G::vec_type<T, 2>* v3rho2sigma,
+                      G2G::vec_type<T, 2>* v3rhosigma2,
+                      G2G::vec_type<T, 2>* v3sigma3) {
+  cudaError_t err = cudaSuccess;
+  // CALCULATE CONTRACTED GRADIENTS
+  T* sigma = NULL;
+  T* cruz = NULL;  // is not referenced
+  int size = sizeof(T) * points;
 
-   err = cudaMalloc((void**)&sigma, size);
-   if ( err != cudaSuccess ) cout << "Falied to allocate sigma on GPU/ gpu_derivs" << endl;
+  err = cudaMalloc((void**)&sigma, size);
+  if (err != cudaSuccess)
+    cout << "Falied to allocate sigma on GPU/ gpu_derivs" << endl;
 
-   err = cudaMalloc((void**)&cruz, size);
-   if ( err != cudaSuccess ) cout << "Falied to allocate cruz on GPU/ gpu_derivs" << endl;
+  err = cudaMalloc((void**)&cruz, size);
+  if (err != cudaSuccess)
+    cout << "Falied to allocate cruz on GPU/ gpu_derivs" << endl;
 
-   int threadsPerBlock = 256;
-   int blocksPerGrid = (points + threadsPerBlock - 1) / threadsPerBlock;
-   all_ContractGradients<<<blocksPerGrid,threadsPerBlock>>>(dxyz,dxyz,
-                           sigma,cruz,points);
+  int threadsPerBlock = 256;
+  int blocksPerGrid = (points + threadsPerBlock - 1) / threadsPerBlock;
+  all_ContractGradients<<<blocksPerGrid, threadsPerBlock>>>(dxyz, dxyz, sigma,
+                                                            cruz, points);
 
-   cudaFree(cruz); cruz = NULL;
-   libxcProxy->obtain_gpu_der(points,dens,sigma,vrho,vsigma,v2rho2,v2rhosigma,
-               v2sigma2, v3rho3, v3rho2sigma, v3rhosigma2, v3sigma3);
+  cudaFree(cruz);
+  cruz = NULL;
+  libxcProxy->obtain_gpu_der(points, dens, sigma, vrho, vsigma, v2rho2,
+                             v2rhosigma, v2sigma2, v3rho3, v3rho2sigma,
+                             v3rhosigma2, v3sigma3);
 
-   cudaFree(sigma); sigma = NULL;
+  cudaFree(sigma);
+  sigma = NULL;
 }
 
 //////////////////////////////////////////////////////////////
@@ -445,22 +436,23 @@ void libxc_gpu_derivs(LibxcProxy_cuda<T,WIDTH>* libxcProxy, uint points,
 // calculateContractedGradient
 // Calculate a contracted gradient for a given gradient.
 // grad: array of vec_type.
-// contracted_grad: the contracted gradient as a result of 
+// contracted_grad: the contracted gradient as a result of
 //                  contract the variable grad.
 // numElements: the size of the arrays.
 //
 // Note: all the pointer data are pointers in CUDA memory.
 //
 
-template<class T>
-__global__ void calculateContractedGradient(G2G::vec_type<T,WIDTH>* grad, T* contracted_grad, int numElements)
-{
-    int i = blockDim.x * blockIdx.x + threadIdx.x;
+template <class T>
+__global__ void calculateContractedGradient(G2G::vec_type<T, WIDTH>* grad,
+                                            T* contracted_grad,
+                                            int numElements) {
+  int i = blockDim.x * blockIdx.x + threadIdx.x;
 
-    if (i < numElements)
-    {
-        contracted_grad[i] = (grad[i].x * grad[i].x) + (grad[i].y * grad[i].y) + (grad[i].z * grad[i].z);
-    }
+  if (i < numElements) {
+    contracted_grad[i] = (grad[i].x * grad[i].x) + (grad[i].y * grad[i].y) +
+                         (grad[i].z * grad[i].z);
+  }
 }
 
 //////////////////////////////////////////////////////////////
@@ -475,17 +467,14 @@ __global__ void calculateContractedGradient(G2G::vec_type<T,WIDTH>* grad, T* con
 //
 // Note: all the pointer data are pointers in CUDA memory.
 //
-template<class T>
-__global__ void vectorAdd(const T* A, const T* B, T* C, int numElements)
-{
-    int i = blockDim.x * blockIdx.x + threadIdx.x;
+template <class T>
+__global__ void vectorAdd(const T* A, const T* B, T* C, int numElements) {
+  int i = blockDim.x * blockIdx.x + threadIdx.x;
 
-    if (i < numElements)
-    {
-        C[i] = A[i] + B[i];
-    }
+  if (i < numElements) {
+    C[i] = A[i] + B[i];
+  }
 }
-
 
 //////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////
@@ -501,119 +490,110 @@ __global__ void vectorAdd(const T* A, const T* B, T* C, int numElements)
 //
 // Note: all the pointer data are pointers in CUDA memory.
 //
-template<class T, bool compute_energy, bool compute_factor, bool lda>
-    void libxc_exchange_correlation_gpu (LibxcProxy_cuda<T, WIDTH>* libxcProxy,
-	T* energy_gpu,
-	T* factor_gpu,
-	uint points,
-	T* accumulated_density_gpu,
-	G2G::vec_type<T,WIDTH>* dxyz_gpu,
-        G2G::vec_type<T,WIDTH>* dd1_gpu,
-	G2G::vec_type<T,WIDTH>* dd2_gpu)
-{
-    //printf("libxc_exchage_correlation_gpu<%u,%d,%d,%d>(%u) \n", sizeof(T), compute_energy, compute_factor, lda, points);
-    //print_libxc_exchange_correlation_gpu_input (energy_gpu, factor_gpu, points, accumulated_density_gpu, dxyz_gpu, dd1_gpu, dd2_gpu);
+template <class T, bool compute_energy, bool compute_factor, bool lda>
+void libxc_exchange_correlation_gpu(LibxcProxy_cuda<T, WIDTH>* libxcProxy,
+                                    T* energy_gpu, T* factor_gpu, uint points,
+                                    T* accumulated_density_gpu,
+                                    G2G::vec_type<T, WIDTH>* dxyz_gpu,
+                                    G2G::vec_type<T, WIDTH>* dd1_gpu,
+                                    G2G::vec_type<T, WIDTH>* dd2_gpu) {
+  // printf("libxc_exchage_correlation_gpu<%u,%d,%d,%d>(%u) \n", sizeof(T),
+  // compute_energy, compute_factor, lda, points);
+  // print_libxc_exchange_correlation_gpu_input (energy_gpu, factor_gpu, points,
+  // accumulated_density_gpu, dxyz_gpu, dd1_gpu, dd2_gpu);
 
-    cudaError_t err = cudaSuccess;
+  cudaError_t err = cudaSuccess;
 
-    /////////////////////
-    // Libxc proxy
-    /////////////////////
-    // Parameters
-    T* exc_gpu = NULL;
-    T* corr_gpu = NULL;
-    T* y2a_gpu = NULL;
-    T* contracted_gradient = NULL;
-    int array_size = sizeof(T) * points;
-    //printf ("array_size: %u \n", array_size);
+  /////////////////////
+  // Libxc proxy
+  /////////////////////
+  // Parameters
+  T* exc_gpu = NULL;
+  T* corr_gpu = NULL;
+  T* y2a_gpu = NULL;
+  T* contracted_gradient = NULL;
+  int array_size = sizeof(T) * points;
+  // printf ("array_size: %u \n", array_size);
 
-    // Alloc memory for cuda variables.
-    err = cudaMalloc((void **)&exc_gpu, array_size);
-    if (err != cudaSuccess)
-    {
-        fprintf(stderr, "Failed to allocate device exc_gpu! %u \n", err);
-        exit(EXIT_FAILURE);
+  // Alloc memory for cuda variables.
+  err = cudaMalloc((void**)&exc_gpu, array_size);
+  if (err != cudaSuccess) {
+    fprintf(stderr, "Failed to allocate device exc_gpu! %u \n", err);
+    exit(EXIT_FAILURE);
+  }
+
+  err = cudaMalloc((void**)&corr_gpu, array_size);
+  if (err != cudaSuccess) {
+    fprintf(stderr, "Failed to allocate device corr_gpu!\n");
+    exit(EXIT_FAILURE);
+  }
+
+  err = cudaMalloc((void**)&y2a_gpu, array_size);
+  if (err != cudaSuccess) {
+    fprintf(stderr, "Failed to allocate device y2a_gpu!\n");
+    exit(EXIT_FAILURE);
+  }
+
+  // err = cudaMalloc((void**)&contracted_gradient, sizeof(T)*points);
+  err = cudaMalloc((void**)&contracted_gradient, array_size);
+  if (err != cudaSuccess) {
+    fprintf(stderr, "Failed to allocate device contracted_gradient!\n");
+    exit(EXIT_FAILURE);
+  }
+
+  cudaMemset(exc_gpu, 0, array_size);
+  cudaMemset(corr_gpu, 0, array_size);
+  cudaMemset(y2a_gpu, 0, array_size);
+  cudaMemset(contracted_gradient, 0, array_size);
+
+  // Variables for the Kernels
+  int threadsPerBlock = 256;
+  int blocksPerGrid = (points + threadsPerBlock - 1) / threadsPerBlock;
+
+  if (libxcProxy != NULL) {
+    // printf("Calling calculateContractedGradient() \n");
+    // Call the Kernel to compute the contracted gradient
+    // printf("CUDA kernel launch with %d blocks of %d threads\n",
+    // blocksPerGrid, threadsPerBlock);
+    calculateContractedGradient<<<blocksPerGrid, threadsPerBlock>>>(
+        dxyz_gpu, contracted_gradient, points);
+
+    /////////////////////////////////////////
+    // Compute exc_corr using LIBXC GPU.
+    // printf("Calling libxcProxy->doGGA() \n");
+
+    libxcProxy->doGGA(accumulated_density_gpu, points, contracted_gradient,
+                      dxyz_gpu, dd1_gpu, dd2_gpu, exc_gpu, corr_gpu, y2a_gpu);
+
+    ///////////////////////
+    // Join the results.
+    if (compute_energy && energy_gpu != NULL) {
+      vectorAdd<<<blocksPerGrid, threadsPerBlock>>>(exc_gpu, corr_gpu,
+                                                    energy_gpu, points);
     }
-
-    err = cudaMalloc((void **)&corr_gpu, array_size);
-    if (err != cudaSuccess)
-    {
-        fprintf(stderr, "Failed to allocate device corr_gpu!\n");
-        exit(EXIT_FAILURE);
+    if (compute_factor && factor_gpu != NULL) {
+      err =
+          cudaMemcpy(factor_gpu, y2a_gpu, array_size, cudaMemcpyDeviceToDevice);
+      if (err != cudaSuccess) {
+        fprintf(stderr,
+                "Failed to copy y2a_gpu to factor_gpu from DeviceToDevice for "
+                "array of %i !\n",
+                array_size);
+      }
     }
+  }
 
-    err = cudaMalloc((void **)&y2a_gpu, array_size);
-    if (err != cudaSuccess)
-    {
-        fprintf(stderr, "Failed to allocate device y2a_gpu!\n");
-        exit(EXIT_FAILURE);
-    }
-
-    //err = cudaMalloc((void**)&contracted_gradient, sizeof(T)*points);
-    err = cudaMalloc((void**)&contracted_gradient, array_size);
-    if (err != cudaSuccess)
-    {
-        fprintf(stderr, "Failed to allocate device contracted_gradient!\n");
-	exit(EXIT_FAILURE);
-    }
-
-    cudaMemset(exc_gpu,0,array_size);
-    cudaMemset(corr_gpu,0,array_size);
-    cudaMemset(y2a_gpu,0,array_size);
-    cudaMemset(contracted_gradient,0,array_size);
-
-    // Variables for the Kernels
-    int threadsPerBlock = 256;
-    int blocksPerGrid = (points + threadsPerBlock - 1) / threadsPerBlock;
-
-    if (libxcProxy != NULL) {
-        //printf("Calling calculateContractedGradient() \n");
-	// Call the Kernel to compute the contracted gradient
-        //printf("CUDA kernel launch with %d blocks of %d threads\n", blocksPerGrid, threadsPerBlock);
-	calculateContractedGradient<<<blocksPerGrid, threadsPerBlock>>>(dxyz_gpu, contracted_gradient, points);
-
-	/////////////////////////////////////////
-	// Compute exc_corr using LIBXC GPU.
-        //printf("Calling libxcProxy->doGGA() \n");
-
-	libxcProxy->doGGA (accumulated_density_gpu,
-	    points, 
-	    contracted_gradient, 
-	    dxyz_gpu, 
-	    dd1_gpu, 
-	    dd2_gpu, 
-	    exc_gpu, 
-	    corr_gpu, 
-	    y2a_gpu);
-
-	///////////////////////
-	// Join the results.
-    	if (compute_energy && energy_gpu != NULL)
-	{
-	    vectorAdd<<<blocksPerGrid, threadsPerBlock>>>(exc_gpu, corr_gpu, energy_gpu, points);
-	}
-	if (compute_factor && factor_gpu != NULL)
-	{
-	    err = cudaMemcpy(factor_gpu, y2a_gpu, array_size, cudaMemcpyDeviceToDevice);
-	    if (err != cudaSuccess)
-	    {
-    		fprintf(stderr, "Failed to copy y2a_gpu to factor_gpu from DeviceToDevice for array of %i !\n", array_size);
-	    }
-	}
-    }
-
-    // Free memory.
-    if (contracted_gradient != NULL) {
-	cudaFree(contracted_gradient);
-    }
-    if (exc_gpu != NULL) {
-	cudaFree(exc_gpu);
-    }
-    if (corr_gpu != NULL) {
-        cudaFree(corr_gpu);
-    }
-    if (y2a_gpu != NULL) {
-	cudaFree(y2a_gpu);
-    }
+  // Free memory.
+  if (contracted_gradient != NULL) {
+    cudaFree(contracted_gradient);
+  }
+  if (exc_gpu != NULL) {
+    cudaFree(exc_gpu);
+  }
+  if (corr_gpu != NULL) {
+    cudaFree(corr_gpu);
+  }
+  if (y2a_gpu != NULL) {
+    cudaFree(y2a_gpu);
+  }
 }
-

--- a/g2g/libxc/libxcproxy.h
+++ b/g2g/libxc/libxcproxy.h
@@ -12,181 +12,157 @@
 //#include <cuda_runtime.h>
 #include "../timer.h"
 
-extern "C" void g2g_timer_sum_start_(const char* timer_name, unsigned int length_arg);
-extern "C" void g2g_timer_sum_stop_(const char* timer_name, unsigned int length_arg);
-extern "C" void g2g_timer_sum_pause_(const char* timer_name, unsigned int length_arg);
+extern "C" void g2g_timer_sum_start_(const char* timer_name,
+                                     unsigned int length_arg);
+extern "C" void g2g_timer_sum_stop_(const char* timer_name,
+                                    unsigned int length_arg);
+extern "C" void g2g_timer_sum_pause_(const char* timer_name,
+                                     unsigned int length_arg);
 
 template <class T, int width>
-class LibxcProxy
-{
-private:
-    // Inner Variables
-    xc_func_type* funcsId;
-    int ntotal_funcs, nxcoef, nccoef, nspin, nsrid;
-    double omega;
-    double* funcsCoef;
+class LibxcProxy {
+ private:
+  // Inner Variables
+  xc_func_type* funcsId;
+  int ntotal_funcs, nxcoef, nccoef, nspin, nsrid;
+  double omega;
+  double* funcsCoef;
 
-    // Is inited
-    bool inited;
+  // Is inited
+  bool inited;
 
-//  TODO: borrar esto, es solo pa que compile por partes
-    xc_func_type funcForExchange, funcForCorrelation;
-    double fact_exchange;
-///////////////////
+  //  TODO: borrar esto, es solo pa que compile por partes
+  xc_func_type funcForExchange, funcForCorrelation;
+  double fact_exchange;
+  ///////////////////
 
-    // 3rd order derivative
-    void Zv_exchange(double td, double* dxyz, double* txyz,
-           double* Coef, double v2rho2, double v2rhosigma, double v2sigma2,
-           double v3rho3,double v3rho2sigma,double v3rhosigma2,double v3sigma3);
+  // 3rd order derivative
+  void Zv_exchange(double td, double* dxyz, double* txyz, double* Coef,
+                   double v2rho2, double v2rhosigma, double v2sigma2,
+                   double v3rho3, double v3rho2sigma, double v3rhosigma2,
+                   double v3sigma3);
 
-    void Zv_coulomb(double td,double* dxyz,double* txyz, double* Coef, 
-                double v2rhosigma, double v2sigma2,double v3rho3,
-                double v3rho2sigma,double v3rhosigma2,double v3sigma3);
+  void Zv_coulomb(double td, double* dxyz, double* txyz, double* Coef,
+                  double v2rhosigma, double v2sigma2, double v3rho3,
+                  double v3rho2sigma, double v3rhosigma2, double v3sigma3);
 
+ public:
+  // Constructors
+  LibxcProxy();
+  LibxcProxy(int* func_id, double* func_coef, int nx_coef, int nc_coef,
+             int nsr_id, double screen, int nSpin);
+  void init(int* func_id, double* func_coef, int nx_coef, int nc_coef,
+            int nsr_id, double screen, int nSpin);
+  // Destructors
+  ~LibxcProxy();
+  void closeProxy();
 
-public:
+  // Libxc Calculations
+  void doSCF(T& dens, const G2G::vec_type<T, width>& grad,
+             const G2G::vec_type<T, width>& hess1,
+             const G2G::vec_type<T, width>& hess2, T& ex, T& ec, T& y2a);
 
-    // Constructors
-    LibxcProxy ();
-    LibxcProxy (int* func_id,double* func_coef, int nx_coef, int nc_coef,
-                                int nsr_id, double screen, int nSpin);
-    void init (int* func_id,double* func_coef, int nx_coef, int nc_coef,
-                                int nsr_id, double screen, int nSpin);
-    // Destructors
-    ~LibxcProxy ();
-    void closeProxy ();
+  void doGGA(T dens, const G2G::vec_type<T, width>& grad,
+             const G2G::vec_type<T, width>& hess1,
+             const G2G::vec_type<T, width>& hess2, T& ex, T& ec, T& y2a);
 
-    // Libxc Calculations
-    void doSCF(T& dens, const G2G::vec_type<T, width>& grad,
-               const G2G::vec_type<T, width>& hess1,
-               const G2G::vec_type<T, width>& hess2,
-               T& ex, T& ec, T& y2a);
+  void doGGA(T* dens, const int number_of_points,
+             const G2G::vec_type<T, width>* grad,
+             const G2G::vec_type<T, width>* hess1,
+             const G2G::vec_type<T, width>* hess2, T* ex, T* ec, T* y2a);
 
-    void doGGA (T dens,
-                const G2G::vec_type<T,width>& grad,
-                const G2G::vec_type<T,width>& hess1,
-                const G2G::vec_type<T,width>& hess2,
-                T& ex,
-                T& ec,
-                T& y2a);
+  void doGGA(T dens, T sigma, T* v2rho2, T v2rhosigma, T v2sigma2);
 
-    void doGGA (T* dens,
-                const int number_of_points,
-		const G2G::vec_type<T,width>* grad,
-                const G2G::vec_type<T,width>* hess1,
-                const G2G::vec_type<T,width>* hess2,
-                T* ex,
-                T* ec,
-                T* y2a);
+  void doGGA(T* dens, T* sigma, const int number_of_points, T* v2rho2,
+             T* v2rhosigma, T* v2sigma2);
 
-    void doGGA (T dens,
-                T sigma,
-                T* v2rho2,
-                T v2rhosigma,
-                T v2sigma2);
+  void doGGA(T* dens, const int number_of_points, const T* contracted_grad,
+             const G2G::vec_type<T, width>* grad,
+             const G2G::vec_type<T, width>* hess1,
+             const G2G::vec_type<T, width>* hess2, T* ex, T* ec, T* y2a);
 
-    void doGGA (T* dens,
-		T* sigma,
-                const int number_of_points,
-		T* v2rho2,
-		T* v2rhosigma,
-		T* v2sigma2);
+  void coefLR(double* rho, double* sigma, double red, double cruz,
+              double* lrCoef);
 
-    void doGGA (T* dens,
-                const int number_of_points,
-		const T* contracted_grad,
-		const G2G::vec_type<T,width>* grad,
-                const G2G::vec_type<T,width>* hess1,
-                const G2G::vec_type<T,width>* hess2,
-                T* ex,
-                T* ec,
-                T* y2a);
+  void coefZv(double pd, double sigma, double pdx, double pdy, double pdz,
+              double red, double redx, double redy, double redz, double* zcoef);
 
-    void coefLR(double* rho, double* sigma, double red,
-                double cruz, double* lrCoef);
+  void terms_derivs(double* dens, double* sigma, double* vrho, double* vsigma,
+                    double* v2rho2, double* v2rhosigma, double* v2sigma2,
+                    double* v3rho3, double* v3rho2sigma, double* v3rhosigma2,
+                    double* v3sigma3);
 
-    void coefZv(double pd, double sigma, double pdx, double pdy,
-                double pdz, double red, double redx, double redy,
-                double redz, double* zcoef);
-
-    void terms_derivs(double* dens, double* sigma,
-                double* vrho, double* vsigma, double* v2rho2,
-                double* v2rhosigma, double* v2sigma2, double* v3rho3,
-                double* v3rho2sigma, double* v3rhosigma2, double* v3sigma3);
-
-    void doLDA (T dens,
-                const G2G::vec_type<T,width>& grad,
-                const G2G::vec_type<T,width>& hess1,
-                const G2G::vec_type<T,width>& hess2,
-                T& ex,
-                T& ec,
-                T& y2a);
+  void doLDA(T dens, const G2G::vec_type<T, width>& grad,
+             const G2G::vec_type<T, width>& hess1,
+             const G2G::vec_type<T, width>& hess2, T& ex, T& ec, T& y2a);
 };
 
 template <class T, int width>
-LibxcProxy <T, width>::LibxcProxy()
-{
-   ntotal_funcs = -1;
-   nxcoef = -1; nccoef = -1;
-   nspin = -1;
-   nsrid = -1;
-   omega = -1.0f;
-   inited = false;
+LibxcProxy<T, width>::LibxcProxy() {
+  ntotal_funcs = -1;
+  nxcoef = -1;
+  nccoef = -1;
+  nspin = -1;
+  nsrid = -1;
+  omega = -1.0f;
+  inited = false;
 }
 
 template <class T, int width>
-LibxcProxy <T, width>::LibxcProxy (int* func_id,double* func_coef, int nx_coef, int nc_coef,
-                                   int nsr_id, double screen, int nSpin)
-{
-    init(func_id,func_coef,nx_coef,nc_coef,nsr_id,screen,nSpin);
+LibxcProxy<T, width>::LibxcProxy(int* func_id, double* func_coef, int nx_coef,
+                                 int nc_coef, int nsr_id, double screen,
+                                 int nSpin) {
+  init(func_id, func_coef, nx_coef, nc_coef, nsr_id, screen, nSpin);
 }
 
 template <class T, int width>
-void LibxcProxy<T, width>::init(int* func_id,double* func_coef, int nx_coef, int nc_coef,
-                                int nsr_id, double screen, int nSpin)
-{
-    // Set inner libxc variables
-    ntotal_funcs = nx_coef + nc_coef;
-    nxcoef = nx_coef; nccoef = nc_coef;
-    nspin  = nSpin; nsrid = nsr_id; omega = screen;
-    funcsId   = (xc_func_type*) malloc(ntotal_funcs*sizeof(xc_func_type));
-    funcsCoef = (double*) malloc(ntotal_funcs*sizeof(double));
-    double threshold = 1e-20;
+void LibxcProxy<T, width>::init(int* func_id, double* func_coef, int nx_coef,
+                                int nc_coef, int nsr_id, double screen,
+                                int nSpin) {
+  // Set inner libxc variables
+  ntotal_funcs = nx_coef + nc_coef;
+  nxcoef = nx_coef;
+  nccoef = nc_coef;
+  nspin = nSpin;
+  nsrid = nsr_id;
+  omega = screen;
+  funcsId = (xc_func_type*)malloc(ntotal_funcs * sizeof(xc_func_type));
+  funcsCoef = (double*)malloc(ntotal_funcs * sizeof(double));
+  double threshold = 1e-20;
 
-    // Init of differents functionals needed in the simulation
-    for (int ii=0; ii<ntotal_funcs; ii++) {
-       if (xc_func_init (&funcsId[ii], func_id[ii], nspin) != 0) {
-           fprintf (stderr, "Functional '%d' not found\n", func_id[ii]);
-           exit(-1);
-       }
-       if ( ii == nsrid ) {
-          xc_func_set_ext_params(&funcsId[ii],&omega);
-       } else {
-          xc_func_set_dens_threshold(&funcsId[ii],threshold);
-       }
-       funcsCoef[ii] = func_coef[ii];
+  // Init of differents functionals needed in the simulation
+  for (int ii = 0; ii < ntotal_funcs; ii++) {
+    if (xc_func_init(&funcsId[ii], func_id[ii], nspin) != 0) {
+      fprintf(stderr, "Functional '%d' not found\n", func_id[ii]);
+      exit(-1);
     }
-
-    inited = true;
-}
-
-template <class T, int width>
-LibxcProxy <T, width>::~LibxcProxy ()
-{
-    closeProxy ();
-}
-
-template <class T, int width>
-void LibxcProxy <T, width>::closeProxy ()
-{
-    if (inited) {
-        for (int ii=0; ii<ntotal_funcs; ii++)
-           xc_func_end(&funcsId[ii]);
-
-        free(funcsId);   funcsId   = NULL;
-        free(funcsCoef); funcsCoef = NULL;
-	inited = false;
+    if (ii == nsrid) {
+      xc_func_set_ext_params(&funcsId[ii], &omega);
+    } else {
+      xc_func_set_dens_threshold(&funcsId[ii], threshold);
     }
+    funcsCoef[ii] = func_coef[ii];
+  }
+
+  inited = true;
+}
+
+template <class T, int width>
+LibxcProxy<T, width>::~LibxcProxy() {
+  closeProxy();
+}
+
+template <class T, int width>
+void LibxcProxy<T, width>::closeProxy() {
+  if (inited) {
+    for (int ii = 0; ii < ntotal_funcs; ii++) xc_func_end(&funcsId[ii]);
+
+    free(funcsId);
+    funcsId = NULL;
+    free(funcsCoef);
+    funcsCoef = NULL;
+    inited = false;
+  }
 }
 
 //////////////////////////////////////////////////////////////
@@ -197,118 +173,117 @@ void LibxcProxy <T, width>::closeProxy ()
 // grad:.
 // hess1:
 // hess2:
-// ex: here goes the results after calling xc_gga from libxc for the exchange functional
-// ec: here goes the results after calling xc_gga from libxc for the correlation functional
-// y2a:
+// ex: here goes the results after calling xc_gga from libxc for the exchange
+// functional ec: here goes the results after calling xc_gga from libxc for the
+// correlation functional y2a:
 //
 template <class T, int width>
-void LibxcProxy <T, width>::doSCF(T& dens,
-    const G2G::vec_type<T, width>& grad,
-    const G2G::vec_type<T, width>& hess1,
-    const G2G::vec_type<T, width>& hess2,
-    T& ex, T& ec, T& y2a)
-{
-    const double rho[1] = {dens};
-    double sigma[1] = {(grad.x * grad.x) + (grad.y * grad.y) + (grad.z * grad.z)};
+void LibxcProxy<T, width>::doSCF(T& dens, const G2G::vec_type<T, width>& grad,
+                                 const G2G::vec_type<T, width>& hess1,
+                                 const G2G::vec_type<T, width>& hess2, T& ex,
+                                 T& ec, T& y2a) {
+  const double rho[1] = {dens};
+  double sigma[1] = {(grad.x * grad.x) + (grad.y * grad.y) + (grad.z * grad.z)};
 
-    //All outputs
-    ex = ec = 0.0f;
-    double vrho=0.0f;
-    double vsigma=0.0f;
-    double v2rho2=0.0f;
-    double v2rhosigma=0.0f;
-    double v2sigma2=0.0f;
+  // All outputs
+  ex = ec = 0.0f;
+  double vrho = 0.0f;
+  double vsigma = 0.0f;
+  double v2rho2 = 0.0f;
+  double v2rhosigma = 0.0f;
+  double v2sigma2 = 0.0f;
 
-    // Functional outputs
-    double lenergy[1];
-    double lvrho[1];
-    double lvsigma[1];
-    double lv2rho2[1];
-    double lv2rhosigma[1];
-    double lv2sigma2[1];
+  // Functional outputs
+  double lenergy[1];
+  double lvrho[1];
+  double lvsigma[1];
+  double lv2rho2[1];
+  double lv2rhosigma[1];
+  double lv2sigma2[1];
 
-    double cc = 0.0f;
+  double cc = 0.0f;
 
-    // Exchange Calculation
-    for (int ii=0; ii<nxcoef; ii++) {
-        // Set zero values
-        lenergy[0]  = 0.0f;
-        lvrho[0]    = 0.0f;
-        lv2rho2[0]  = 0.0f;
-        lvsigma[0]  = 0.0f;
-        lv2rhosigma[0] = 0.0f;
-        lv2sigma2[0]   = 0.0f;
+  // Exchange Calculation
+  for (int ii = 0; ii < nxcoef; ii++) {
+    // Set zero values
+    lenergy[0] = 0.0f;
+    lvrho[0] = 0.0f;
+    lv2rho2[0] = 0.0f;
+    lvsigma[0] = 0.0f;
+    lv2rhosigma[0] = 0.0f;
+    lv2sigma2[0] = 0.0f;
 
-        switch( (&funcsId[ii])->info->family ) {
-           case (XC_FAMILY_LDA):
-              xc_lda(&funcsId[ii],1,rho,lenergy,lvrho,lv2rho2,
-                     NULL,
-                     NULL); break;
-           case (XC_FAMILY_GGA):
-              xc_gga(&funcsId[ii],1,rho,sigma,lenergy,lvrho,lvsigma,
-                     lv2rho2,lv2rhosigma,lv2sigma2,
-                     NULL,NULL,NULL,NULL,
-                     NULL,NULL,NULL,NULL,NULL); break;
-           default:
-             printf("Unidentified Family Functional\n");
-             exit(-1); break;
+    switch ((&funcsId[ii])->info->family) {
+      case (XC_FAMILY_LDA):
+        xc_lda(&funcsId[ii], 1, rho, lenergy, lvrho, lv2rho2, NULL, NULL);
+        break;
+      case (XC_FAMILY_GGA):
+        xc_gga(&funcsId[ii], 1, rho, sigma, lenergy, lvrho, lvsigma, lv2rho2,
+               lv2rhosigma, lv2sigma2, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+               NULL, NULL);
+        break;
+      default:
+        printf("Unidentified Family Functional\n");
+        exit(-1);
+        break;
 
-        } // end switch
+    }  // end switch
 
-        cc = funcsCoef[ii];
-        ex         += cc*lenergy[0];
-        vrho       += cc*lvrho[0];
-        v2rho2     += cc*lv2rho2[0];
-        vsigma     += cc*lvsigma[0];
-        v2rhosigma += cc*lv2rhosigma[0];
-        v2sigma2   += cc*lv2sigma2[0];
-    } // end exchange
+    cc = funcsCoef[ii];
+    ex += cc * lenergy[0];
+    vrho += cc * lvrho[0];
+    v2rho2 += cc * lv2rho2[0];
+    vsigma += cc * lvsigma[0];
+    v2rhosigma += cc * lv2rhosigma[0];
+    v2sigma2 += cc * lv2sigma2[0];
+  }  // end exchange
 
-    // Correlation Calculation
-    for (int ii=nxcoef; ii<ntotal_funcs; ii++) {
-        // Set zero values
-        lenergy[0]  = 0.0f;
-        lvrho[0]    = 0.0f;
-        lv2rho2[0]  = 0.0f;
-        lvsigma[0]  = 0.0f;
-        lv2rhosigma[0] = 0.0f;
-        lv2sigma2[0]   = 0.0f;
+  // Correlation Calculation
+  for (int ii = nxcoef; ii < ntotal_funcs; ii++) {
+    // Set zero values
+    lenergy[0] = 0.0f;
+    lvrho[0] = 0.0f;
+    lv2rho2[0] = 0.0f;
+    lvsigma[0] = 0.0f;
+    lv2rhosigma[0] = 0.0f;
+    lv2sigma2[0] = 0.0f;
 
-        switch( (&funcsId[ii])->info->family ) {
-           case (XC_FAMILY_LDA):
-              xc_lda(&funcsId[ii],1,rho,lenergy,lvrho,lv2rho2,
-                     NULL,
-                     NULL); break;
-           case (XC_FAMILY_GGA):
-              xc_gga(&funcsId[ii],1,rho,sigma,lenergy,lvrho,lvsigma,
-                     lv2rho2,lv2rhosigma,lv2sigma2,
-                     NULL,NULL,NULL,NULL,
-                     NULL,NULL,NULL,NULL,NULL); break;
-           default:
-             printf("Unidentified Family Functional\n");
-             exit(-1); break;
+    switch ((&funcsId[ii])->info->family) {
+      case (XC_FAMILY_LDA):
+        xc_lda(&funcsId[ii], 1, rho, lenergy, lvrho, lv2rho2, NULL, NULL);
+        break;
+      case (XC_FAMILY_GGA):
+        xc_gga(&funcsId[ii], 1, rho, sigma, lenergy, lvrho, lvsigma, lv2rho2,
+               lv2rhosigma, lv2sigma2, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+               NULL, NULL);
+        break;
+      default:
+        printf("Unidentified Family Functional\n");
+        exit(-1);
+        break;
 
-        } // end switch
+    }  // end switch
 
-        cc = funcsCoef[ii];
-        ec         += cc*lenergy[0];
-        vrho       += cc*lvrho[0];
-        v2rho2     += cc*lv2rho2[0];
-        vsigma     += cc*lvsigma[0];
-        v2rhosigma += cc*lv2rhosigma[0];
-        v2sigma2   += cc*lv2sigma2[0];
-    } // end correlation
+    cc = funcsCoef[ii];
+    ec += cc * lenergy[0];
+    vrho += cc * lvrho[0];
+    v2rho2 += cc * lv2rho2[0];
+    vsigma += cc * lvsigma[0];
+    v2rhosigma += cc * lv2rhosigma[0];
+    v2sigma2 += cc * lv2sigma2[0];
+  }  // end correlation
 
-    // Now, compute y2a value.
-    y2a = vrho - (2.0f * sigma[0] * v2rhosigma + 2.0f * (hess1.x + hess1.y + hess1.z) * vsigma
-               + 4.0f * v2sigma2 * (grad.x * grad.x * hess1.x + 
-                                   grad.y * grad.y * hess1.y +
-                                   grad.z * grad.z * hess1.z + 
-                            2.0f * grad.x * grad.y * hess2.x + 
-                            2.0f * grad.x * grad.z * hess2.y +
-                            2.0f * grad.y * grad.z * hess2.z));
+  // Now, compute y2a value.
+  y2a = vrho -
+        (2.0f * sigma[0] * v2rhosigma +
+         2.0f * (hess1.x + hess1.y + hess1.z) * vsigma +
+         4.0f * v2sigma2 *
+             (grad.x * grad.x * hess1.x + grad.y * grad.y * hess1.y +
+              grad.z * grad.z * hess1.z + 2.0f * grad.x * grad.y * hess2.x +
+              2.0f * grad.x * grad.z * hess2.y +
+              2.0f * grad.y * grad.z * hess2.z));
 
-    return;
+  return;
 }
 
 //////////////////////////////////////////////////////////////
@@ -320,118 +295,116 @@ void LibxcProxy <T, width>::doSCF(T& dens,
 // grad: gradient value in each point
 // hess1:
 // hess2:
-// ex: here goes the results after calling xc_gga from libxc for the exchange functional
-// ec: here goes the results after calling xc_gga from libxc for the correlation functional
-// y2a:
+// ex: here goes the results after calling xc_gga from libxc for the exchange
+// functional ec: here goes the results after calling xc_gga from libxc for the
+// correlation functional y2a:
 //
 template <class T, int width>
-void LibxcProxy <T, width>::doGGA(T* dens,
-    const int number_of_points,
-    const G2G::vec_type<T, width>* grad,
-    const G2G::vec_type<T, width>* hess1,
-    const G2G::vec_type<T, width>* hess2,
-    T* ex,
-    T* ec,
-    T* y2a)
-{
-    //printf("LibxcProxy::doGGA cpu multiple (...) \n");
+void LibxcProxy<T, width>::doGGA(T* dens, const int number_of_points,
+                                 const G2G::vec_type<T, width>* grad,
+                                 const G2G::vec_type<T, width>* hess1,
+                                 const G2G::vec_type<T, width>* hess2, T* ex,
+                                 T* ec, T* y2a) {
+  // printf("LibxcProxy::doGGA cpu multiple (...) \n");
 
-    int array_size = sizeof(double)*number_of_points;
-    double* rho = (double*)malloc(array_size);
-    for (int i=0; i<number_of_points; i++) {
-	rho[i] = (double)dens[i];
-    }
+  int array_size = sizeof(double) * number_of_points;
+  double* rho = (double*)malloc(array_size);
+  for (int i = 0; i < number_of_points; i++) {
+    rho[i] = (double)dens[i];
+  }
 
-    // Libxc needs the 'contracted gradient'
-    double* sigma = (double*)malloc(array_size);
-    for (int i=0; i< number_of_points; i++) {
-	sigma[i] = (double)((grad[i].x * grad[i].x) + (grad[i].y * grad[i].y) + (grad[i].z * grad[i].z));
-    }
-    double* exchange = (double*)malloc(array_size);
-    double* correlation = (double*)malloc(array_size);
+  // Libxc needs the 'contracted gradient'
+  double* sigma = (double*)malloc(array_size);
+  for (int i = 0; i < number_of_points; i++) {
+    sigma[i] = (double)((grad[i].x * grad[i].x) + (grad[i].y * grad[i].y) +
+                        (grad[i].z * grad[i].z));
+  }
+  double* exchange = (double*)malloc(array_size);
+  double* correlation = (double*)malloc(array_size);
 
-    // The outputs for exchange
-    double* vrho = (double*)malloc(array_size);
-    double* vsigma = (double*)malloc(array_size);
-    double* v2rho = (double*)malloc(array_size);
-    double* v2rhosigma = (double*)malloc(array_size);
-    double* v2sigma = (double*)malloc(array_size);
+  // The outputs for exchange
+  double* vrho = (double*)malloc(array_size);
+  double* vsigma = (double*)malloc(array_size);
+  double* v2rho = (double*)malloc(array_size);
+  double* v2rhosigma = (double*)malloc(array_size);
+  double* v2sigma = (double*)malloc(array_size);
 
-    // The outputs for correlation
-    double* vrhoC = (double*)malloc(array_size);
-    double* vsigmaC = (double*)malloc(array_size);
-    double* v2rhoC = (double*)malloc(array_size);
-    double* v2rhosigmaC = (double*)malloc(array_size);
-    double* v2sigmaC = (double*)malloc(array_size);
+  // The outputs for correlation
+  double* vrhoC = (double*)malloc(array_size);
+  double* vsigmaC = (double*)malloc(array_size);
+  double* v2rhoC = (double*)malloc(array_size);
+  double* v2rhosigmaC = (double*)malloc(array_size);
+  double* v2sigmaC = (double*)malloc(array_size);
 
-/* TODO
-    // Exchange values
-    xc_gga (&funcForExchange, number_of_points,
-                rho,
-                sigma,
-                exchange,
-                vrho,
-                vsigma,
-                v2rho,
-                v2rhosigma,
-                v2sigma,
-                NULL, NULL, NULL, NULL);
+  /* TODO
+      // Exchange values
+      xc_gga (&funcForExchange, number_of_points,
+                  rho,
+                  sigma,
+                  exchange,
+                  vrho,
+                  vsigma,
+                  v2rho,
+                  v2rhosigma,
+                  v2sigma,
+                  NULL, NULL, NULL, NULL);
 
-    // Now the correlation value.
-    xc_gga (&funcForCorrelation, number_of_points,
-                rho,
-                sigma,
-                correlation,
-                vrhoC,
-                vsigmaC,
-                v2rhoC,
-                v2rhosigmaC,
-                v2sigmaC,
-                NULL, NULL, NULL, NULL);
-*/
+      // Now the correlation value.
+      xc_gga (&funcForCorrelation, number_of_points,
+                  rho,
+                  sigma,
+                  correlation,
+                  vrhoC,
+                  vsigmaC,
+                  v2rhoC,
+                  v2rhosigmaC,
+                  v2sigmaC,
+                  NULL, NULL, NULL, NULL);
+  */
 
-    for (int i=0; i<number_of_points; i++) {
-	ex[i] = exchange[i];
-        ec[i] = correlation[i];
-        // Merge the results for the derivatives.
-        vrho[i] += vrhoC[i];
-        vsigma[i] += vsigmaC[i];
-        v2rho[i] += v2rhoC[i];
-        v2rhosigma[i] += v2rhosigmaC[i];
-        v2sigma[i] += v2sigmaC[i];
+  for (int i = 0; i < number_of_points; i++) {
+    ex[i] = exchange[i];
+    ec[i] = correlation[i];
+    // Merge the results for the derivatives.
+    vrho[i] += vrhoC[i];
+    vsigma[i] += vsigmaC[i];
+    v2rho[i] += v2rhoC[i];
+    v2rhosigma[i] += v2rhosigmaC[i];
+    v2sigma[i] += v2sigmaC[i];
 
-	// Now, compute y2a value.
-        y2a[i] = vrho[i] - (2 * sigma[i] * v2rhosigma[i]
-	        + 2 * (hess1[i].x + hess1[i].y + hess1[i].z) * vsigma[i]
-    		+ 4 * v2sigma[i] * (grad[i].x * grad[i].x * hess1[i].x +
-				    grad[i].y * grad[i].y * hess1[i].y +
-				    grad[i].z * grad[i].z * hess1[i].z +
-				    2 * grad[i].x * grad[i].y * hess2[i].x +
-				    2 * grad[i].x * grad[i].z * hess2[i].y +
-				    2 * grad[i].y * grad[i].z * hess2[i].z));
-    }
+    // Now, compute y2a value.
+    y2a[i] = vrho[i] - (2 * sigma[i] * v2rhosigma[i] +
+                        2 * (hess1[i].x + hess1[i].y + hess1[i].z) * vsigma[i] +
+                        4 * v2sigma[i] *
+                            (grad[i].x * grad[i].x * hess1[i].x +
+                             grad[i].y * grad[i].y * hess1[i].y +
+                             grad[i].z * grad[i].z * hess1[i].z +
+                             2 * grad[i].x * grad[i].y * hess2[i].x +
+                             2 * grad[i].x * grad[i].z * hess2[i].y +
+                             2 * grad[i].y * grad[i].z * hess2[i].z));
+  }
 
-    // Free memory.
-    free(rho);
-    free(sigma);
-    free(exchange);
-    free(correlation);
+  // Free memory.
+  free(rho);
+  free(sigma);
+  free(exchange);
+  free(correlation);
 
-    // The outputs for exchange
-    free(vrho);
-    free(vsigma);
-    free(v2rho);
-    free(v2rhosigma);
-    free(v2sigma);
+  // The outputs for exchange
+  free(vrho);
+  free(vsigma);
+  free(v2rho);
+  free(v2rhosigma);
+  free(v2sigma);
 
-    // The outputs for correlation
-    free(vrhoC);
-    free(vsigmaC);
-    free(v2rhoC);
-    free(v2rhosigmaC);
-    free(v2sigmaC);
+  // The outputs for correlation
+  free(vrhoC);
+  free(vsigmaC);
+  free(v2rhoC);
+  free(v2rhosigmaC);
+  free(v2sigmaC);
 
-    return;
+  return;
 }
 
 //////////////////////////////////////////////////////////////
@@ -441,106 +414,81 @@ void LibxcProxy <T, width>::doGGA(T* dens,
 // rho: pointer for the density array.
 // sigma: contracted gradient array.
 // number_of_points: the size of all the input arrays.
-// v2rho2: second partial derivative of the energy per unit volume in terms of the density.
-// v2rhosigma: second partial derivative of the energy per unit volume in terms of the density and sigma.
-// v2sigma2: second partial derivative of the energy per unit volume in terms of sigma.
+// v2rho2: second partial derivative of the energy per unit volume in terms of
+// the density. v2rhosigma: second partial derivative of the energy per unit
+// volume in terms of the density and sigma. v2sigma2: second partial derivative
+// of the energy per unit volume in terms of sigma.
 //
 template <class T, int width>
-void LibxcProxy <T, width>::doGGA (T* rho,
-    T* sigma,
-    const int number_of_points,
-    T* v2rho2,
-    T* v2rhosigma,
-    T* v2sigma2)
-{
-    int array_size = sizeof(double)*number_of_points;
+void LibxcProxy<T, width>::doGGA(T* rho, T* sigma, const int number_of_points,
+                                 T* v2rho2, T* v2rhosigma, T* v2sigma2) {
+  int array_size = sizeof(double) * number_of_points;
 
-    // The outputs for exchange
-    double* v2rho2X = (double*)malloc(array_size);
-    double* v2rhosigmaX = (double*)malloc(array_size);
-    double* v2sigma2X = (double*)malloc(array_size);
+  // The outputs for exchange
+  double* v2rho2X = (double*)malloc(array_size);
+  double* v2rhosigmaX = (double*)malloc(array_size);
+  double* v2sigma2X = (double*)malloc(array_size);
 
-    // The outputs for correlation
-    double* v2rho2C = (double*)malloc(array_size);
-    double* v2rhosigmaC = (double*)malloc(array_size);
-    double* v2sigma2C = (double*)malloc(array_size);
+  // The outputs for correlation
+  double* v2rho2C = (double*)malloc(array_size);
+  double* v2rhosigmaC = (double*)malloc(array_size);
+  double* v2sigma2C = (double*)malloc(array_size);
 
-    // Exchange values
-    xc_gga_fxc (&funcForExchange, number_of_points,
-                rho,
-                sigma,
-                v2rho2X,
-                v2rhosigmaX,
-                v2sigma2X);
+  // Exchange values
+  xc_gga_fxc(&funcForExchange, number_of_points, rho, sigma, v2rho2X,
+             v2rhosigmaX, v2sigma2X);
 
-    // Now the correlation value.
-    xc_gga_fxc (&funcForCorrelation, number_of_points,
-                rho,
-                sigma,
-                v2rho2C,
-                v2rhosigmaC,
-                v2sigma2C);
+  // Now the correlation value.
+  xc_gga_fxc(&funcForCorrelation, number_of_points, rho, sigma, v2rho2C,
+             v2rhosigmaC, v2sigma2C);
 
-    for (int i=0; i<number_of_points; i++) {
-        // Merge the results for the derivatives.
-        v2rho2[i] = v2rho2X[i] + v2rho2C[i];
-        v2rhosigma[i] = v2rhosigmaX[i] + v2rhosigmaC[i];
-        v2sigma2[i] += v2sigma2X[i] + v2sigma2C[i];
-    }
+  for (int i = 0; i < number_of_points; i++) {
+    // Merge the results for the derivatives.
+    v2rho2[i] = v2rho2X[i] + v2rho2C[i];
+    v2rhosigma[i] = v2rhosigmaX[i] + v2rhosigmaC[i];
+    v2sigma2[i] += v2sigma2X[i] + v2sigma2C[i];
+  }
 
-    // Free memory
-    // The outputs for exchange
-    free(v2rho2X);
-    free(v2rhosigmaX);
-    free(v2sigma2X);
+  // Free memory
+  // The outputs for exchange
+  free(v2rho2X);
+  free(v2rhosigmaX);
+  free(v2sigma2X);
 
-    // The outputs for correlation
-    free(v2rho2C);
-    free(v2rhosigmaC);
-    free(v2sigma2C);
+  // The outputs for correlation
+  free(v2rho2C);
+  free(v2rhosigmaC);
+  free(v2sigma2C);
 
-    return;
+  return;
 }
 
 template <class T, int width>
-void LibxcProxy <T, width>::doGGA (T rho,
-               T sigma,
-               T* v2rho2,
-               T v2rhosigma,
-               T v2sigma2)
-{
-    const double dens = rho;
-    const double sig = sigma;
+void LibxcProxy<T, width>::doGGA(T rho, T sigma, T* v2rho2, T v2rhosigma,
+                                 T v2sigma2) {
+  const double dens = rho;
+  const double sig = sigma;
 
-    // The outputs for exchange
-    double v2rho2X = 0.0;
-    double v2rhosigmaX = 0.0;
-    double v2sigma2X = 0.0;
+  // The outputs for exchange
+  double v2rho2X = 0.0;
+  double v2rhosigmaX = 0.0;
+  double v2sigma2X = 0.0;
 
-    // The outputs for correlation
-    double v2rho2C = 0.0;
-    double v2rhosigmaC = 0.0;
-    double v2sigma2C = 0.0;
+  // The outputs for correlation
+  double v2rho2C = 0.0;
+  double v2rhosigmaC = 0.0;
+  double v2sigma2C = 0.0;
 
-    // Exchange values
-    xc_gga_fxc (&funcForExchange,1,
-                &dens,
-                &sig,
-                &v2rho2X,
-                &v2rhosigmaX,
-                &v2sigma2X);
+  // Exchange values
+  xc_gga_fxc(&funcForExchange, 1, &dens, &sig, &v2rho2X, &v2rhosigmaX,
+             &v2sigma2X);
 
-    // Correlation values
-    xc_gga_fxc (&funcForCorrelation,1,
-                &dens,
-                &sig,
-                &v2rho2C,
-                &v2rhosigmaC,
-                &v2sigma2C);
+  // Correlation values
+  xc_gga_fxc(&funcForCorrelation, 1, &dens, &sig, &v2rho2C, &v2rhosigmaC,
+             &v2sigma2C);
 
-
-    *v2rho2 = v2rho2C + v2rho2X;
-    return;
+  *v2rho2 = v2rho2C + v2rho2X;
+  return;
 }
 
 #ifdef __CUDACC__
@@ -552,113 +500,107 @@ void LibxcProxy <T, width>::doGGA (T rho,
 // calling Libxc.
 //
 template <class T, int width>
-__global__ void joinResults(
-		    double* ex, double* exchange,
-		    double* ec, double* correlation,
-		    double* vrho, double* vrhoC,
-		    double* vsigma, double* vsigmaC,
-		    double* v2rho, double* v2rhoC,
-		    double* v2rhosigma, double* v2rhosigmaC,
-		    double* v2sigma, double* v2sigmaC,
-		    double* y2a,
-		    const double* sigma,
-		    const G2G::vec_type<double, width>* grad,
-		    const G2G::vec_type<double, width>* hess1,
-		    const G2G::vec_type<double, width>* hess2,
-		    int numElements,double fEE)
-{
-    int i = blockDim.x * blockIdx.x + threadIdx.x;
+__global__ void joinResults(double* ex, double* exchange, double* ec,
+                            double* correlation, double* vrho, double* vrhoC,
+                            double* vsigma, double* vsigmaC, double* v2rho,
+                            double* v2rhoC, double* v2rhosigma,
+                            double* v2rhosigmaC, double* v2sigma,
+                            double* v2sigmaC, double* y2a, const double* sigma,
+                            const G2G::vec_type<double, width>* grad,
+                            const G2G::vec_type<double, width>* hess1,
+                            const G2G::vec_type<double, width>* hess2,
+                            int numElements, double fEE) {
+  int i = blockDim.x * blockIdx.x + threadIdx.x;
 
-    if (i < numElements)
-    {
-	ex[i] = fEE * exchange[i];
-	ec[i] = correlation[i];
+  if (i < numElements) {
+    ex[i] = fEE * exchange[i];
+    ec[i] = correlation[i];
 
-	// Merge the results for the derivatives.
-	vrho[i]       = fEE * vrho[i] + vrhoC[i];
-        vsigma[i]     = fEE * v2sigma[i] + vsigmaC[i];
-        v2rho[i]      = fEE * v2rho[i] + v2rhoC[i];
-        v2rhosigma[i] = fEE * v2rhosigma[i] + v2rhosigmaC[i];
-        v2sigma[i]    = fEE * v2sigma[i] + v2sigmaC[i];
-        // Now, compute y2a value.
-	y2a[i] = vrho[i] - (2 * sigma[i] * v2rhosigma[i]
-            + 2 * (hess1[i].x + hess1[i].y + hess1[i].z) * vsigma[i]
-            + 4 * v2sigma[i] * (grad[i].x * grad[i].x * hess1[i].x +
-					    grad[i].y * grad[i].y * hess1[i].y +
-					    grad[i].z * grad[i].z * hess1[i].z +
-					    2 * grad[i].x * grad[i].y * hess2[i].x +
-					    2 * grad[i].x * grad[i].z * hess2[i].y +
-					    2 * grad[i].y * grad[i].z * hess2[i].z));
-    }
+    // Merge the results for the derivatives.
+    vrho[i] = fEE * vrho[i] + vrhoC[i];
+    vsigma[i] = fEE * v2sigma[i] + vsigmaC[i];
+    v2rho[i] = fEE * v2rho[i] + v2rhoC[i];
+    v2rhosigma[i] = fEE * v2rhosigma[i] + v2rhosigmaC[i];
+    v2sigma[i] = fEE * v2sigma[i] + v2sigmaC[i];
+    // Now, compute y2a value.
+    y2a[i] = vrho[i] - (2 * sigma[i] * v2rhosigma[i] +
+                        2 * (hess1[i].x + hess1[i].y + hess1[i].z) * vsigma[i] +
+                        4 * v2sigma[i] *
+                            (grad[i].x * grad[i].x * hess1[i].x +
+                             grad[i].y * grad[i].y * hess1[i].y +
+                             grad[i].z * grad[i].z * hess1[i].z +
+                             2 * grad[i].x * grad[i].y * hess2[i].x +
+                             2 * grad[i].x * grad[i].z * hess2[i].y +
+                             2 * grad[i].y * grad[i].z * hess2[i].z));
+  }
 }
 
 /////////////////////////////////////
 // Conversion KERNELS
 //
 // Utils for data type conversion from lio to libxc
-__global__ void convertFloatToDouble(const float* input, double* output, int numElements)
-{
-    int i = blockDim.x * blockIdx.x + threadIdx.x;
-    if (i < numElements)
-    {
-	output[i] = (double)input[i];
-    }
+__global__ void convertFloatToDouble(const float* input, double* output,
+                                     int numElements) {
+  int i = blockDim.x * blockIdx.x + threadIdx.x;
+  if (i < numElements) {
+    output[i] = (double)input[i];
+  }
 }
 
-__global__ void convertDoubleToFloat(const double* input, float* output, int numElements)
-{
-    int i = blockDim.x * blockIdx.x + threadIdx.x;
-    if (i < numElements)
-    {
-	output[i] = (float)input[i];
-    }
+__global__ void convertDoubleToFloat(const double* input, float* output,
+                                     int numElements) {
+  int i = blockDim.x * blockIdx.x + threadIdx.x;
+  if (i < numElements) {
+    output[i] = (float)input[i];
+  }
 }
 
-__global__ void convertFloatToDouble(const G2G::vec_type<float,4>* input, G2G::vec_type<double,4>* output, int numElements)
-{
-    int i = blockDim.x * blockIdx.x + threadIdx.x;
-    if (i < numElements)
-    {
-	//float x, y, z, _w;
-	output[i].x = (double)(input[i].x);
-	output[i].y = (double)(input[i].y);
-	output[i].z = (double)(input[i].z);
-	output[i].w = (double)(input[i].w);
-    }
-}
-
-// Esto es para engañar al compilador pq el FLAG FULL_DOUBLE
-// a veces permite que T sea double y se rompe todo.
-__global__ void convertDoubleToFloat(const double* input, double* output, int numElements)
-{
-    return;
+__global__ void convertFloatToDouble(const G2G::vec_type<float, 4>* input,
+                                     G2G::vec_type<double, 4>* output,
+                                     int numElements) {
+  int i = blockDim.x * blockIdx.x + threadIdx.x;
+  if (i < numElements) {
+    // float x, y, z, _w;
+    output[i].x = (double)(input[i].x);
+    output[i].y = (double)(input[i].y);
+    output[i].z = (double)(input[i].z);
+    output[i].w = (double)(input[i].w);
+  }
 }
 
 // Esto es para engañar al compilador pq el FLAG FULL_DOUBLE
 // a veces permite que T sea double y se rompe todo.
-__global__ void convertFloatToDouble(const double* input, double* output, int numElements)
-{
-    return;
+__global__ void convertDoubleToFloat(const double* input, double* output,
+                                     int numElements) {
+  return;
 }
 
 // Esto es para engañar al compilador pq el FLAG FULL_DOUBLE
 // a veces permite que T sea double y se rompe todo.
-__global__ void convertFloatToDouble(const G2G::vec_type<double,4>* input, G2G::vec_type<double,4>* output, int numElements)
-{
-    return;
+__global__ void convertFloatToDouble(const double* input, double* output,
+                                     int numElements) {
+  return;
 }
 
-__global__ void convertDoubleToFloat(const G2G::vec_type<double,4>* input, G2G::vec_type<float,4>* output, int numElements)
-{
-    int i = blockDim.x * blockIdx.x + threadIdx.x;
-    if (i < numElements)
-    {
-	//float x, y, z, _w;
-	output[i].x = (float)(input[i].x);
-	output[i].y = (float)(input[i].y);
-	output[i].z = (float)(input[i].z);
-	output[i].w = (float)(input[i].w);
-    }
+// Esto es para engañar al compilador pq el FLAG FULL_DOUBLE
+// a veces permite que T sea double y se rompe todo.
+__global__ void convertFloatToDouble(const G2G::vec_type<double, 4>* input,
+                                     G2G::vec_type<double, 4>* output,
+                                     int numElements) {
+  return;
+}
+
+__global__ void convertDoubleToFloat(const G2G::vec_type<double, 4>* input,
+                                     G2G::vec_type<float, 4>* output,
+                                     int numElements) {
+  int i = blockDim.x * blockIdx.x + threadIdx.x;
+  if (i < numElements) {
+    // float x, y, z, _w;
+    output[i].x = (float)(input[i].x);
+    output[i].y = (float)(input[i].y);
+    output[i].z = (float)(input[i].z);
+    output[i].w = (float)(input[i].w);
+  }
 }
 
 // end Conversion KERNELS
@@ -666,596 +608,604 @@ __global__ void convertDoubleToFloat(const G2G::vec_type<double,4>* input, G2G::
 
 #endif
 
-
 template <class T, int width>
-void LibxcProxy <T, width>::coefLR (double *rho,
-                double* sigma,
-                double red,
-                double cruz,
-                double* lrCoef)
-{
-    //All outputs
-    double vrho=0.0f;
-    double vsigma=0.0f;
-    double v2rho2=0.0f;
-    double v2rhosigma=0.0f;
-    double v2sigma2=0.0f;
+void LibxcProxy<T, width>::coefLR(double* rho, double* sigma, double red,
+                                  double cruz, double* lrCoef) {
+  // All outputs
+  double vrho = 0.0f;
+  double vsigma = 0.0f;
+  double v2rho2 = 0.0f;
+  double v2rhosigma = 0.0f;
+  double v2sigma2 = 0.0f;
 
-    // Functional outputs
-    double lenergy[1];
-    double lvrho[1];
-    double lvsigma[1];
-    double lv2rho2[1];
-    double lv2rhosigma[1];
-    double lv2sigma2[1];
+  // Functional outputs
+  double lenergy[1];
+  double lvrho[1];
+  double lvsigma[1];
+  double lv2rho2[1];
+  double lv2rhosigma[1];
+  double lv2sigma2[1];
 
-    double cc = 0.0f;
+  double cc = 0.0f;
 
-    // Exchange Calculation
-    for (int ii=0; ii<nxcoef; ii++) {
-        // Set zero values
-        lenergy[0]  = 0.0f;
-        lvrho[0]    = 0.0f;
-        lv2rho2[0]  = 0.0f;
-        lvsigma[0]  = 0.0f;
-        lv2rhosigma[0] = 0.0f;
-        lv2sigma2[0]   = 0.0f;
+  // Exchange Calculation
+  for (int ii = 0; ii < nxcoef; ii++) {
+    // Set zero values
+    lenergy[0] = 0.0f;
+    lvrho[0] = 0.0f;
+    lv2rho2[0] = 0.0f;
+    lvsigma[0] = 0.0f;
+    lv2rhosigma[0] = 0.0f;
+    lv2sigma2[0] = 0.0f;
 
-        switch( (&funcsId[ii])->info->family ) {
-           case (XC_FAMILY_LDA):
-              xc_lda(&funcsId[ii],1,rho,lenergy,lvrho,lv2rho2,
-                     NULL,
-                     NULL); break;
-           case (XC_FAMILY_GGA):
-              xc_gga(&funcsId[ii],1,rho,sigma,lenergy,lvrho,lvsigma,
-                     lv2rho2,lv2rhosigma,lv2sigma2,
-                     NULL,NULL,NULL,NULL,
-                     NULL,NULL,NULL,NULL,NULL); break;
-           default:
-             printf("Unidentified Family Functional\n");
-             exit(-1); break;
+    switch ((&funcsId[ii])->info->family) {
+      case (XC_FAMILY_LDA):
+        xc_lda(&funcsId[ii], 1, rho, lenergy, lvrho, lv2rho2, NULL, NULL);
+        break;
+      case (XC_FAMILY_GGA):
+        xc_gga(&funcsId[ii], 1, rho, sigma, lenergy, lvrho, lvsigma, lv2rho2,
+               lv2rhosigma, lv2sigma2, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+               NULL, NULL);
+        break;
+      default:
+        printf("Unidentified Family Functional\n");
+        exit(-1);
+        break;
 
-        } // end switch
+    }  // end switch
 
-        cc = funcsCoef[ii];
-        vrho       += cc*lvrho[0];
-        v2rho2     += cc*lv2rho2[0];
-        vsigma     += cc*lvsigma[0];
-        v2rhosigma += cc*lv2rhosigma[0];
-        v2sigma2   += cc*lv2sigma2[0];
-    } // end exchange
+    cc = funcsCoef[ii];
+    vrho += cc * lvrho[0];
+    v2rho2 += cc * lv2rho2[0];
+    vsigma += cc * lvsigma[0];
+    v2rhosigma += cc * lv2rhosigma[0];
+    v2sigma2 += cc * lv2sigma2[0];
+  }  // end exchange
 
-    // Correlation Calculation
-    for (int ii=nxcoef; ii<ntotal_funcs; ii++) {
-        // Set zero values
-        lenergy[0]  = 0.0f;
-        lvrho[0]    = 0.0f;
-        lv2rho2[0]  = 0.0f;
-        lvsigma[0]  = 0.0f;
-        lv2rhosigma[0] = 0.0f;
-        lv2sigma2[0]   = 0.0f;
+  // Correlation Calculation
+  for (int ii = nxcoef; ii < ntotal_funcs; ii++) {
+    // Set zero values
+    lenergy[0] = 0.0f;
+    lvrho[0] = 0.0f;
+    lv2rho2[0] = 0.0f;
+    lvsigma[0] = 0.0f;
+    lv2rhosigma[0] = 0.0f;
+    lv2sigma2[0] = 0.0f;
 
-        switch( (&funcsId[ii])->info->family ) {
-           case (XC_FAMILY_LDA):
-              xc_lda(&funcsId[ii],1,rho,lenergy,lvrho,lv2rho2,
-                     NULL,
-                     NULL); break;
-           case (XC_FAMILY_GGA):
-              xc_gga(&funcsId[ii],1,rho,sigma,lenergy,lvrho,lvsigma,
-                     lv2rho2,lv2rhosigma,lv2sigma2,
-                     NULL,NULL,NULL,NULL,
-                     NULL,NULL,NULL,NULL,NULL); break;
-           default:
-             printf("Unidentified Family Functional\n");
-             exit(-1); break;
+    switch ((&funcsId[ii])->info->family) {
+      case (XC_FAMILY_LDA):
+        xc_lda(&funcsId[ii], 1, rho, lenergy, lvrho, lv2rho2, NULL, NULL);
+        break;
+      case (XC_FAMILY_GGA):
+        xc_gga(&funcsId[ii], 1, rho, sigma, lenergy, lvrho, lvsigma, lv2rho2,
+               lv2rhosigma, lv2sigma2, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+               NULL, NULL);
+        break;
+      default:
+        printf("Unidentified Family Functional\n");
+        exit(-1);
+        break;
 
-        } // end switch
+    }  // end switch
 
-        cc = funcsCoef[ii];
-        vrho       += cc*lvrho[0];
-        v2rho2     += cc*lv2rho2[0];
-        vsigma     += cc*lvsigma[0];
-        v2rhosigma += cc*lv2rhosigma[0];
-        v2sigma2   += cc*lv2sigma2[0];
-    } // end correlation
+    cc = funcsCoef[ii];
+    vrho += cc * lvrho[0];
+    v2rho2 += cc * lv2rho2[0];
+    vsigma += cc * lvsigma[0];
+    v2rhosigma += cc * lv2rhosigma[0];
+    v2sigma2 += cc * lv2sigma2[0];
+  }  // end correlation
 
-   // Results
-   lrCoef[0] = 2.0f * red * v2rho2  + 8.0f * cruz * v2rhosigma ;
-   lrCoef[1] = 8.0f * red * v2rhosigma  + 32.0f * cruz * v2sigma2 ;
-   lrCoef[2] = 4.0f * vsigma ;
+  // Results
+  lrCoef[0] = 2.0f * red * v2rho2 + 8.0f * cruz * v2rhosigma;
+  lrCoef[1] = 8.0f * red * v2rhosigma + 32.0f * cruz * v2sigma2;
+  lrCoef[2] = 4.0f * vsigma;
 
-   return;
+  return;
 }
 
 template <class T, int width>
 void LibxcProxy<T, width>::Zv_exchange(double td, double* dxyz, double* txyz,
-           double* Coef, double v2rho2, double v2rhosigma, double v2sigma2,
-           double v3rho3,double v3rho2sigma,double v3rhosigma2,double v3sigma3)
-{
-   double DUMNV[2],DXV[2],DYV[2],DZV[2],DUMGRV[4],DUMXX[4];
-   double C[10];
+                                       double* Coef, double v2rho2,
+                                       double v2rhosigma, double v2sigma2,
+                                       double v3rho3, double v3rho2sigma,
+                                       double v3rhosigma2, double v3sigma3) {
+  double DUMNV[2], DXV[2], DYV[2], DZV[2], DUMGRV[4], DUMXX[4];
+  double C[10];
 
-   DUMNV[0] = DUMNV[1] = td;
+  DUMNV[0] = DUMNV[1] = td;
 
-   DUMGRV[0]=DUMGRV[1]=txyz[0]*dxyz[0]*0.5f + txyz[1]*dxyz[1]*0.5f + txyz[2]*dxyz[2]*0.5f;
-   DUMGRV[2]=DUMGRV[3]=DUMGRV[0];
+  DUMGRV[0] = DUMGRV[1] = txyz[0] * dxyz[0] * 0.5f + txyz[1] * dxyz[1] * 0.5f +
+                          txyz[2] * dxyz[2] * 0.5f;
+  DUMGRV[2] = DUMGRV[3] = DUMGRV[0];
 
-   DUMXX[0]=DUMXX[1]=txyz[0]*txyz[0] + txyz[1]*txyz[1] + txyz[2]*txyz[2];
-   DUMXX[2]=DUMXX[3]=DUMXX[0];
+  DUMXX[0] = DUMXX[1] =
+      txyz[0] * txyz[0] + txyz[1] * txyz[1] + txyz[2] * txyz[2];
+  DUMXX[2] = DUMXX[3] = DUMXX[0];
 
-   C[0]=2.0f*DUMXX[0];
-   C[1]=DUMNV[0]*DUMNV[0];
-   C[2]=2.0f*DUMNV[0]*DUMGRV[0];
-   C[3]=2.0f*DUMGRV[0]*DUMNV[0];
-   C[4]=DUMGRV[0]*DUMNV[0];
-   C[5]=DUMNV[0]*DUMGRV[0];
-   C[6]=4.0f*DUMGRV[0]*DUMGRV[0];
-   C[7]=2.0f*DUMGRV[0]*DUMGRV[0];
-   C[8]=2.0f*DUMGRV[0]*DUMGRV[0];
-   C[9]=DUMGRV[0]*DUMGRV[0];
+  C[0] = 2.0f * DUMXX[0];
+  C[1] = DUMNV[0] * DUMNV[0];
+  C[2] = 2.0f * DUMNV[0] * DUMGRV[0];
+  C[3] = 2.0f * DUMGRV[0] * DUMNV[0];
+  C[4] = DUMGRV[0] * DUMNV[0];
+  C[5] = DUMNV[0] * DUMGRV[0];
+  C[6] = 4.0f * DUMGRV[0] * DUMGRV[0];
+  C[7] = 2.0f * DUMGRV[0] * DUMGRV[0];
+  C[8] = 2.0f * DUMGRV[0] * DUMGRV[0];
+  C[9] = DUMGRV[0] * DUMGRV[0];
 
-   double XDUMA=0.0f;
-   double XDUMAG=0.0f;
-   XDUMA  = C[0] * 4.00f * v2rhosigma;
-   XDUMAG = C[0] * 16.0f * v2sigma2;
-   XDUMA += C[1] * 4.00f * v3rho3;
-   XDUMAG+= C[1] * 16.0f * v3rho2sigma;
-   XDUMA += C[2] * 8.00f * v3rho2sigma;
-   XDUMAG+= C[2] * 32.0f * v3rhosigma2;
-   XDUMA += C[3] * 8.00f * v3rho2sigma;
-   XDUMAG+= C[3] * 32.0f * v3rhosigma2;
-   XDUMA += C[6] * 16.0f * v3rhosigma2;
-   XDUMAG+= C[6] * 64.0f * v3sigma3;
+  double XDUMA = 0.0f;
+  double XDUMAG = 0.0f;
+  XDUMA = C[0] * 4.00f * v2rhosigma;
+  XDUMAG = C[0] * 16.0f * v2sigma2;
+  XDUMA += C[1] * 4.00f * v3rho3;
+  XDUMAG += C[1] * 16.0f * v3rho2sigma;
+  XDUMA += C[2] * 8.00f * v3rho2sigma;
+  XDUMAG += C[2] * 32.0f * v3rhosigma2;
+  XDUMA += C[3] * 8.00f * v3rho2sigma;
+  XDUMAG += C[3] * 32.0f * v3rhosigma2;
+  XDUMA += C[6] * 16.0f * v3rhosigma2;
+  XDUMAG += C[6] * 64.0f * v3sigma3;
 
-   double XDUMAGEA=0.0f;
-   XDUMAGEA  = 4.0f * DUMNV[0]  * 4.0f * v2rhosigma;
-   XDUMAGEA += 8.0f * DUMGRV[1] * 8.0f * v2sigma2;
+  double XDUMAGEA = 0.0f;
+  XDUMAGEA = 4.0f * DUMNV[0] * 4.0f * v2rhosigma;
+  XDUMAGEA += 8.0f * DUMGRV[1] * 8.0f * v2sigma2;
 
-   Coef[0] = XDUMA;
-   Coef[1] = XDUMAG;
-   Coef[2] = XDUMAGEA;
-
+  Coef[0] = XDUMA;
+  Coef[1] = XDUMAG;
+  Coef[2] = XDUMAGEA;
 }
 
 template <class T, int width>
-void LibxcProxy<T, width>::Zv_coulomb(double td,double* dxyz,double* txyz, double* Coef, 
-                double v2rhosigma, double v2sigma2,double v3rho3,
-                double v3rho2sigma,double v3rhosigma2,double v3sigma3)
-{
-   double DUMNV[2],DXV[2],DYV[2],DZV[2],DUMGRV[4],DUMXX[4];
-   double C[20];
+void LibxcProxy<T, width>::Zv_coulomb(double td, double* dxyz, double* txyz,
+                                      double* Coef, double v2rhosigma,
+                                      double v2sigma2, double v3rho3,
+                                      double v3rho2sigma, double v3rhosigma2,
+                                      double v3sigma3) {
+  double DUMNV[2], DXV[2], DYV[2], DZV[2], DUMGRV[4], DUMXX[4];
+  double C[20];
 
-   DUMNV[0] = DUMNV[1] = td;
+  DUMNV[0] = DUMNV[1] = td;
 
-   DUMGRV[0]=DUMGRV[1]=txyz[0]*dxyz[0]*0.5f + txyz[1]*dxyz[1]*0.5f + txyz[2]*dxyz[2]*0.5f;
-   DUMGRV[2]=DUMGRV[3]=DUMGRV[0];
+  DUMGRV[0] = DUMGRV[1] = txyz[0] * dxyz[0] * 0.5f + txyz[1] * dxyz[1] * 0.5f +
+                          txyz[2] * dxyz[2] * 0.5f;
+  DUMGRV[2] = DUMGRV[3] = DUMGRV[0];
 
-   DUMXX[0]=DUMXX[1]=txyz[0]*txyz[0] + txyz[1]*txyz[1] + txyz[2]*txyz[2];
-   DUMXX[2]=DUMXX[3]=DUMXX[0];
+  DUMXX[0] = DUMXX[1] =
+      txyz[0] * txyz[0] + txyz[1] * txyz[1] + txyz[2] * txyz[2];
+  DUMXX[2] = DUMXX[3] = DUMXX[0];
 
-   C[0]=2.0f*DUMXX[0];
-   C[1]=DUMNV[0]*DUMNV[0];
-   C[2]=2.0f*DUMNV[0]*DUMGRV[0];
-   C[3]=2.0f*DUMGRV[0]*DUMNV[0];
-   C[4]=DUMGRV[0]*DUMNV[0];
-   C[5]=DUMNV[0]*DUMGRV[0];
-   C[6]=4.0f*DUMGRV[0]*DUMGRV[0];
-   C[7]=2.0f*DUMGRV[0]*DUMGRV[0];
-   C[8]=2.0f*DUMGRV[0]*DUMGRV[0];
-   C[9]=DUMGRV[0]*DUMGRV[0];
+  C[0] = 2.0f * DUMXX[0];
+  C[1] = DUMNV[0] * DUMNV[0];
+  C[2] = 2.0f * DUMNV[0] * DUMGRV[0];
+  C[3] = 2.0f * DUMGRV[0] * DUMNV[0];
+  C[4] = DUMGRV[0] * DUMNV[0];
+  C[5] = DUMNV[0] * DUMGRV[0];
+  C[6] = 4.0f * DUMGRV[0] * DUMGRV[0];
+  C[7] = 2.0f * DUMGRV[0] * DUMGRV[0];
+  C[8] = 2.0f * DUMGRV[0] * DUMGRV[0];
+  C[9] = DUMGRV[0] * DUMGRV[0];
 
-   double CDUMA=0.0f;
-   double CDUMAG1=0.0f;
-   double CDUMAG2=0.0f;
-   CDUMA=C[0]*v2rhosigma;
-   CDUMAG1=C[0]*2.0f*v2sigma2;
-   CDUMAG2=C[0]*v2sigma2*2.0f;
-   CDUMA=CDUMA+C[1]*v3rho3;
-   CDUMAG1=CDUMAG1+C[1]*2.0f*v3rho2sigma;
-   CDUMAG2=CDUMAG2+C[1]*v3rho2sigma*2.0f;
-   CDUMA=CDUMA+C[2]*v3rho2sigma;
-   CDUMAG1=CDUMAG1+C[2]*2.0f*v3rhosigma2;
-   CDUMAG2=CDUMAG2+C[2]*v3rhosigma2*2.0f;
-   CDUMA=CDUMA+C[3]*v3rho2sigma;
-   CDUMAG1=CDUMAG1+C[3]*2.0f*v3rhosigma2;
-   CDUMAG2=CDUMAG2+C[3]*v3rhosigma2*2.0f;
-   CDUMA=CDUMA+C[4]*v3rho2sigma*2.0f;
-   CDUMAG1=CDUMAG1+C[4]*2.0f*v3rhosigma2*2.0f;
-   CDUMAG2=CDUMAG2+C[4]*v3rhosigma2*4.0f;
-   CDUMA=CDUMA+C[5]*v3rho2sigma*2.0f;
-   CDUMAG1=CDUMAG1+C[5]*2.0f*v3rhosigma2*2.0f;
-   CDUMAG2=CDUMAG2+C[5]*v3rhosigma2*4.0f;
-   CDUMA=CDUMA+C[6]*v3rhosigma2;
-   CDUMAG1=CDUMAG1+C[6]*2.0f*v3sigma3;
-   CDUMAG2=CDUMAG2+C[6]*v3sigma3*2.0f;
-   CDUMA=CDUMA+C[7]*v3rhosigma2*2.0f;
-   CDUMAG1=CDUMAG1+C[7]*2.0f*v3sigma3*2.0f;
-   CDUMAG2=CDUMAG2+C[7]*v3sigma3*4.0f;
-   CDUMA=CDUMA+C[8]*v3rhosigma2*2.0f;
-   CDUMAG1=CDUMAG1+C[8]*2.0f*v3sigma3*2.0f;
-   CDUMAG2=CDUMAG2+C[8]*v3sigma3*4.0f;
-   CDUMA=CDUMA+C[9]*v3rhosigma2*4.0f;
-   CDUMAG1=CDUMAG1+C[9]*2.0f*v3sigma3*4.0f;
-   CDUMAG2=CDUMAG2+C[9]*v3sigma3*8.0f;
+  double CDUMA = 0.0f;
+  double CDUMAG1 = 0.0f;
+  double CDUMAG2 = 0.0f;
+  CDUMA = C[0] * v2rhosigma;
+  CDUMAG1 = C[0] * 2.0f * v2sigma2;
+  CDUMAG2 = C[0] * v2sigma2 * 2.0f;
+  CDUMA = CDUMA + C[1] * v3rho3;
+  CDUMAG1 = CDUMAG1 + C[1] * 2.0f * v3rho2sigma;
+  CDUMAG2 = CDUMAG2 + C[1] * v3rho2sigma * 2.0f;
+  CDUMA = CDUMA + C[2] * v3rho2sigma;
+  CDUMAG1 = CDUMAG1 + C[2] * 2.0f * v3rhosigma2;
+  CDUMAG2 = CDUMAG2 + C[2] * v3rhosigma2 * 2.0f;
+  CDUMA = CDUMA + C[3] * v3rho2sigma;
+  CDUMAG1 = CDUMAG1 + C[3] * 2.0f * v3rhosigma2;
+  CDUMAG2 = CDUMAG2 + C[3] * v3rhosigma2 * 2.0f;
+  CDUMA = CDUMA + C[4] * v3rho2sigma * 2.0f;
+  CDUMAG1 = CDUMAG1 + C[4] * 2.0f * v3rhosigma2 * 2.0f;
+  CDUMAG2 = CDUMAG2 + C[4] * v3rhosigma2 * 4.0f;
+  CDUMA = CDUMA + C[5] * v3rho2sigma * 2.0f;
+  CDUMAG1 = CDUMAG1 + C[5] * 2.0f * v3rhosigma2 * 2.0f;
+  CDUMAG2 = CDUMAG2 + C[5] * v3rhosigma2 * 4.0f;
+  CDUMA = CDUMA + C[6] * v3rhosigma2;
+  CDUMAG1 = CDUMAG1 + C[6] * 2.0f * v3sigma3;
+  CDUMAG2 = CDUMAG2 + C[6] * v3sigma3 * 2.0f;
+  CDUMA = CDUMA + C[7] * v3rhosigma2 * 2.0f;
+  CDUMAG1 = CDUMAG1 + C[7] * 2.0f * v3sigma3 * 2.0f;
+  CDUMAG2 = CDUMAG2 + C[7] * v3sigma3 * 4.0f;
+  CDUMA = CDUMA + C[8] * v3rhosigma2 * 2.0f;
+  CDUMAG1 = CDUMAG1 + C[8] * 2.0f * v3sigma3 * 2.0f;
+  CDUMAG2 = CDUMAG2 + C[8] * v3sigma3 * 4.0f;
+  CDUMA = CDUMA + C[9] * v3rhosigma2 * 4.0f;
+  CDUMAG1 = CDUMAG1 + C[9] * 2.0f * v3sigma3 * 4.0f;
+  CDUMAG2 = CDUMAG2 + C[9] * v3sigma3 * 8.0f;
 
-   C[0]=2.0f*DUMXX[1];
-   C[1]=DUMNV[1]*DUMNV[1];
-   C[2]=2.0f*DUMNV[1]*DUMGRV[1];
-   C[3]=2.0f*DUMGRV[1]*DUMNV[1];
-   C[4]=DUMGRV[1]*DUMNV[1];
-   C[5]=DUMNV[1]*DUMGRV[1];
-   C[6]=4.0f*DUMGRV[1]*DUMGRV[1];
-   C[7]=2.0f*DUMGRV[1]*DUMGRV[1];
-   C[8]=2.0f*DUMGRV[1]*DUMGRV[1];
-   C[9]=DUMGRV[1]*DUMGRV[1];
+  C[0] = 2.0f * DUMXX[1];
+  C[1] = DUMNV[1] * DUMNV[1];
+  C[2] = 2.0f * DUMNV[1] * DUMGRV[1];
+  C[3] = 2.0f * DUMGRV[1] * DUMNV[1];
+  C[4] = DUMGRV[1] * DUMNV[1];
+  C[5] = DUMNV[1] * DUMGRV[1];
+  C[6] = 4.0f * DUMGRV[1] * DUMGRV[1];
+  C[7] = 2.0f * DUMGRV[1] * DUMGRV[1];
+  C[8] = 2.0f * DUMGRV[1] * DUMGRV[1];
+  C[9] = DUMGRV[1] * DUMGRV[1];
 
-   CDUMA=CDUMA+C[0]*v2rhosigma;
-   CDUMAG1=CDUMAG1+C[0]*2.0f*v2sigma2;
-   CDUMAG2=CDUMAG2+C[0]*v2sigma2*2.0f;
-   CDUMA=CDUMA+C[1]*v3rho3;
-   CDUMAG1=CDUMAG1+C[1]*2.0f*v3rho2sigma;
-   CDUMAG2=CDUMAG2+C[1]*v3rho2sigma*2.0f;
-   CDUMA=CDUMA+C[2]*v3rho2sigma;
-   CDUMAG1=CDUMAG1+C[2]*2.0f*v3rhosigma2;
-   CDUMAG2=CDUMAG2+C[2]*v3rhosigma2*2.0f;
-   CDUMA=CDUMA+C[3]*v3rho2sigma;
-   CDUMAG1=CDUMAG1+C[3]*2.0f*v3rhosigma2;
-   CDUMAG2=CDUMAG2+C[3]*v3rhosigma2*2.0f;
-   CDUMA=CDUMA+C[4]*v3rho2sigma*2.0f;
-   CDUMAG1=CDUMAG1+C[4]*2.0f*v3rhosigma2*2.0f;
-   CDUMAG2=CDUMAG2+C[4]*v3rhosigma2*4.0f;
-   CDUMA=CDUMA+C[5]*v3rho2sigma*2.0f;
-   CDUMAG1=CDUMAG1+C[5]*2.0f*v3rhosigma2*2.0f;
-   CDUMAG2=CDUMAG2+C[5]*v3rhosigma2*4.0f;
-   CDUMA=CDUMA+C[6]*v3rhosigma2;
-   CDUMAG1=CDUMAG1+C[6]*2.0f*v3sigma3;
-   CDUMAG2=CDUMAG2+C[6]*v3sigma3*2.0f;
-   CDUMA=CDUMA+C[7]*v3rhosigma2*2.0f;
-   CDUMAG1=CDUMAG1+C[7]*2.0f*v3sigma3*2.0f;
-   CDUMAG2=CDUMAG2+C[7]*v3sigma3*4.0f;
-   CDUMA=CDUMA+C[8]*v3rhosigma2*2.0f;
-   CDUMAG1=CDUMAG1+C[8]*2.0f*v3sigma3*2.0f;
-   CDUMAG2=CDUMAG2+C[8]*v3sigma3*4.0f;
-   CDUMA=CDUMA+C[9]*v3rhosigma2*4.0f;
-   CDUMAG1=CDUMAG1+C[9]*2.0f*v3sigma3*4.0f;
-   CDUMAG2=CDUMAG2+C[9]*v3sigma3*8.0f;
+  CDUMA = CDUMA + C[0] * v2rhosigma;
+  CDUMAG1 = CDUMAG1 + C[0] * 2.0f * v2sigma2;
+  CDUMAG2 = CDUMAG2 + C[0] * v2sigma2 * 2.0f;
+  CDUMA = CDUMA + C[1] * v3rho3;
+  CDUMAG1 = CDUMAG1 + C[1] * 2.0f * v3rho2sigma;
+  CDUMAG2 = CDUMAG2 + C[1] * v3rho2sigma * 2.0f;
+  CDUMA = CDUMA + C[2] * v3rho2sigma;
+  CDUMAG1 = CDUMAG1 + C[2] * 2.0f * v3rhosigma2;
+  CDUMAG2 = CDUMAG2 + C[2] * v3rhosigma2 * 2.0f;
+  CDUMA = CDUMA + C[3] * v3rho2sigma;
+  CDUMAG1 = CDUMAG1 + C[3] * 2.0f * v3rhosigma2;
+  CDUMAG2 = CDUMAG2 + C[3] * v3rhosigma2 * 2.0f;
+  CDUMA = CDUMA + C[4] * v3rho2sigma * 2.0f;
+  CDUMAG1 = CDUMAG1 + C[4] * 2.0f * v3rhosigma2 * 2.0f;
+  CDUMAG2 = CDUMAG2 + C[4] * v3rhosigma2 * 4.0f;
+  CDUMA = CDUMA + C[5] * v3rho2sigma * 2.0f;
+  CDUMAG1 = CDUMAG1 + C[5] * 2.0f * v3rhosigma2 * 2.0f;
+  CDUMAG2 = CDUMAG2 + C[5] * v3rhosigma2 * 4.0f;
+  CDUMA = CDUMA + C[6] * v3rhosigma2;
+  CDUMAG1 = CDUMAG1 + C[6] * 2.0f * v3sigma3;
+  CDUMAG2 = CDUMAG2 + C[6] * v3sigma3 * 2.0f;
+  CDUMA = CDUMA + C[7] * v3rhosigma2 * 2.0f;
+  CDUMAG1 = CDUMAG1 + C[7] * 2.0f * v3sigma3 * 2.0f;
+  CDUMAG2 = CDUMAG2 + C[7] * v3sigma3 * 4.0f;
+  CDUMA = CDUMA + C[8] * v3rhosigma2 * 2.0f;
+  CDUMAG1 = CDUMAG1 + C[8] * 2.0f * v3sigma3 * 2.0f;
+  CDUMAG2 = CDUMAG2 + C[8] * v3sigma3 * 4.0f;
+  CDUMA = CDUMA + C[9] * v3rhosigma2 * 4.0f;
+  CDUMAG1 = CDUMAG1 + C[9] * 2.0f * v3sigma3 * 4.0f;
+  CDUMAG2 = CDUMAG2 + C[9] * v3sigma3 * 8.0f;
 
-   C[10]=DUMXX[2];
-   C[11]=DUMNV[0]*DUMNV[1];
-   C[12]=2.0f*DUMNV[0]*DUMGRV[1];
-   C[13]=2.0f*DUMGRV[0]*DUMNV[1];
-   C[14]=DUMNV[0]*DUMGRV[3];
-   C[15]=DUMGRV[2]*DUMNV[1];
-   C[16]=4.0f*DUMGRV[0]*DUMGRV[1];
-   C[17]=2.0f*DUMGRV[0]*DUMGRV[3];
-   C[18]=2.0f*DUMGRV[2]*DUMGRV[1];
-   C[19]=DUMGRV[2]*DUMGRV[3];
+  C[10] = DUMXX[2];
+  C[11] = DUMNV[0] * DUMNV[1];
+  C[12] = 2.0f * DUMNV[0] * DUMGRV[1];
+  C[13] = 2.0f * DUMGRV[0] * DUMNV[1];
+  C[14] = DUMNV[0] * DUMGRV[3];
+  C[15] = DUMGRV[2] * DUMNV[1];
+  C[16] = 4.0f * DUMGRV[0] * DUMGRV[1];
+  C[17] = 2.0f * DUMGRV[0] * DUMGRV[3];
+  C[18] = 2.0f * DUMGRV[2] * DUMGRV[1];
+  C[19] = DUMGRV[2] * DUMGRV[3];
 
-   CDUMA=CDUMA+C[10]*v2rhosigma*2.0f;
-   CDUMAG1=CDUMAG1+C[10]*2.0f*v2sigma2*2.0f;
-   CDUMAG2=CDUMAG2+C[10]*v2sigma2*4.0f;
-   CDUMA=CDUMA+C[11]*v3rho3;
-   CDUMAG1=CDUMAG1+C[11]*2.0f*v3rho2sigma;
-   CDUMAG2=CDUMAG2+C[11]*v3rho2sigma*2.0f;
-   CDUMA=CDUMA+C[12]*v3rho2sigma;
-   CDUMAG1=CDUMAG1+C[12]*2.0f*v3rhosigma2;
-   CDUMAG2=CDUMAG2+C[12]*v3rhosigma2*2.0f;
-   CDUMA=CDUMA+C[13]*v3rho2sigma;
-   CDUMAG1=CDUMAG1+C[13]*2.0f*v3rhosigma2;
-   CDUMAG2=CDUMAG2+C[13]*v3rhosigma2*2.0f;
-   CDUMA=CDUMA+C[14]*v3rho2sigma*2.0f;
-   CDUMAG1=CDUMAG1+C[14]*2.0f*v3rhosigma2*2.0f;
-   CDUMAG2=CDUMAG2+C[14]*v3rhosigma2*4.0f;
-   CDUMA=CDUMA+C[15]*v3rho2sigma*2.0f;
-   CDUMAG1=CDUMAG1+C[15]*2.0f*v3rhosigma2*2.0f;
-   CDUMAG2=CDUMAG2+C[15]*v3rhosigma2*4.0f;
-   CDUMA=CDUMA+C[16]*v3rhosigma2;
-   CDUMAG1=CDUMAG1+C[16]*2.0f*v3sigma3;
-   CDUMAG2=CDUMAG2+C[16]*v3sigma3*2.0f;
-   CDUMA=CDUMA+C[17]*v3rhosigma2*2.0f;
-   CDUMAG1=CDUMAG1+C[17]*2.0f*v3sigma3*2.0f;
-   CDUMAG2=CDUMAG2+C[17]*v3sigma3*4.0f;
-   CDUMA=CDUMA+C[18]*v3rhosigma2*2.0f;
-   CDUMAG1=CDUMAG1+C[18]*2.0f*v3sigma3*2.0f;
-   CDUMAG2=CDUMAG2+C[18]*v3sigma3*4.0f;
-   CDUMA=CDUMA+C[19]*v3rhosigma2*4.0f;
-   CDUMAG1=CDUMAG1+C[19]*2.0f*v3sigma3*4.0f;
-   CDUMAG2=CDUMAG2+C[19]*v3sigma3*8.0f;
+  CDUMA = CDUMA + C[10] * v2rhosigma * 2.0f;
+  CDUMAG1 = CDUMAG1 + C[10] * 2.0f * v2sigma2 * 2.0f;
+  CDUMAG2 = CDUMAG2 + C[10] * v2sigma2 * 4.0f;
+  CDUMA = CDUMA + C[11] * v3rho3;
+  CDUMAG1 = CDUMAG1 + C[11] * 2.0f * v3rho2sigma;
+  CDUMAG2 = CDUMAG2 + C[11] * v3rho2sigma * 2.0f;
+  CDUMA = CDUMA + C[12] * v3rho2sigma;
+  CDUMAG1 = CDUMAG1 + C[12] * 2.0f * v3rhosigma2;
+  CDUMAG2 = CDUMAG2 + C[12] * v3rhosigma2 * 2.0f;
+  CDUMA = CDUMA + C[13] * v3rho2sigma;
+  CDUMAG1 = CDUMAG1 + C[13] * 2.0f * v3rhosigma2;
+  CDUMAG2 = CDUMAG2 + C[13] * v3rhosigma2 * 2.0f;
+  CDUMA = CDUMA + C[14] * v3rho2sigma * 2.0f;
+  CDUMAG1 = CDUMAG1 + C[14] * 2.0f * v3rhosigma2 * 2.0f;
+  CDUMAG2 = CDUMAG2 + C[14] * v3rhosigma2 * 4.0f;
+  CDUMA = CDUMA + C[15] * v3rho2sigma * 2.0f;
+  CDUMAG1 = CDUMAG1 + C[15] * 2.0f * v3rhosigma2 * 2.0f;
+  CDUMAG2 = CDUMAG2 + C[15] * v3rhosigma2 * 4.0f;
+  CDUMA = CDUMA + C[16] * v3rhosigma2;
+  CDUMAG1 = CDUMAG1 + C[16] * 2.0f * v3sigma3;
+  CDUMAG2 = CDUMAG2 + C[16] * v3sigma3 * 2.0f;
+  CDUMA = CDUMA + C[17] * v3rhosigma2 * 2.0f;
+  CDUMAG1 = CDUMAG1 + C[17] * 2.0f * v3sigma3 * 2.0f;
+  CDUMAG2 = CDUMAG2 + C[17] * v3sigma3 * 4.0f;
+  CDUMA = CDUMA + C[18] * v3rhosigma2 * 2.0f;
+  CDUMAG1 = CDUMAG1 + C[18] * 2.0f * v3sigma3 * 2.0f;
+  CDUMAG2 = CDUMAG2 + C[18] * v3sigma3 * 4.0f;
+  CDUMA = CDUMA + C[19] * v3rhosigma2 * 4.0f;
+  CDUMAG1 = CDUMAG1 + C[19] * 2.0f * v3sigma3 * 4.0f;
+  CDUMAG2 = CDUMAG2 + C[19] * v3sigma3 * 8.0f;
 
-   C[10]=DUMXX[2];
-   C[11]=DUMNV[0]*DUMNV[1];
-   C[12]=2.0f*DUMNV[0]*DUMGRV[1];
-   C[13]=2.0f*DUMGRV[0]*DUMNV[1];
-   C[14]=DUMNV[0]*DUMGRV[3];
-   C[15]=DUMGRV[2]*DUMNV[1];
-   C[16]=4.0f*DUMGRV[0]*DUMGRV[1];
-   C[17]=2.0f*DUMGRV[0]*DUMGRV[3];
-   C[18]=2.0f*DUMGRV[2]*DUMGRV[1];
-   C[19]=DUMGRV[2]*DUMGRV[3];
+  C[10] = DUMXX[2];
+  C[11] = DUMNV[0] * DUMNV[1];
+  C[12] = 2.0f * DUMNV[0] * DUMGRV[1];
+  C[13] = 2.0f * DUMGRV[0] * DUMNV[1];
+  C[14] = DUMNV[0] * DUMGRV[3];
+  C[15] = DUMGRV[2] * DUMNV[1];
+  C[16] = 4.0f * DUMGRV[0] * DUMGRV[1];
+  C[17] = 2.0f * DUMGRV[0] * DUMGRV[3];
+  C[18] = 2.0f * DUMGRV[2] * DUMGRV[1];
+  C[19] = DUMGRV[2] * DUMGRV[3];
 
-   CDUMA=CDUMA+C[10]*v2rhosigma*2.0f;
-   CDUMAG1=CDUMAG1+C[10]*2.0f*v2sigma2*2.0f;
-   CDUMAG2=CDUMAG2+C[10]*v2sigma2*4.0f;
-   CDUMA=CDUMA+C[11]*v3rho3;
-   CDUMAG1=CDUMAG1+C[11]*2.0f*v3rho2sigma;
-   CDUMAG2=CDUMAG2+C[11]*v3rho2sigma*2.0f;
-   CDUMA=CDUMA+C[12]*v3rho2sigma;
-   CDUMAG1=CDUMAG1+C[12]*2.0f*v3rhosigma2;
-   CDUMAG2=CDUMAG2+C[12]*v3rhosigma2*2.0f;
-   CDUMA=CDUMA+C[13]*v3rho2sigma;
-   CDUMAG1=CDUMAG1+C[13]*2.0f*v3rhosigma2;
-   CDUMAG2=CDUMAG2+C[13]*v3rhosigma2*2.0f;
-   CDUMA=CDUMA+C[14]*v3rho2sigma*2.0f;
-   CDUMAG1=CDUMAG1+C[14]*2.0f*v3rhosigma2*2.0f;
-   CDUMAG2=CDUMAG2+C[14]*v3rhosigma2*4.0f;
-   CDUMA=CDUMA+C[15]*v3rho2sigma*2.0f;
-   CDUMAG1=CDUMAG1+C[15]*2.0f*v3rhosigma2*2.0f;
-   CDUMAG2=CDUMAG2+C[15]*v3rhosigma2*4.0f;
-   CDUMA=CDUMA+C[16]*v3rhosigma2;
-   CDUMAG1=CDUMAG1+C[16]*2.0f*v3sigma3;
-   CDUMAG2=CDUMAG2+C[16]*v3sigma3*2.0f;
-   CDUMA=CDUMA+C[17]*v3rhosigma2*2.0f;
-   CDUMAG1=CDUMAG1+C[17]*2.0f*v3sigma3*2.0f;
-   CDUMAG2=CDUMAG2+C[17]*v3sigma3*4.0f;
-   CDUMA=CDUMA+C[18]*v3rhosigma2*2.0f;
-   CDUMAG1=CDUMAG1+C[18]*2.0f*v3sigma3*2.0f;
-   CDUMAG2=CDUMAG2+C[18]*v3sigma3*4.0f;
-   CDUMA=CDUMA+C[19]*v3rhosigma2*4.0f;
-   CDUMAG1=CDUMAG1+C[19]*2.0f*v3sigma3*4.0f;
-   CDUMAG2=CDUMAG2+C[19]*v3sigma3*8.0f;
+  CDUMA = CDUMA + C[10] * v2rhosigma * 2.0f;
+  CDUMAG1 = CDUMAG1 + C[10] * 2.0f * v2sigma2 * 2.0f;
+  CDUMAG2 = CDUMAG2 + C[10] * v2sigma2 * 4.0f;
+  CDUMA = CDUMA + C[11] * v3rho3;
+  CDUMAG1 = CDUMAG1 + C[11] * 2.0f * v3rho2sigma;
+  CDUMAG2 = CDUMAG2 + C[11] * v3rho2sigma * 2.0f;
+  CDUMA = CDUMA + C[12] * v3rho2sigma;
+  CDUMAG1 = CDUMAG1 + C[12] * 2.0f * v3rhosigma2;
+  CDUMAG2 = CDUMAG2 + C[12] * v3rhosigma2 * 2.0f;
+  CDUMA = CDUMA + C[13] * v3rho2sigma;
+  CDUMAG1 = CDUMAG1 + C[13] * 2.0f * v3rhosigma2;
+  CDUMAG2 = CDUMAG2 + C[13] * v3rhosigma2 * 2.0f;
+  CDUMA = CDUMA + C[14] * v3rho2sigma * 2.0f;
+  CDUMAG1 = CDUMAG1 + C[14] * 2.0f * v3rhosigma2 * 2.0f;
+  CDUMAG2 = CDUMAG2 + C[14] * v3rhosigma2 * 4.0f;
+  CDUMA = CDUMA + C[15] * v3rho2sigma * 2.0f;
+  CDUMAG1 = CDUMAG1 + C[15] * 2.0f * v3rhosigma2 * 2.0f;
+  CDUMAG2 = CDUMAG2 + C[15] * v3rhosigma2 * 4.0f;
+  CDUMA = CDUMA + C[16] * v3rhosigma2;
+  CDUMAG1 = CDUMAG1 + C[16] * 2.0f * v3sigma3;
+  CDUMAG2 = CDUMAG2 + C[16] * v3sigma3 * 2.0f;
+  CDUMA = CDUMA + C[17] * v3rhosigma2 * 2.0f;
+  CDUMAG1 = CDUMAG1 + C[17] * 2.0f * v3sigma3 * 2.0f;
+  CDUMAG2 = CDUMAG2 + C[17] * v3sigma3 * 4.0f;
+  CDUMA = CDUMA + C[18] * v3rhosigma2 * 2.0f;
+  CDUMAG1 = CDUMAG1 + C[18] * 2.0f * v3sigma3 * 2.0f;
+  CDUMAG2 = CDUMAG2 + C[18] * v3sigma3 * 4.0f;
+  CDUMA = CDUMA + C[19] * v3rhosigma2 * 4.0f;
+  CDUMAG1 = CDUMAG1 + C[19] * 2.0f * v3sigma3 * 4.0f;
+  CDUMAG2 = CDUMAG2 + C[19] * v3sigma3 * 8.0f;
 
-   double CDUMAGEA=0.0f;
-   CDUMAGEA=CDUMAGEA+4.0f*DUMNV[0]*v2rhosigma;
-   CDUMAGEA=CDUMAGEA+8.0f*DUMGRV[0]*v2sigma2;
-   CDUMAGEA=CDUMAGEA+4.0f*DUMGRV[2]*v2sigma2*2.0f;
-   CDUMAGEA=CDUMAGEA+4.0f*DUMNV[1]*v2rhosigma;
-   CDUMAGEA=CDUMAGEA+8.0f*DUMGRV[1]*v2sigma2;
-   CDUMAGEA=CDUMAGEA+4.0f*DUMGRV[3]*v2sigma2*2.0f;
+  double CDUMAGEA = 0.0f;
+  CDUMAGEA = CDUMAGEA + 4.0f * DUMNV[0] * v2rhosigma;
+  CDUMAGEA = CDUMAGEA + 8.0f * DUMGRV[0] * v2sigma2;
+  CDUMAGEA = CDUMAGEA + 4.0f * DUMGRV[2] * v2sigma2 * 2.0f;
+  CDUMAGEA = CDUMAGEA + 4.0f * DUMNV[1] * v2rhosigma;
+  CDUMAGEA = CDUMAGEA + 8.0f * DUMGRV[1] * v2sigma2;
+  CDUMAGEA = CDUMAGEA + 4.0f * DUMGRV[3] * v2sigma2 * 2.0f;
 
-   double CDUMAGEC=0.0f;
-   CDUMAGEC=CDUMAGEC+2.0f*DUMNV[0]*v2rhosigma*2.0f;
-   CDUMAGEC=CDUMAGEC+4.0f*DUMGRV[0]*v2sigma2*2.0f;
-   CDUMAGEC=CDUMAGEC+2.0f*DUMGRV[2]*v2sigma2*4.0f;
-   CDUMAGEC=CDUMAGEC+2.0f*DUMNV[1]*v2rhosigma*2.0f;
-   CDUMAGEC=CDUMAGEC+4.0f*DUMGRV[1]*v2sigma2*2.0f;
-   CDUMAGEC=CDUMAGEC+2.0f*DUMGRV[3]*v2sigma2*4.0f;
+  double CDUMAGEC = 0.0f;
+  CDUMAGEC = CDUMAGEC + 2.0f * DUMNV[0] * v2rhosigma * 2.0f;
+  CDUMAGEC = CDUMAGEC + 4.0f * DUMGRV[0] * v2sigma2 * 2.0f;
+  CDUMAGEC = CDUMAGEC + 2.0f * DUMGRV[2] * v2sigma2 * 4.0f;
+  CDUMAGEC = CDUMAGEC + 2.0f * DUMNV[1] * v2rhosigma * 2.0f;
+  CDUMAGEC = CDUMAGEC + 4.0f * DUMGRV[1] * v2sigma2 * 2.0f;
+  CDUMAGEC = CDUMAGEC + 2.0f * DUMGRV[3] * v2sigma2 * 4.0f;
 
-   Coef[0] += CDUMA;
-   Coef[1] += CDUMAG1+CDUMAG2;
-   Coef[2] += CDUMAGEA+CDUMAGEC;
-
+  Coef[0] += CDUMA;
+  Coef[1] += CDUMAG1 + CDUMAG2;
+  Coef[2] += CDUMAGEA + CDUMAGEC;
 }
 
 template <class T, int width>
-void LibxcProxy<T,width>::terms_derivs(double* rho, double* sigma,
-               double* vrho, double* vsigma, double* v2rho2,
-               double* v2rhosigma, double* v2sigma2, double* v3rho3,
-               double* v3rho2sigma, double* v3rhosigma2, double* v3sigma3)
-{
-   // All outputs
-   vrho[0] = vrho[1] = vsigma[0] = vsigma[1] = 0.0f;
-   v2rho2[0] = v2rho2[1] = v2rhosigma[0] = v2rhosigma[1] = 0.0f;
-   v2sigma2[0] = v2sigma2[1] = 0.0f;
-   v3rho3[0] = v3rho3[1] = v3rho2sigma[0] = v3rho2sigma[1] = 0.0f;
-   v3rhosigma2[0] = v3rhosigma2[1] = v3sigma3[0] = v3sigma3[1] =0.0f;
+void LibxcProxy<T, width>::terms_derivs(double* rho, double* sigma,
+                                        double* vrho, double* vsigma,
+                                        double* v2rho2, double* v2rhosigma,
+                                        double* v2sigma2, double* v3rho3,
+                                        double* v3rho2sigma,
+                                        double* v3rhosigma2, double* v3sigma3) {
+  // All outputs
+  vrho[0] = vrho[1] = vsigma[0] = vsigma[1] = 0.0f;
+  v2rho2[0] = v2rho2[1] = v2rhosigma[0] = v2rhosigma[1] = 0.0f;
+  v2sigma2[0] = v2sigma2[1] = 0.0f;
+  v3rho3[0] = v3rho3[1] = v3rho2sigma[0] = v3rho2sigma[1] = 0.0f;
+  v3rhosigma2[0] = v3rhosigma2[1] = v3sigma3[0] = v3sigma3[1] = 0.0f;
 
-   // Local otputs libxc
-   double lvrho[1], lvsigma[1], lv2rho2[1], lv2rhosigma[1], lv2sigma2[1];
-   double lv3rho3[1], lv3rho2sigma[1], lv3rhosigma2[1], lv3sigma3[1], lenergy[1];
-   double cc = 0.0f;
+  // Local otputs libxc
+  double lvrho[1], lvsigma[1], lv2rho2[1], lv2rhosigma[1], lv2sigma2[1];
+  double lv3rho3[1], lv3rho2sigma[1], lv3rhosigma2[1], lv3sigma3[1], lenergy[1];
+  double cc = 0.0f;
 
-   // Exchange Calculation
-   for (int ii=0; ii<nxcoef; ii++) {
-       // Set zero values
-       lenergy[0]  = 0.0f;
-       lvrho[0]    = 0.0f;
-       lv2rho2[0]  = 0.0f;
-       lvsigma[0]  = 0.0f;
-       lv2rhosigma[0] = 0.0f;
-       lv2sigma2[0]   = 0.0f;
-       lv3rho3[0]     = 0.0f;
-       lv3rho2sigma[0]= 0.0f;
-       lv3rhosigma2[0]= 0.0f;
-       lv3sigma3[0]   = 0.0f;
+  // Exchange Calculation
+  for (int ii = 0; ii < nxcoef; ii++) {
+    // Set zero values
+    lenergy[0] = 0.0f;
+    lvrho[0] = 0.0f;
+    lv2rho2[0] = 0.0f;
+    lvsigma[0] = 0.0f;
+    lv2rhosigma[0] = 0.0f;
+    lv2sigma2[0] = 0.0f;
+    lv3rho3[0] = 0.0f;
+    lv3rho2sigma[0] = 0.0f;
+    lv3rhosigma2[0] = 0.0f;
+    lv3sigma3[0] = 0.0f;
 
-       switch( (&funcsId[ii])->info->family ) {
-          case (XC_FAMILY_LDA):
-             xc_lda(&funcsId[ii],1,rho,lenergy,lvrho,lv2rho2,
-                    lv3rho3,
-                    NULL); break;
-          case (XC_FAMILY_GGA):
-             xc_gga(&funcsId[ii],1,rho,sigma,lenergy,lvrho,lvsigma,
-                    lv2rho2,lv2rhosigma,lv2sigma2,
-                    lv3rho3,lv3rho2sigma,lv3rhosigma2,lv3sigma3,
-                    NULL,NULL,NULL,NULL,NULL); break;
-          default:
-            printf("Unidentified Family Functional\n");
-            exit(-1); break;
+    switch ((&funcsId[ii])->info->family) {
+      case (XC_FAMILY_LDA):
+        xc_lda(&funcsId[ii], 1, rho, lenergy, lvrho, lv2rho2, lv3rho3, NULL);
+        break;
+      case (XC_FAMILY_GGA):
+        xc_gga(&funcsId[ii], 1, rho, sigma, lenergy, lvrho, lvsigma, lv2rho2,
+               lv2rhosigma, lv2sigma2, lv3rho3, lv3rho2sigma, lv3rhosigma2,
+               lv3sigma3, NULL, NULL, NULL, NULL, NULL);
+        break;
+      default:
+        printf("Unidentified Family Functional\n");
+        exit(-1);
+        break;
 
-       } // end switch
+    }  // end switch
 
-       cc = funcsCoef[ii];
-       vrho[0]       += cc*lvrho[0];
-       vsigma[0]     += cc*lvsigma[0];
-       v2rho2[0]     += cc*lv2rho2[0];
-       v2rhosigma[0] += cc*lv2rhosigma[0];
-       v2sigma2[0]   += cc*lv2sigma2[0];
-       v3rho3[0]     += cc*lv3rho3[0];
-       v3rho2sigma[0]+= cc*lv3rho2sigma[0];
-       v3sigma3[0]   += cc*lv3sigma3[0];
-       v3rhosigma2[0]+= cc*lv3rhosigma2[0];
-   } // end exchange
+    cc = funcsCoef[ii];
+    vrho[0] += cc * lvrho[0];
+    vsigma[0] += cc * lvsigma[0];
+    v2rho2[0] += cc * lv2rho2[0];
+    v2rhosigma[0] += cc * lv2rhosigma[0];
+    v2sigma2[0] += cc * lv2sigma2[0];
+    v3rho3[0] += cc * lv3rho3[0];
+    v3rho2sigma[0] += cc * lv3rho2sigma[0];
+    v3sigma3[0] += cc * lv3sigma3[0];
+    v3rhosigma2[0] += cc * lv3rhosigma2[0];
+  }  // end exchange
 
-   // Correlation Calculation
-   for (int ii=nxcoef; ii<ntotal_funcs; ii++) {
-       // Set zero values
-       lenergy[0]  = 0.0f;
-       lvrho[0]    = 0.0f;
-       lv2rho2[0]  = 0.0f;
-       lvsigma[0]  = 0.0f;
-       lv2rhosigma[0] = 0.0f;
-       lv2sigma2[0]   = 0.0f;
-       lv3rho3[0]     = 0.0f;
-       lv3rho2sigma[0]= 0.0f;
-       lv3rhosigma2[0]= 0.0f;
-       lv3sigma3[0]   = 0.0f;
+  // Correlation Calculation
+  for (int ii = nxcoef; ii < ntotal_funcs; ii++) {
+    // Set zero values
+    lenergy[0] = 0.0f;
+    lvrho[0] = 0.0f;
+    lv2rho2[0] = 0.0f;
+    lvsigma[0] = 0.0f;
+    lv2rhosigma[0] = 0.0f;
+    lv2sigma2[0] = 0.0f;
+    lv3rho3[0] = 0.0f;
+    lv3rho2sigma[0] = 0.0f;
+    lv3rhosigma2[0] = 0.0f;
+    lv3sigma3[0] = 0.0f;
 
-       switch( (&funcsId[ii])->info->family ) {
-          case (XC_FAMILY_LDA):
-             xc_lda(&funcsId[ii],1,rho,lenergy,lvrho,lv2rho2,
-                    lv3rho3,
-                    NULL); break;
-          case (XC_FAMILY_GGA):
-             xc_gga(&funcsId[ii],1,rho,sigma,lenergy,lvrho,lvsigma,
-                    lv2rho2,lv2rhosigma,lv2sigma2,
-                    lv3rho3,lv3rho2sigma,lv3rhosigma2,lv3sigma3,
-                    NULL,NULL,NULL,NULL,NULL); break;
-          default:
-            printf("Unidentified Family Functional\n");
-            exit(-1); break;
+    switch ((&funcsId[ii])->info->family) {
+      case (XC_FAMILY_LDA):
+        xc_lda(&funcsId[ii], 1, rho, lenergy, lvrho, lv2rho2, lv3rho3, NULL);
+        break;
+      case (XC_FAMILY_GGA):
+        xc_gga(&funcsId[ii], 1, rho, sigma, lenergy, lvrho, lvsigma, lv2rho2,
+               lv2rhosigma, lv2sigma2, lv3rho3, lv3rho2sigma, lv3rhosigma2,
+               lv3sigma3, NULL, NULL, NULL, NULL, NULL);
+        break;
+      default:
+        printf("Unidentified Family Functional\n");
+        exit(-1);
+        break;
 
-       } // end switch
+    }  // end switch
 
-       cc = funcsCoef[ii];
-       vrho[1]       += cc*lvrho[0];
-       vsigma[1]     += cc*lvsigma[0];
-       v2rho2[1]     += cc*lv2rho2[0];
-       v2rhosigma[1] += cc*lv2rhosigma[0];
-       v2sigma2[1]   += cc*lv2sigma2[0];
-       v3rho3[1]     += cc*lv3rho3[0];
-       v3rho2sigma[1]+= cc*lv3rho2sigma[0];
-       v3sigma3[1]   += cc*lv3sigma3[0];
-       v3rhosigma2[1]+= cc*lv3rhosigma2[0];
-   } // end correlation
+    cc = funcsCoef[ii];
+    vrho[1] += cc * lvrho[0];
+    vsigma[1] += cc * lvsigma[0];
+    v2rho2[1] += cc * lv2rho2[0];
+    v2rhosigma[1] += cc * lv2rhosigma[0];
+    v2sigma2[1] += cc * lv2sigma2[0];
+    v3rho3[1] += cc * lv3rho3[0];
+    v3rho2sigma[1] += cc * lv3rho2sigma[0];
+    v3sigma3[1] += cc * lv3sigma3[0];
+    v3rhosigma2[1] += cc * lv3rhosigma2[0];
+  }  // end correlation
 }
 
 template <class T, int width>
-void LibxcProxy <T, width>::coefZv(double dens, double sigma, double pdx, double pdy,
-                double pdz, double red, double redx, double redy, double redz,
-                double* zcoef)
-{
-   double* dxyz = (double*)malloc(3*sizeof(double));
-   double* txyz = (double*)malloc(3*sizeof(double));
+void LibxcProxy<T, width>::coefZv(double dens, double sigma, double pdx,
+                                  double pdy, double pdz, double red,
+                                  double redx, double redy, double redz,
+                                  double* zcoef) {
+  double* dxyz = (double*)malloc(3 * sizeof(double));
+  double* txyz = (double*)malloc(3 * sizeof(double));
 
-   dxyz[0] = pdx; dxyz[1] = pdy; dxyz[2] = pdz;
-   txyz[0] = redx; txyz[1] = redy; txyz[2] = redz;
+  dxyz[0] = pdx;
+  dxyz[1] = pdy;
+  dxyz[2] = pdz;
+  txyz[0] = redx;
+  txyz[1] = redy;
+  txyz[2] = redz;
 
-   // All outputs
-   double vrho, vsigma, v2rho2, v2rhosigma, v2sigma2, v3rho3, v3rho2sigma;
-   double v3rhosigma2, v3sigma3, exc;
-   vrho = vsigma = 0.0f; v2rho2 = v2rhosigma = v2sigma2 = 0.0f;
-   v3rho3 = v3rho2sigma = v3rhosigma2 = v3sigma3 = exc = 0.0f;
+  // All outputs
+  double vrho, vsigma, v2rho2, v2rhosigma, v2sigma2, v3rho3, v3rho2sigma;
+  double v3rhosigma2, v3sigma3, exc;
+  vrho = vsigma = 0.0f;
+  v2rho2 = v2rhosigma = v2sigma2 = 0.0f;
+  v3rho3 = v3rho2sigma = v3rhosigma2 = v3sigma3 = exc = 0.0f;
 
-   // Functional outputs
-   double lenergy[1];
-   double lvrho[1];
-   double lvsigma[1];
-   double lv2rho2[1];
-   double lv2rhosigma[1];
-   double lv2sigma2[1];
-   double lv3rho3[1];
-   double lv3rho2sigma[1];
-   double lv3rhosigma2[1];
-   double lv3sigma3[1];
+  // Functional outputs
+  double lenergy[1];
+  double lvrho[1];
+  double lvsigma[1];
+  double lv2rho2[1];
+  double lv2rhosigma[1];
+  double lv2sigma2[1];
+  double lv3rho3[1];
+  double lv3rho2sigma[1];
+  double lv3rhosigma2[1];
+  double lv3sigma3[1];
 
-   double cc = 0.0f;
+  double cc = 0.0f;
 
-   // Exchange Calculation
-   for (int ii=0; ii<nxcoef; ii++) {
-       // Set zero values
-       lenergy[0]  = 0.0f;
-       lvrho[0]    = 0.0f;
-       lv2rho2[0]  = 0.0f;
-       lvsigma[0]  = 0.0f;
-       lv2rhosigma[0] = 0.0f;
-       lv2sigma2[0]   = 0.0f;
-       lv3rho3[0]     = 0.0f;
-       lv3rho2sigma[0]= 0.0f;
-       lv3rhosigma2[0]= 0.0f;
-       lv3sigma3[0]   = 0.0f;
+  // Exchange Calculation
+  for (int ii = 0; ii < nxcoef; ii++) {
+    // Set zero values
+    lenergy[0] = 0.0f;
+    lvrho[0] = 0.0f;
+    lv2rho2[0] = 0.0f;
+    lvsigma[0] = 0.0f;
+    lv2rhosigma[0] = 0.0f;
+    lv2sigma2[0] = 0.0f;
+    lv3rho3[0] = 0.0f;
+    lv3rho2sigma[0] = 0.0f;
+    lv3rhosigma2[0] = 0.0f;
+    lv3sigma3[0] = 0.0f;
 
-       switch( (&funcsId[ii])->info->family ) {
-          case (XC_FAMILY_LDA):
-             xc_lda(&funcsId[ii],1,&dens,lenergy,lvrho,lv2rho2,
-                    lv3rho3,
-                    NULL); break;
-          case (XC_FAMILY_GGA):
-             xc_gga(&funcsId[ii],1,&dens,&sigma,lenergy,lvrho,lvsigma,
-                    lv2rho2,lv2rhosigma,lv2sigma2,
-                    lv3rho3,lv3rho2sigma,lv3rhosigma2,lv3sigma3,
-                    NULL,NULL,NULL,NULL,NULL); break;
-          default:
-            printf("Unidentified Family Functional\n");
-            exit(-1); break;
+    switch ((&funcsId[ii])->info->family) {
+      case (XC_FAMILY_LDA):
+        xc_lda(&funcsId[ii], 1, &dens, lenergy, lvrho, lv2rho2, lv3rho3, NULL);
+        break;
+      case (XC_FAMILY_GGA):
+        xc_gga(&funcsId[ii], 1, &dens, &sigma, lenergy, lvrho, lvsigma, lv2rho2,
+               lv2rhosigma, lv2sigma2, lv3rho3, lv3rho2sigma, lv3rhosigma2,
+               lv3sigma3, NULL, NULL, NULL, NULL, NULL);
+        break;
+      default:
+        printf("Unidentified Family Functional\n");
+        exit(-1);
+        break;
 
-       } // end switch
+    }  // end switch
 
-       cc = funcsCoef[ii];
-       v2rho2     += cc*lv2rho2[0];
-       v2rhosigma += cc*lv2rhosigma[0];
-       v2sigma2   += cc*lv2sigma2[0];
-       v3rho3     += cc*lv3rho3[0];
-       v3rho2sigma+= cc*lv3rho2sigma[0];
-       v3rhosigma2+= cc*lv3rhosigma2[0];
-       v3sigma3   += cc*lv3sigma3[0];
-       
-   } // end exchange
+    cc = funcsCoef[ii];
+    v2rho2 += cc * lv2rho2[0];
+    v2rhosigma += cc * lv2rhosigma[0];
+    v2sigma2 += cc * lv2sigma2[0];
+    v3rho3 += cc * lv3rho3[0];
+    v3rho2sigma += cc * lv3rho2sigma[0];
+    v3rhosigma2 += cc * lv3rhosigma2[0];
+    v3sigma3 += cc * lv3sigma3[0];
 
-   // Obtain Z coef of exchange
-   Zv_exchange(red,dxyz,txyz,zcoef,v2rho2,v2rhosigma,v2sigma2,
-               v3rho3,v3rho2sigma,v3rhosigma2,v3sigma3);
+  }  // end exchange
 
-   vrho = vsigma = 0.0f; v2rho2 = v2rhosigma = v2sigma2 = 0.0f;
-   v3rho3 = v3rho2sigma = v3rhosigma2 = v3sigma3 = exc = 0.0f;
+  // Obtain Z coef of exchange
+  Zv_exchange(red, dxyz, txyz, zcoef, v2rho2, v2rhosigma, v2sigma2, v3rho3,
+              v3rho2sigma, v3rhosigma2, v3sigma3);
 
-   // Exchange Calculation
-   for (int ii=nxcoef; ii<ntotal_funcs; ii++) {
-       // Set zero values
-       lenergy[0]  = 0.0f;
-       lvrho[0]    = 0.0f;
-       lv2rho2[0]  = 0.0f;
-       lvsigma[0]  = 0.0f;
-       lv2rhosigma[0] = 0.0f;
-       lv2sigma2[0]   = 0.0f;
-       lv3rho3[0]     = 0.0f;
-       lv3rho2sigma[0]= 0.0f;
-       lv3rhosigma2[0]= 0.0f;
-       lv3sigma3[0]   = 0.0f;
+  vrho = vsigma = 0.0f;
+  v2rho2 = v2rhosigma = v2sigma2 = 0.0f;
+  v3rho3 = v3rho2sigma = v3rhosigma2 = v3sigma3 = exc = 0.0f;
 
-       switch( (&funcsId[ii])->info->family ) {
-          case (XC_FAMILY_LDA):
-             xc_lda(&funcsId[ii],1,&dens,lenergy,lvrho,lv2rho2,
-                    lv3rho3,
-                    NULL); break;
-          case (XC_FAMILY_GGA):
-             xc_gga(&funcsId[ii],1,&dens,&sigma,lenergy,lvrho,lvsigma,
-                    lv2rho2,lv2rhosigma,lv2sigma2,
-                    lv3rho3,lv3rho2sigma,lv3rhosigma2,lv3sigma3,
-                    NULL,NULL,NULL,NULL,NULL); break;
-          default:
-            printf("Unidentified Family Functional\n");
-            exit(-1); break;
+  // Exchange Calculation
+  for (int ii = nxcoef; ii < ntotal_funcs; ii++) {
+    // Set zero values
+    lenergy[0] = 0.0f;
+    lvrho[0] = 0.0f;
+    lv2rho2[0] = 0.0f;
+    lvsigma[0] = 0.0f;
+    lv2rhosigma[0] = 0.0f;
+    lv2sigma2[0] = 0.0f;
+    lv3rho3[0] = 0.0f;
+    lv3rho2sigma[0] = 0.0f;
+    lv3rhosigma2[0] = 0.0f;
+    lv3sigma3[0] = 0.0f;
 
-       } // end switch
+    switch ((&funcsId[ii])->info->family) {
+      case (XC_FAMILY_LDA):
+        xc_lda(&funcsId[ii], 1, &dens, lenergy, lvrho, lv2rho2, lv3rho3, NULL);
+        break;
+      case (XC_FAMILY_GGA):
+        xc_gga(&funcsId[ii], 1, &dens, &sigma, lenergy, lvrho, lvsigma, lv2rho2,
+               lv2rhosigma, lv2sigma2, lv3rho3, lv3rho2sigma, lv3rhosigma2,
+               lv3sigma3, NULL, NULL, NULL, NULL, NULL);
+        break;
+      default:
+        printf("Unidentified Family Functional\n");
+        exit(-1);
+        break;
 
-       cc = funcsCoef[ii];
-       v2rhosigma += cc*lv2rhosigma[0];
-       v2sigma2   += cc*lv2sigma2[0];
-       v3rho3     += cc*lv3rho3[0];
-       v3rho2sigma+= cc*lv3rho2sigma[0];
-       v3rhosigma2+= cc*lv3rhosigma2[0];
-       v3sigma3   += cc*lv3sigma3[0];
+    }  // end switch
 
-   } // end correlation
+    cc = funcsCoef[ii];
+    v2rhosigma += cc * lv2rhosigma[0];
+    v2sigma2 += cc * lv2sigma2[0];
+    v3rho3 += cc * lv3rho3[0];
+    v3rho2sigma += cc * lv3rho2sigma[0];
+    v3rhosigma2 += cc * lv3rhosigma2[0];
+    v3sigma3 += cc * lv3sigma3[0];
 
-   // Obtain Z coef of correlation
-   Zv_coulomb(red,dxyz,txyz,zcoef,v2rhosigma,v2sigma2,
-              v3rho3,v3rho2sigma,v3rhosigma2,v3sigma3);
+  }  // end correlation
 
-   free(dxyz); dxyz = NULL;
-   free(txyz); txyz = NULL;
+  // Obtain Z coef of correlation
+  Zv_coulomb(red, dxyz, txyz, zcoef, v2rhosigma, v2sigma2, v3rho3, v3rho2sigma,
+             v3rhosigma2, v3sigma3);
 
-   return;
+  free(dxyz);
+  dxyz = NULL;
+  free(txyz);
+  txyz = NULL;
+
+  return;
 }
 
 //////////////////////////////////////////////////////////////
@@ -1265,396 +1215,359 @@ void LibxcProxy <T, width>::coefZv(double dens, double sigma, double pdx, double
 // dens: pointer for the density array
 // number_of_points: the size of all the input arrays
 // contracted_grad: the contracted grad for libxc
-// grad: 
+// grad:
 // hess1:
 // hess2:
-// ex: here goes the results after calling xc_gga from libxc for the exchange functional
-// ec: here goes the results after calling xc_gga from libxc for the correlation functional
+// ex: here goes the results after calling xc_gga from libxc for the exchange
+// functional ec: here goes the results after calling xc_gga from libxc for the
+// correlation functional
 //
 // Note: all the pointer data are pointers in CUDA memory.
 //
 template <class T, int width>
-void LibxcProxy <T, width>::doGGA(T* dens,
-    const int number_of_points,
-    const T* contracted_grad,
-    const G2G::vec_type<T, width>* grad,
-    const G2G::vec_type<T, width>* hess1,
-    const G2G::vec_type<T, width>* hess2,
-    T* ex,
-    T* ec,
-    T* y2a)
-{
+void LibxcProxy<T, width>::doGGA(T* dens, const int number_of_points,
+                                 const T* contracted_grad,
+                                 const G2G::vec_type<T, width>* grad,
+                                 const G2G::vec_type<T, width>* hess1,
+                                 const G2G::vec_type<T, width>* hess2, T* ex,
+                                 T* ec, T* y2a) {
 #ifdef __CUDACC__
-    //printf("doGGA - GPU \n");
-    //printf("Number of points: %u\n", number_of_points);
+  // printf("doGGA - GPU \n");
+  // printf("Number of points: %u\n", number_of_points);
 
-    // Este flag esta asi ya que a veces lio utiliza precision mixta
-    // y solo en tiempo de ejecucion podemos saber que tipos
-    // de datos esta utilizando.
-    bool full_double = (sizeof(T) == 8);
+  // Este flag esta asi ya que a veces lio utiliza precision mixta
+  // y solo en tiempo de ejecucion podemos saber que tipos
+  // de datos esta utilizando.
+  bool full_double = (sizeof(T) == 8);
 
-    // Variables for the Kernels
-    int threadsPerBlock = 256;
-    int blocksPerGrid = (number_of_points + threadsPerBlock - 1) / threadsPerBlock;
+  // Variables for the Kernels
+  int threadsPerBlock = 256;
+  int blocksPerGrid =
+      (number_of_points + threadsPerBlock - 1) / threadsPerBlock;
 
-    cudaError_t err = cudaSuccess;
+  cudaError_t err = cudaSuccess;
 
-    // All the arrays for libxc must be of double*
-    int array_size = sizeof(double) * number_of_points;
-    int vec_size = sizeof(G2G::vec_type<double,width>) * number_of_points;
+  // All the arrays for libxc must be of double*
+  int array_size = sizeof(double) * number_of_points;
+  int vec_size = sizeof(G2G::vec_type<double, width>) * number_of_points;
 
-    double* rho = NULL;
-    double* sigma = NULL;
+  double* rho = NULL;
+  double* sigma = NULL;
 
-    double* ex_double = NULL;
-    double* ec_double = NULL;
-    double* y2a_double = NULL;
-    G2G::vec_type<double, width>* grad_double = NULL;
-    G2G::vec_type<double, width>* hess1_double = NULL;
-    G2G::vec_type<double, width>* hess2_double = NULL;
+  double* ex_double = NULL;
+  double* ec_double = NULL;
+  double* y2a_double = NULL;
+  G2G::vec_type<double, width>* grad_double = NULL;
+  G2G::vec_type<double, width>* hess1_double = NULL;
+  G2G::vec_type<double, width>* hess2_double = NULL;
 
-    err = cudaMalloc((void**)&rho, array_size);
-    if (err != cudaSuccess)
-    {
-        fprintf(stderr, "Failed to allocate device rho!\n");
-        exit(EXIT_FAILURE);
+  err = cudaMalloc((void**)&rho, array_size);
+  if (err != cudaSuccess) {
+    fprintf(stderr, "Failed to allocate device rho!\n");
+    exit(EXIT_FAILURE);
+  }
+
+  err = cudaMalloc((void**)&sigma, array_size);
+  if (err != cudaSuccess) {
+    fprintf(stderr, "Failed to allocate device sigma!\n");
+    exit(EXIT_FAILURE);
+  }
+
+  // Si el tipo de datos es float, creamos los arrays para copiar
+  // los inputs y convertirlos a floats.
+  if (!full_double) {
+    err = cudaMalloc((void**)&ex_double, array_size);
+    if (err != cudaSuccess) {
+      fprintf(stderr, "Failed to allocate device ex_double!\n");
+      exit(EXIT_FAILURE);
+    }
+    cudaMemset(ex_double, 0, array_size);
+
+    err = cudaMalloc((void**)&ec_double, array_size);
+    if (err != cudaSuccess) {
+      fprintf(stderr, "Failed to allocate device ec_double!\n");
+      exit(EXIT_FAILURE);
+    }
+    cudaMemset(ec_double, 0, array_size);
+
+    err = cudaMalloc((void**)&y2a_double, array_size);
+    if (err != cudaSuccess) {
+      fprintf(stderr, "Failed to allocate device y2a_double!\n");
+      exit(EXIT_FAILURE);
+    }
+    cudaMemset(y2a_double, 0, array_size);
+
+    err = cudaMalloc((void**)&grad_double, vec_size);
+    if (err != cudaSuccess) {
+      fprintf(stderr, "Failed to allocate device grad_double!\n");
+      exit(EXIT_FAILURE);
     }
 
-    err = cudaMalloc((void**)&sigma, array_size);
-    if (err != cudaSuccess)
-    {
-        fprintf(stderr, "Failed to allocate device sigma!\n");
-	exit(EXIT_FAILURE);
+    err = cudaMalloc((void**)&hess1_double, vec_size);
+    if (err != cudaSuccess) {
+      fprintf(stderr, "Failed to allocate device hess1_double!\n");
+      exit(EXIT_FAILURE);
     }
 
-    // Si el tipo de datos es float, creamos los arrays para copiar
-    // los inputs y convertirlos a floats.
-    if (!full_double) {
-	err = cudaMalloc((void**)&ex_double, array_size);
-        if (err != cudaSuccess)
-        {
-	    fprintf(stderr, "Failed to allocate device ex_double!\n");
-    	    exit(EXIT_FAILURE);
-        }
-	cudaMemset(ex_double,0,array_size);
+    err = cudaMalloc((void**)&hess2_double, vec_size);
+    if (err != cudaSuccess) {
+      fprintf(stderr, "Failed to allocate device hess2_double!\n");
+      exit(EXIT_FAILURE);
+    }
+  }
 
-        err = cudaMalloc((void**)&ec_double, array_size);
-	if (err != cudaSuccess)
-        {
-	    fprintf(stderr, "Failed to allocate device ec_double!\n");
-	    exit(EXIT_FAILURE);
-        }
-	cudaMemset(ec_double,0,array_size);
-
-        err = cudaMalloc((void**)&y2a_double, array_size);
-	if (err != cudaSuccess)
-        {
-    	    fprintf(stderr, "Failed to allocate device y2a_double!\n");
-	    exit(EXIT_FAILURE);
-        }
-	cudaMemset(y2a_double,0,array_size);
-
-        err = cudaMalloc((void**)&grad_double, vec_size);
-	if (err != cudaSuccess)
-	{
-	    fprintf(stderr, "Failed to allocate device grad_double!\n");
-    	    exit(EXIT_FAILURE);
-        }
-
-	err = cudaMalloc((void**)&hess1_double, vec_size);
-        if (err != cudaSuccess)
-	{
-	    fprintf(stderr, "Failed to allocate device hess1_double!\n");
-	    exit(EXIT_FAILURE);
-        }
-
-	err = cudaMalloc((void**)&hess2_double, vec_size);
-        if (err != cudaSuccess)
-	{
-	    fprintf(stderr, "Failed to allocate device hess2_double!\n");
-	    exit(EXIT_FAILURE);
-        }
+  // Preparamos los datos.
+  if (full_double) {
+    err = cudaMemcpy(rho, dens, array_size, cudaMemcpyDeviceToDevice);
+    if (err != cudaSuccess) {
+      fprintf(stderr, "Failed to copy data from dens->rho\n");
     }
 
-    // Preparamos los datos.
-    if (full_double) {
-	err = cudaMemcpy(rho, dens, array_size, cudaMemcpyDeviceToDevice);
-        if (err != cudaSuccess)
-	{
-	    fprintf(stderr, "Failed to copy data from dens->rho\n");
-        }
-
-	err = cudaMemcpy(sigma, contracted_grad, array_size, cudaMemcpyDeviceToDevice);
-        if (err != cudaSuccess)
-	{
-	    fprintf(stderr, "Failed to copy data from contracted_grad->sigma\n");
-	}
-
-        // Usamos los datos como vienen ya que son todos doubles.
-	ex_double = (double*)ex;
-	ec_double = (double*)ec;
-        y2a_double = (double*)y2a;
-	grad_double = (G2G::vec_type<double,4>*)grad;
-        hess1_double = (G2G::vec_type<double,4>*)hess1;
-        hess2_double = (G2G::vec_type<double,4>*)hess2;
-
-    } else {
-	// Como los inputs son float, los convertimos para libxc
-	convertFloatToDouble<<<blocksPerGrid, threadsPerBlock>>>(dens, rho, number_of_points);
-	convertFloatToDouble<<<blocksPerGrid, threadsPerBlock>>>(contracted_grad, sigma, number_of_points);
-        convertFloatToDouble<<<blocksPerGrid, threadsPerBlock>>>(grad, grad_double, number_of_points);
-	convertFloatToDouble<<<blocksPerGrid, threadsPerBlock>>>(hess1, hess1_double, number_of_points);
-        convertFloatToDouble<<<blocksPerGrid, threadsPerBlock>>>(hess2, hess2_double, number_of_points);
+    err = cudaMemcpy(sigma, contracted_grad, array_size,
+                     cudaMemcpyDeviceToDevice);
+    if (err != cudaSuccess) {
+      fprintf(stderr, "Failed to copy data from contracted_grad->sigma\n");
     }
 
-    // Preparamos los arrays de salida.
-    double* exchange = NULL;
-    err = cudaMalloc((void **)&exchange, array_size);
-    if (err != cudaSuccess)
-    {
-        fprintf(stderr, "Failed to allocate device exchange!\n");
-        exit(EXIT_FAILURE);
-    }
+    // Usamos los datos como vienen ya que son todos doubles.
+    ex_double = (double*)ex;
+    ec_double = (double*)ec;
+    y2a_double = (double*)y2a;
+    grad_double = (G2G::vec_type<double, 4>*)grad;
+    hess1_double = (G2G::vec_type<double, 4>*)hess1;
+    hess2_double = (G2G::vec_type<double, 4>*)hess2;
 
-    double* correlation = NULL;
-    err = cudaMalloc((void **)&correlation, array_size);
-    if (err != cudaSuccess)
-    {
-        fprintf(stderr, "Failed to allocate device correlation!\n");
-        exit(EXIT_FAILURE);
-    }
+  } else {
+    // Como los inputs son float, los convertimos para libxc
+    convertFloatToDouble<<<blocksPerGrid, threadsPerBlock>>>(dens, rho,
+                                                             number_of_points);
+    convertFloatToDouble<<<blocksPerGrid, threadsPerBlock>>>(
+        contracted_grad, sigma, number_of_points);
+    convertFloatToDouble<<<blocksPerGrid, threadsPerBlock>>>(grad, grad_double,
+                                                             number_of_points);
+    convertFloatToDouble<<<blocksPerGrid, threadsPerBlock>>>(
+        hess1, hess1_double, number_of_points);
+    convertFloatToDouble<<<blocksPerGrid, threadsPerBlock>>>(
+        hess2, hess2_double, number_of_points);
+  }
 
-    cudaMemset(exchange,0,array_size);
-    cudaMemset(correlation,0,array_size);
+  // Preparamos los arrays de salida.
+  double* exchange = NULL;
+  err = cudaMalloc((void**)&exchange, array_size);
+  if (err != cudaSuccess) {
+    fprintf(stderr, "Failed to allocate device exchange!\n");
+    exit(EXIT_FAILURE);
+  }
 
-    // The outputs for exchange
-    double* vrho = NULL;
-    double* vsigma = NULL;
-    double* v2rho = NULL;
-    double* v2rhosigma = NULL;
-    double* v2sigma = NULL;
+  double* correlation = NULL;
+  err = cudaMalloc((void**)&correlation, array_size);
+  if (err != cudaSuccess) {
+    fprintf(stderr, "Failed to allocate device correlation!\n");
+    exit(EXIT_FAILURE);
+  }
 
-    err = cudaMalloc((void **)&vrho, array_size);
-    if (err != cudaSuccess)
-    {
-        fprintf(stderr, "Failed to allocate device vrho!\n");
-        exit(EXIT_FAILURE);
-    }
+  cudaMemset(exchange, 0, array_size);
+  cudaMemset(correlation, 0, array_size);
 
-    err = cudaMalloc((void **)&vsigma, array_size);
-    if (err != cudaSuccess)
-    {
-        fprintf(stderr, "Failed to allocate device vsigma!\n");
-        exit(EXIT_FAILURE);
-    }
+  // The outputs for exchange
+  double* vrho = NULL;
+  double* vsigma = NULL;
+  double* v2rho = NULL;
+  double* v2rhosigma = NULL;
+  double* v2sigma = NULL;
 
-    err = cudaMalloc((void **)&v2rho, array_size);
-    if (err != cudaSuccess)
-    {
-        fprintf(stderr, "Failed to allocate device v2rho!\n");
-        exit(EXIT_FAILURE);
-    }
+  err = cudaMalloc((void**)&vrho, array_size);
+  if (err != cudaSuccess) {
+    fprintf(stderr, "Failed to allocate device vrho!\n");
+    exit(EXIT_FAILURE);
+  }
 
-    err = cudaMalloc((void **)&v2rhosigma, array_size);
-    if (err != cudaSuccess)
-    {
-        fprintf(stderr, "Failed to allocate device v2rhosigma!\n");
-        exit(EXIT_FAILURE);
-    }
+  err = cudaMalloc((void**)&vsigma, array_size);
+  if (err != cudaSuccess) {
+    fprintf(stderr, "Failed to allocate device vsigma!\n");
+    exit(EXIT_FAILURE);
+  }
 
-    err = cudaMalloc((void **)&v2sigma, array_size);
-    if (err != cudaSuccess)
-    {
-        fprintf(stderr, "Failed to allocate device v2sigma!\n");
-        exit(EXIT_FAILURE);
-    }
+  err = cudaMalloc((void**)&v2rho, array_size);
+  if (err != cudaSuccess) {
+    fprintf(stderr, "Failed to allocate device v2rho!\n");
+    exit(EXIT_FAILURE);
+  }
 
-    // Clear arrays
-    cudaMemset(vrho, 0, array_size);
-    cudaMemset(vsigma, 0, array_size);
-    cudaMemset(v2rho, 0, array_size);
-    cudaMemset(v2rhosigma, 0, array_size);
-    cudaMemset(v2sigma, 0, array_size);
+  err = cudaMalloc((void**)&v2rhosigma, array_size);
+  if (err != cudaSuccess) {
+    fprintf(stderr, "Failed to allocate device v2rhosigma!\n");
+    exit(EXIT_FAILURE);
+  }
 
-    // The outputs for correlation
-    double* vrhoC = NULL;
-    double* vsigmaC = NULL;
-    double* v2rhoC = NULL;
-    double* v2rhosigmaC = NULL;
-    double* v2sigmaC = NULL;
+  err = cudaMalloc((void**)&v2sigma, array_size);
+  if (err != cudaSuccess) {
+    fprintf(stderr, "Failed to allocate device v2sigma!\n");
+    exit(EXIT_FAILURE);
+  }
 
-    err = cudaMalloc((void **)&vrhoC, array_size);
-    if (err != cudaSuccess)
-    {
-        fprintf(stderr, "Failed to allocate device vrhoC!\n");
-        exit(EXIT_FAILURE);
-    }
+  // Clear arrays
+  cudaMemset(vrho, 0, array_size);
+  cudaMemset(vsigma, 0, array_size);
+  cudaMemset(v2rho, 0, array_size);
+  cudaMemset(v2rhosigma, 0, array_size);
+  cudaMemset(v2sigma, 0, array_size);
 
-    err = cudaMalloc((void **)&vsigmaC, array_size);
-    if (err != cudaSuccess)
-    {
-        fprintf(stderr, "Failed to allocate device vsigmaC!\n");
-        exit(EXIT_FAILURE);
-    }
+  // The outputs for correlation
+  double* vrhoC = NULL;
+  double* vsigmaC = NULL;
+  double* v2rhoC = NULL;
+  double* v2rhosigmaC = NULL;
+  double* v2sigmaC = NULL;
 
-    err = cudaMalloc((void **)&v2rhoC, array_size);
-    if (err != cudaSuccess)
-    {
-        fprintf(stderr, "Failed to allocate device v2rhoC!\n");
-        exit(EXIT_FAILURE);
-    }
+  err = cudaMalloc((void**)&vrhoC, array_size);
+  if (err != cudaSuccess) {
+    fprintf(stderr, "Failed to allocate device vrhoC!\n");
+    exit(EXIT_FAILURE);
+  }
 
-    err = cudaMalloc((void **)&v2rhosigmaC, array_size);
-    if (err != cudaSuccess)
-    {
-        fprintf(stderr, "Failed to allocate device v2rhosigmaC!\n");
-        exit(EXIT_FAILURE);
-    }
+  err = cudaMalloc((void**)&vsigmaC, array_size);
+  if (err != cudaSuccess) {
+    fprintf(stderr, "Failed to allocate device vsigmaC!\n");
+    exit(EXIT_FAILURE);
+  }
 
-    err = cudaMalloc((void **)&v2sigmaC, array_size);
-    if (err != cudaSuccess)
-    {
-        fprintf(stderr, "Failed to allocate device v2sigmaC!\n");
-        exit(EXIT_FAILURE);
-    }
+  err = cudaMalloc((void**)&v2rhoC, array_size);
+  if (err != cudaSuccess) {
+    fprintf(stderr, "Failed to allocate device v2rhoC!\n");
+    exit(EXIT_FAILURE);
+  }
 
-    ///////////////////////////////////
-    // Clear arrays for correlation
-    cudaMemset(vrhoC, 0, array_size);
-    cudaMemset(vsigmaC, 0, array_size);
-    cudaMemset(v2rhoC, 0, array_size);
-    cudaMemset(v2rhosigmaC, 0, array_size);
-    cudaMemset(v2sigmaC, 0, array_size);
+  err = cudaMalloc((void**)&v2rhosigmaC, array_size);
+  if (err != cudaSuccess) {
+    fprintf(stderr, "Failed to allocate device v2rhosigmaC!\n");
+    exit(EXIT_FAILURE);
+  }
 
-    /////////////////////////////
-    // Call LIBXC for exchange
-    try {
-        xc_gga (&funcForExchange, number_of_points,
-                rho,
-                sigma,
-                exchange,
-                vrho,
-                vsigma,
-                v2rho,
-                v2rhosigma,
-                v2sigma,
-                NULL, NULL, NULL, NULL);
-    } catch (int exception) {
-        fprintf (stderr, "Exception ocurred calling xc_gga for Exchange '%d' \n", exception);
-        return;
-    }
+  err = cudaMalloc((void**)&v2sigmaC, array_size);
+  if (err != cudaSuccess) {
+    fprintf(stderr, "Failed to allocate device v2sigmaC!\n");
+    exit(EXIT_FAILURE);
+  }
 
-    ////////////////////////////////
-    // Call LIBXC for correlation
-    try {
-        // Now the correlation value.
-        xc_gga (&funcForCorrelation, number_of_points,
-                rho,
-                sigma,
-                correlation,
-                vrhoC,
-                vsigmaC,
-                v2rhoC,
-                v2rhosigmaC,
-                v2sigmaC,
-                NULL, NULL, NULL, NULL);
-    } catch (int exception) {
-        fprintf (stderr, "Exception ocurred calling xc_gga for Correlation '%d' \n", exception);
-        return;
-    }
+  ///////////////////////////////////
+  // Clear arrays for correlation
+  cudaMemset(vrhoC, 0, array_size);
+  cudaMemset(vsigmaC, 0, array_size);
+  cudaMemset(v2rhoC, 0, array_size);
+  cudaMemset(v2rhosigmaC, 0, array_size);
+  cudaMemset(v2sigmaC, 0, array_size);
 
-    ////////////////////////
-    // Gather the results
-    joinResults<T, width><<<blocksPerGrid, threadsPerBlock>>>(
-	ex_double, exchange,
-	ec_double, correlation,
-	vrho, vrhoC,
-	vsigma, vsigmaC,
-	v2rho, v2rhoC,
-	v2rhosigma, v2rhosigmaC,
-	v2sigma, v2sigmaC,
-	y2a_double,
-	sigma,
-	grad_double,
-	hess1_double,
-	hess2_double,
-	number_of_points,fact_exchange);
-
-    //////////////////////////
-    // Convert if necessary
-    if (!full_double) {
-	convertDoubleToFloat<<<blocksPerGrid, threadsPerBlock>>> (ex_double, ex, number_of_points);
-	convertDoubleToFloat<<<blocksPerGrid, threadsPerBlock>>> (ec_double, ec, number_of_points);
-        convertDoubleToFloat<<<blocksPerGrid, threadsPerBlock>>> (y2a_double, y2a, number_of_points);
-    }
-
-    /////////////////////////
-    // Free device memory
-    if (rho != NULL) {
-	cudaFree(rho);
-    }
-    if (sigma != NULL) {
-	cudaFree(sigma);
-    }
-    if (exchange != NULL) {
-	cudaFree(exchange);
-    }
-    if (correlation != NULL) {
-	cudaFree(correlation);
-    }
-    if (vrho != NULL) {
-        cudaFree(vrho);
-    }
-    if (vsigma != NULL) {
-	cudaFree(vsigma);
-    }
-    if (v2rho != NULL) {
-	cudaFree(v2rho);
-    }
-    if (v2rhosigma != NULL) {
-	cudaFree(v2rhosigma);
-    }
-    if (v2sigma != NULL) {
-	cudaFree(v2sigma);
-    }
-    if (vrhoC != NULL) {
-        cudaFree(vrhoC);
-    }
-    if (vsigmaC != NULL) {
-	cudaFree(vsigmaC);
-    }
-    if (v2rhoC != NULL) {
-	cudaFree(v2rhoC);
-    }
-    if (v2rhosigmaC != NULL) {
-	cudaFree(v2rhosigmaC);
-    }
-    if (v2sigmaC != NULL) {
-	cudaFree(v2sigmaC);
-    }
-
-    if (!full_double) {
-        if (ex_double != NULL) {
-            cudaFree(ex_double);
-        }
-        if (ec_double != NULL) {
-            cudaFree(ec_double);
-        }
-        if (y2a_double != NULL) {
-        cudaFree(y2a_double);
-        }
-        if (grad_double != NULL) {
-            cudaFree((void*)grad_double);
-    	}
-    	if (hess1_double != NULL) {
-        cudaFree((void*)hess1_double);
-    	}
-        if (hess2_double != NULL) {
-    	    cudaFree((void*)hess2_double);
-        }
-    }
-#endif
+  /////////////////////////////
+  // Call LIBXC for exchange
+  try {
+    xc_gga(&funcForExchange, number_of_points, rho, sigma, exchange, vrho,
+           vsigma, v2rho, v2rhosigma, v2sigma, NULL, NULL, NULL, NULL);
+  } catch (int exception) {
+    fprintf(stderr, "Exception ocurred calling xc_gga for Exchange '%d' \n",
+            exception);
     return;
+  }
+
+  ////////////////////////////////
+  // Call LIBXC for correlation
+  try {
+    // Now the correlation value.
+    xc_gga(&funcForCorrelation, number_of_points, rho, sigma, correlation,
+           vrhoC, vsigmaC, v2rhoC, v2rhosigmaC, v2sigmaC, NULL, NULL, NULL,
+           NULL);
+  } catch (int exception) {
+    fprintf(stderr, "Exception ocurred calling xc_gga for Correlation '%d' \n",
+            exception);
+    return;
+  }
+
+  ////////////////////////
+  // Gather the results
+  joinResults<T, width><<<blocksPerGrid, threadsPerBlock>>>(
+      ex_double, exchange, ec_double, correlation, vrho, vrhoC, vsigma, vsigmaC,
+      v2rho, v2rhoC, v2rhosigma, v2rhosigmaC, v2sigma, v2sigmaC, y2a_double,
+      sigma, grad_double, hess1_double, hess2_double, number_of_points,
+      fact_exchange);
+
+  //////////////////////////
+  // Convert if necessary
+  if (!full_double) {
+    convertDoubleToFloat<<<blocksPerGrid, threadsPerBlock>>>(ex_double, ex,
+                                                             number_of_points);
+    convertDoubleToFloat<<<blocksPerGrid, threadsPerBlock>>>(ec_double, ec,
+                                                             number_of_points);
+    convertDoubleToFloat<<<blocksPerGrid, threadsPerBlock>>>(y2a_double, y2a,
+                                                             number_of_points);
+  }
+
+  /////////////////////////
+  // Free device memory
+  if (rho != NULL) {
+    cudaFree(rho);
+  }
+  if (sigma != NULL) {
+    cudaFree(sigma);
+  }
+  if (exchange != NULL) {
+    cudaFree(exchange);
+  }
+  if (correlation != NULL) {
+    cudaFree(correlation);
+  }
+  if (vrho != NULL) {
+    cudaFree(vrho);
+  }
+  if (vsigma != NULL) {
+    cudaFree(vsigma);
+  }
+  if (v2rho != NULL) {
+    cudaFree(v2rho);
+  }
+  if (v2rhosigma != NULL) {
+    cudaFree(v2rhosigma);
+  }
+  if (v2sigma != NULL) {
+    cudaFree(v2sigma);
+  }
+  if (vrhoC != NULL) {
+    cudaFree(vrhoC);
+  }
+  if (vsigmaC != NULL) {
+    cudaFree(vsigmaC);
+  }
+  if (v2rhoC != NULL) {
+    cudaFree(v2rhoC);
+  }
+  if (v2rhosigmaC != NULL) {
+    cudaFree(v2rhosigmaC);
+  }
+  if (v2sigmaC != NULL) {
+    cudaFree(v2sigmaC);
+  }
+
+  if (!full_double) {
+    if (ex_double != NULL) {
+      cudaFree(ex_double);
+    }
+    if (ec_double != NULL) {
+      cudaFree(ec_double);
+    }
+    if (y2a_double != NULL) {
+      cudaFree(y2a_double);
+    }
+    if (grad_double != NULL) {
+      cudaFree((void*)grad_double);
+    }
+    if (hess1_double != NULL) {
+      cudaFree((void*)hess1_double);
+    }
+    if (hess2_double != NULL) {
+      cudaFree((void*)hess2_double);
+    }
+  }
+#endif
+  return;
 }
 
 //////////////////////////////////////////////////////////////
@@ -1667,17 +1580,20 @@ void LibxcProxy <T, width>::doGGA(T* dens,
 // grad:.
 // hess1:
 // hess2:
-// ex: here goes the results after calling xc_gga from libxc for the exchange functional
-// ec: here goes the results after calling xc_gga from libxc for the correlation functional
+// ex: here goes the results after calling xc_gga from libxc for the exchange
+// functional ec: here goes the results after calling xc_gga from libxc for the
+// correlation functional
 //
 // Note: all the pointer data are pointers in CUDA memory.
 //
 
 template <class T, int width>
-void LibxcProxy <T, width>::doLDA(T dens, const G2G::vec_type<T, width> &grad, const G2G::vec_type<T, width> &hess1, const G2G::vec_type<T, width> &hess2, T &ex, T &ec, T &y2a)
-{
-    //TODO: not implemented yet!
-    return;
+void LibxcProxy<T, width>::doLDA(T dens, const G2G::vec_type<T, width>& grad,
+                                 const G2G::vec_type<T, width>& hess1,
+                                 const G2G::vec_type<T, width>& hess2, T& ex,
+                                 T& ec, T& y2a) {
+  // TODO: not implemented yet!
+  return;
 }
 
-#endif // LIBXCPROXY_H
+#endif  // LIBXCPROXY_H

--- a/g2g/libxc/libxcproxy_cuda.h
+++ b/g2g/libxc/libxcproxy_cuda.h
@@ -13,259 +13,233 @@
 //#include <cuda_runtime.h>
 #include "../timer.h"
 
-extern "C" void g2g_timer_sum_start_(const char* timer_name, unsigned int length_arg);
-extern "C" void g2g_timer_sum_stop_(const char* timer_name, unsigned int length_arg);
-extern "C" void g2g_timer_sum_pause_(const char* timer_name, unsigned int length_arg);
+extern "C" void g2g_timer_sum_start_(const char* timer_name,
+                                     unsigned int length_arg);
+extern "C" void g2g_timer_sum_stop_(const char* timer_name,
+                                    unsigned int length_arg);
+extern "C" void g2g_timer_sum_pause_(const char* timer_name,
+                                     unsigned int length_arg);
 
 template <class T, int width>
-class LibxcProxy_cuda
-{
-private:
+class LibxcProxy_cuda {
+ private:
+  // The libxc components
+  xc_func_type_cuda funcForExchange;
+  xc_func_type_cuda funcForCorrelation;
 
-    // The libxc components
-    xc_func_type_cuda funcForExchange;
-    xc_func_type_cuda funcForCorrelation;
+  // Functional ids
+  int funcIdForExchange;
+  int funcIdForCorrelation;
+  int nspin;
 
-    // Functional ids
-    int funcIdForExchange;
-    int funcIdForCorrelation;
-    int nspin;
+  // Is inited
+  bool inited_cuda;
 
-    // Is inited
-    bool inited_cuda;
+  // Exchange Exact
+  double fact_exchange;
 
-    // Exchange Exact
-    double fact_exchange;
+  void printFunctionalInformation(xc_func_type_cuda* func);
 
-    void printFunctionalInformation (xc_func_type_cuda* func);
+ public:
+  LibxcProxy_cuda();
+  LibxcProxy_cuda(int* func_id, double* func_coef, int nx_coef, int nc_coef,
+                  int nsr_id, double screen, int nSpin);
 
-public:
-    LibxcProxy_cuda ();
-    LibxcProxy_cuda (int* func_id,double* func_coef, int nx_coef, int nc_coef,
-                                int nsr_id, double screen, int nSpin);
+  void init_cuda(int, int, int);
 
-    void init_cuda (int, int, int);
+  ~LibxcProxy_cuda();
 
-    ~LibxcProxy_cuda ();
+  void doGGA(T dens, const G2G::vec_type<T, width>& grad,
+             const G2G::vec_type<T, width>& hess1,
+             const G2G::vec_type<T, width>& hess2, T& ex, T& ec, T& y2a);
 
-    void doGGA (T dens,
-                const G2G::vec_type<T,width>& grad,
-                const G2G::vec_type<T,width>& hess1,
-                const G2G::vec_type<T,width>& hess2,
-                T& ex,
-                T& ec,
-                T& y2a);
+  void doGGA(T* dens, const int number_of_points,
+             const G2G::vec_type<T, width>* grad,
+             const G2G::vec_type<T, width>* hess1,
+             const G2G::vec_type<T, width>* hess2, T* ex, T* ec, T* y2a);
 
-    void doGGA (T* dens,
-                const int number_of_points,
-		const G2G::vec_type<T,width>* grad,
-                const G2G::vec_type<T,width>* hess1,
-                const G2G::vec_type<T,width>* hess2,
-                T* ex,
-                T* ec,
-                T* y2a);
+  void doGGA(T dens, T sigma, T* v2rho2, T v2rhosigma, T v2sigma2);
 
-    void doGGA (T dens,
-                T sigma,
-                T* v2rho2,
-                T v2rhosigma,
-                T v2sigma2);
+  void doGGA(T* dens, T* sigma, const int number_of_points, T* v2rho2,
+             T* v2rhosigma, T* v2sigma2);
 
-    void doGGA (T* dens,
-		T* sigma,
-                const int number_of_points,
-		T* v2rho2,
-		T* v2rhosigma,
-		T* v2sigma2);
+  void doGGA(T* dens, const int number_of_points, const T* contracted_grad,
+             const G2G::vec_type<T, width>* grad,
+             const G2G::vec_type<T, width>* hess1,
+             const G2G::vec_type<T, width>* hess2, T* ex, T* ec, T* y2a);
 
-    void doGGA (T* dens,
-                const int number_of_points,
-		const T* contracted_grad,
-		const G2G::vec_type<T,width>* grad,
-                const G2G::vec_type<T,width>* hess1,
-                const G2G::vec_type<T,width>* hess2,
-                T* ex,
-                T* ec,
-                T* y2a);
+  void coefLR(const int npoints, double* rho, double* sigma, double* red,
+              double* cruz, double* lrCoef);  // GPU
 
-    void coefLR(const int npoints, double* rho,double* sigma,
-                double* red,double* cruz,double* lrCoef); // GPU
+  void coefZv(const int npoints, double* rho, double* sigma, double* red,
+              G2G::vec_type<T, WIDTH>* dxyz, G2G::vec_type<T, WIDTH>* txyz,
+              double* lrCoef);
 
-    void coefZv(const int npoints, double* rho, double* sigma,
-                double* red, G2G::vec_type<T,WIDTH>* dxyz, G2G::vec_type<T,WIDTH>* txyz,
-                double* lrCoef);
+  void obtain_gpu_der(
+      const int npoints, T* rho, T* sigma, G2G::vec_type<T, 2>* vrho,
+      G2G::vec_type<T, 2>* vsigma, G2G::vec_type<T, 2>* v2rho2,
+      G2G::vec_type<T, 2>* v2rhosigma, G2G::vec_type<T, 2>* v2sigma2,
+      G2G::vec_type<T, 2>* v3rho3, G2G::vec_type<T, 2>* v3rho2sigma,
+      G2G::vec_type<T, 2>* v3rhosigma2, G2G::vec_type<T, 2>* v3sigma3);
 
-    void obtain_gpu_der(const int npoints, T* rho, T* sigma, 
-                        G2G::vec_type<T,2>* vrho,
-                        G2G::vec_type<T,2>* vsigma,
-                        G2G::vec_type<T,2>* v2rho2,
-                        G2G::vec_type<T,2>* v2rhosigma,
-                        G2G::vec_type<T,2>* v2sigma2,
-                        G2G::vec_type<T,2>* v3rho3,
-                        G2G::vec_type<T,2>* v3rho2sigma,
-                        G2G::vec_type<T,2>* v3rhosigma2,
-                        G2G::vec_type<T,2>* v3sigma3);
+  void doLDA(T dens, const G2G::vec_type<T, width>& grad,
+             const G2G::vec_type<T, width>& hess1,
+             const G2G::vec_type<T, width>& hess2, T& ex, T& ec, T& y2a);
 
-    void doLDA (T dens,
-                const G2G::vec_type<T,width>& grad,
-                const G2G::vec_type<T,width>& hess1,
-                const G2G::vec_type<T,width>& hess2,
-                T& ex,
-                T& ec,
-                T& y2a);
-
-    void closeProxy_cuda ();
-    void printFunctionalsInformation (int exchangeFunctionalId, int correlationFunctionalId);
+  void closeProxy_cuda();
+  void printFunctionalsInformation(int exchangeFunctionalId,
+                                   int correlationFunctionalId);
 };
 
 template <class T, int width>
-LibxcProxy_cuda <T, width>::LibxcProxy_cuda()
-{
-    funcIdForExchange = 0;
-    funcIdForCorrelation = 0;
-    nspin = 0;
+LibxcProxy_cuda<T, width>::LibxcProxy_cuda() {
+  funcIdForExchange = 0;
+  funcIdForCorrelation = 0;
+  nspin = 0;
+  inited_cuda = false;
+}
+
+template <class T, int width>
+LibxcProxy_cuda<T, width>::LibxcProxy_cuda(int* func_id, double* func_coef,
+                                           int nx_coef, int nc_coef, int nsr_id,
+                                           double screen, int nSpin) {
+  // Checkeamos que el funcional sea pbe o pbe0, ya que libxc en GPU solo
+  // funciona con estos funcionales
+  int ntot = nx_coef + nc_coef;
+  if (ntot != 2) {
+    cout << "Libxc gpu implementation only works with pbe or pbe0" << endl;
+    cout
+        << "If you want other functinal, please compile LIO in cpu with libxc=1"
+        << endl;
+    exit(-1);
+  }
+  int other_func = 0;
+  if (func_id[0] != 101) other_func = 1;
+  if (func_id[1] != 130) other_func = 1;
+
+  if (other_func == 1) {
+    cout << "Libxc gpu implementation only works with pbe or pbe0" << endl;
+    cout
+        << "If you want other functinal, please compile LIO in cpu with libxc=1"
+        << endl;
+    exit(-1);
+  }
+  fact_exchange = func_coef[0];
+  int func_x, func_c;
+  func_x = func_id[0] + 1000;
+  func_c = func_id[1] + 1000;
+  init_cuda(func_x, func_c, nSpin);
+}
+
+template <class T, int width>
+void LibxcProxy_cuda<T, width>::init_cuda(int exchangeFunctionalId,
+                                          int correlationFunctionalId,
+                                          int nSpin) {
+  //    printf("LibxcProxy_cuda::init(%u, %u, %u)\n", exchangeFunctionalId,
+  //    correlationFunctionalId, nSpin);
+  funcIdForExchange = exchangeFunctionalId;
+  funcIdForCorrelation = correlationFunctionalId;
+  nspin = nSpin;
+
+  // printf("libxcproxy_cuda.h XC_GGA_X_PBE_cuda XC_GGA_C_PBE_cuda %d
+  // %d\n",XC_GGA_X_PBE_cuda,XC_GGA_C_PBE_cuda); printf("libxcproxy_cuda.h exID
+  // coID %d %d\n",exchangeFunctionalId,correlationFunctionalId);
+
+  if (xc_func_init_cuda(&funcForExchange, funcIdForExchange, nspin) != 0) {
+    fprintf(stderr, "cuda X Functional '%d' not found\n", funcIdForExchange);
+    exit(-1);
+  }
+
+  if (xc_func_init_cuda(&funcForCorrelation, funcIdForCorrelation, nspin) !=
+      0) {
+    fprintf(stderr, "cuda E Functional '%d' not found\n", funcIdForCorrelation);
+    exit(-1);
+  }
+
+  inited_cuda = true;
+}
+
+template <class T, int width>
+LibxcProxy_cuda<T, width>::~LibxcProxy_cuda() {
+  // xc_func_end (&funcForExchange);
+  // xc_func_end (&funcForCorrelation);
+  //    printf("LibxcProxy_cuda::~LibxcProxy_cuda()\n");
+  closeProxy_cuda();
+}
+
+template <class T, int width>
+void LibxcProxy_cuda<T, width>::closeProxy_cuda() {
+  // printf("LibxcProxy_cuda::closeProxy()\n");
+  if (inited_cuda) {
+    xc_func_end_cuda(&funcForExchange);
+    xc_func_end_cuda(&funcForCorrelation);
     inited_cuda = false;
+  }
 }
 
 template <class T, int width>
-LibxcProxy_cuda <T, width>::LibxcProxy_cuda (int* func_id,double* func_coef, int nx_coef, int nc_coef,
-                                   int nsr_id, double screen, int nSpin)
-{
-// Checkeamos que el funcional sea pbe o pbe0, ya que libxc en GPU solo funciona con estos 
-// funcionales
-    int ntot = nx_coef + nc_coef;
-    if ( ntot != 2 ) {
-       cout << "Libxc gpu implementation only works with pbe or pbe0" << endl;
-       cout << "If you want other functinal, please compile LIO in cpu with libxc=1" << endl;
-       exit(-1);
-    }
-    int other_func = 0;
-    if ( func_id[0] != 101 ) other_func = 1;
-    if ( func_id[1] != 130 ) other_func = 1;
+void LibxcProxy_cuda<T, width>::printFunctionalsInformation(
+    int exchangeFunctionalId, int correlationFunctionalId) {
+  if (!inited_cuda) {
+    init_cuda(exchangeFunctionalId, correlationFunctionalId, 1);
+  }
 
-    if ( other_func == 1 ) {
-       cout << "Libxc gpu implementation only works with pbe or pbe0" << endl;
-       cout << "If you want other functinal, please compile LIO in cpu with libxc=1" << endl;
-       exit(-1);
-    }
-    fact_exchange = func_coef[0];
-    int func_x, func_c;
-    func_x = func_id[0] + 1000;
-    func_c = func_id[1] + 1000;
-    init_cuda (func_x, func_c, nSpin);
+  printFunctionalInformation(&funcForExchange);
+  printFunctionalInformation(&funcForCorrelation);
+
+  if (inited_cuda) {
+    closeProxy_cuda();
+  }
 }
 
 template <class T, int width>
-void LibxcProxy_cuda<T, width>::init_cuda (int exchangeFunctionalId, int correlationFunctionalId, int nSpin)
-{
-//    printf("LibxcProxy_cuda::init(%u, %u, %u)\n", exchangeFunctionalId, correlationFunctionalId, nSpin);
-    funcIdForExchange = exchangeFunctionalId;
-    funcIdForCorrelation = correlationFunctionalId;
-    nspin = nSpin;
+void LibxcProxy_cuda<T, width>::printFunctionalInformation(
+    xc_func_type_cuda* func) {
+  printf("The functional '%s' is ", func->info->name);
+  switch (func->info->kind) {
+    case (XC_EXCHANGE):
+      printf("an exchange functional");
+      break;
+    case (XC_CORRELATION):
+      printf("a correlation functional");
+      break;
+    case (XC_EXCHANGE_CORRELATION):
+      printf("an exchange-correlation functional");
+      break;
+    case (XC_KINETIC):
+      printf("a kinetic energy functional");
+      break;
+    default:
+      printf("of unknown kind");
+      break;
+  }
 
-    //printf("libxcproxy_cuda.h XC_GGA_X_PBE_cuda XC_GGA_C_PBE_cuda %d %d\n",XC_GGA_X_PBE_cuda,XC_GGA_C_PBE_cuda);
-    //printf("libxcproxy_cuda.h exID coID %d %d\n",exchangeFunctionalId,correlationFunctionalId);
+  printf(", it belongs to the '", func->info->name);
+  switch (func->info->family) {
+    case (XC_FAMILY_LDA):
+      printf("LDA");
+      break;
+    case (XC_FAMILY_GGA):
+      printf("GGA");
+      break;
+    case (XC_FAMILY_HYB_GGA):
+      printf("Hybrid GGA");
+      break;
+    case (XC_FAMILY_MGGA):
+      printf("MGGA");
+      break;
+    case (XC_FAMILY_HYB_MGGA):
+      printf("Hybrid MGGA");
+      break;
+    default:
+      printf("unknown");
+      break;
+  }
+  printf("' family and is defined in the reference(s):\n");
 
-
-    if (xc_func_init_cuda (&funcForExchange, funcIdForExchange, nspin) != 0) {
-        fprintf (stderr, "cuda X Functional '%d' not found\n", funcIdForExchange);
-	exit(-1);
-    }
-
-    if (xc_func_init_cuda (&funcForCorrelation, funcIdForCorrelation, nspin) != 0){
-	fprintf (stderr, "cuda E Functional '%d' not found\n", funcIdForCorrelation);
-	exit(-1);
-    }
-
-    inited_cuda = true;
-}
-
-template <class T, int width>
-LibxcProxy_cuda <T, width>::~LibxcProxy_cuda ()
-{
-    //xc_func_end (&funcForExchange);
-    //xc_func_end (&funcForCorrelation);
-//    printf("LibxcProxy_cuda::~LibxcProxy_cuda()\n");
-    closeProxy_cuda ();
-}
-
-template <class T, int width>
-void LibxcProxy_cuda <T, width>::closeProxy_cuda ()
-{
-   // printf("LibxcProxy_cuda::closeProxy()\n");
-    if (inited_cuda) {
-	xc_func_end_cuda (&funcForExchange);
-        xc_func_end_cuda (&funcForCorrelation);
-	inited_cuda = false;
-    }
-}
-
-template <class T, int width>
-void LibxcProxy_cuda<T, width>::printFunctionalsInformation (int exchangeFunctionalId, int correlationFunctionalId) 
-{
-    if (!inited_cuda) 
-    {
-	init_cuda (exchangeFunctionalId, correlationFunctionalId, 1);
-    }
-
-    printFunctionalInformation (&funcForExchange);
-    printFunctionalInformation (&funcForCorrelation);
-
-    if (inited_cuda) 
-    {
-	closeProxy_cuda ();
-    }
-}
-
-template <class T, int width>
-void LibxcProxy_cuda<T, width>::printFunctionalInformation (xc_func_type_cuda* func)
-{
-    printf("The functional '%s' is ", func->info->name);
-    switch (func->info->kind) {
-	case (XC_EXCHANGE):
-	    printf("an exchange functional");
-	break;
-	case (XC_CORRELATION):
-	    printf("a correlation functional");
-	break;
-	case (XC_EXCHANGE_CORRELATION):
-	    printf("an exchange-correlation functional");
-	break;
-	case (XC_KINETIC):
-	    printf("a kinetic energy functional");
-	break;
-	default:
-	    printf("of unknown kind");
-	break;
-    }
-
-    printf(", it belongs to the '", func->info->name);
-    switch (func->info->family) {
-	case (XC_FAMILY_LDA):
-	    printf("LDA");
-        break;
-	case (XC_FAMILY_GGA):
-	    printf("GGA");
-        break;
-	case (XC_FAMILY_HYB_GGA):
-	    printf("Hybrid GGA");
-	break;
-	case (XC_FAMILY_MGGA):
-	    printf("MGGA");
-        break;
-	case (XC_FAMILY_HYB_MGGA):
-	    printf("Hybrid MGGA");
-        break;
-	default:
-	    printf("unknown");
-        break;
-    }
-    printf("' family and is defined in the reference(s):\n");
-
-    for (int ii = 0; func->info->refs[ii] != NULL; ii++) {
-	printf ("[%d] %s\n", ii+1, func->info->refs[ii]->ref);
-    }
-
+  for (int ii = 0; func->info->refs[ii] != NULL; ii++) {
+    printf("[%d] %s\n", ii + 1, func->info->refs[ii]->ref);
+  }
 }
 
 //////////////////////////////////////////////////////////////
@@ -276,90 +250,80 @@ void LibxcProxy_cuda<T, width>::printFunctionalInformation (xc_func_type_cuda* f
 // grad:.
 // hess1:
 // hess2:
-// ex: here goes the results after calling xc_gga from libxc for the exchange functional
-// ec: here goes the results after calling xc_gga from libxc for the correlation functional
-// y2a:
+// ex: here goes the results after calling xc_gga from libxc for the exchange
+// functional ec: here goes the results after calling xc_gga from libxc for the
+// correlation functional y2a:
 //
 template <class T, int width>
-void LibxcProxy_cuda <T, width>::doGGA(T dens,
-    const G2G::vec_type<T, width> &grad,
-    const G2G::vec_type<T, width> &hess1,
-    const G2G::vec_type<T, width> &hess2,
-    T &ex, T &ec, T &y2a)
-{
-    //printf("LibxcProxy_cuda::doGGA cpu simple(...) \n");
+void LibxcProxy_cuda<T, width>::doGGA(T dens,
+                                      const G2G::vec_type<T, width>& grad,
+                                      const G2G::vec_type<T, width>& hess1,
+                                      const G2G::vec_type<T, width>& hess2,
+                                      T& ex, T& ec, T& y2a) {
+  // printf("LibxcProxy_cuda::doGGA cpu simple(...) \n");
 
-    const double rho[1] = {dens};
-    // Libxc needs the 'contracted gradient'
-    double sigma[1] = {(grad.x * grad.x) + (grad.y * grad.y) + (grad.z * grad.z)};
-    double exchange[1];
-    double correlation[1];
+  const double rho[1] = {dens};
+  // Libxc needs the 'contracted gradient'
+  double sigma[1] = {(grad.x * grad.x) + (grad.y * grad.y) + (grad.z * grad.z)};
+  double exchange[1];
+  double correlation[1];
 
-    // The outputs for exchange
-    double vrho [1];
-    double vsigma [1];
-    double v2rho [1];
-    double v2rhosigma[1];
-    double v2sigma [1];
-    double y2a_x;
+  // The outputs for exchange
+  double vrho[1];
+  double vsigma[1];
+  double v2rho[1];
+  double v2rhosigma[1];
+  double v2sigma[1];
+  double y2a_x;
 
-    // The outputs for correlation
-    double vrhoC [1];
-    double vsigmaC [1];
-    double v2rhoC [1];
-    double v2rhosigmaC [1];
-    double v2sigmaC [1];
-    double y2a_c;
+  // The outputs for correlation
+  double vrhoC[1];
+  double vsigmaC[1];
+  double v2rhoC[1];
+  double v2rhosigmaC[1];
+  double v2sigmaC[1];
+  double y2a_c;
 
-    // The exchange values
-    xc_gga_cuda (&funcForExchange, 1,
-                rho,
-                sigma,
-                exchange,
-                vrho,
-                vsigma,
-                v2rho,
-                v2rhosigma,
-                v2sigma,
-                NULL, NULL, NULL, NULL);
+  // The exchange values
+  xc_gga_cuda(&funcForExchange, 1, rho, sigma, exchange, vrho, vsigma, v2rho,
+              v2rhosigma, v2sigma, NULL, NULL, NULL, NULL);
 
-    // Now the correlation value.
-    xc_gga_cuda (&funcForCorrelation, 1,
-                rho,
-                sigma,
-                correlation,
-                vrhoC,
-                vsigmaC,
-                v2rhoC,
-                v2rhosigmaC,
-                v2sigmaC,
-                NULL, NULL, NULL, NULL);
+  // Now the correlation value.
+  xc_gga_cuda(&funcForCorrelation, 1, rho, sigma, correlation, vrhoC, vsigmaC,
+              v2rhoC, v2rhosigmaC, v2sigmaC, NULL, NULL, NULL, NULL);
 
-    ex = fact_exchange * exchange[0];
-    ec = correlation[0];
+  ex = fact_exchange * exchange[0];
+  ec = correlation[0];
 
-    // Merge the results for the derivatives.
-/*
-    vrho[0] += vrhoC[0];
-    vsigma[0] += vsigmaC[0];
-    v2rho[0] += v2rhoC[0];
-    v2rhosigma[0] += v2rhosigmaC[0];
-    v2sigma[0] += v2sigmaC[0];
-*/
+  // Merge the results for the derivatives.
+  /*
+      vrho[0] += vrhoC[0];
+      vsigma[0] += vsigmaC[0];
+      v2rho[0] += v2rhoC[0];
+      v2rhosigma[0] += v2rhosigmaC[0];
+      v2sigma[0] += v2sigmaC[0];
+  */
 
-    // Now, compute y2a value.
-    y2a_x = vrho[0] - (2 * sigma[0] * v2rhosigma[0]
-            + 2 * (hess1.x + hess1.y + hess1.z) * vsigma[0]
-            + 4 * v2sigma[0] * (grad.x * grad.x * hess1.x + grad.y * grad.y * hess1.y + grad.z * grad.z * hess1.z + 2 * grad.x * grad.y * hess2.x + 2 * grad.x * grad.z * hess2.y + 2 * grad.y * grad.z * hess2.z));
+  // Now, compute y2a value.
+  y2a_x = vrho[0] -
+          (2 * sigma[0] * v2rhosigma[0] +
+           2 * (hess1.x + hess1.y + hess1.z) * vsigma[0] +
+           4 * v2sigma[0] *
+               (grad.x * grad.x * hess1.x + grad.y * grad.y * hess1.y +
+                grad.z * grad.z * hess1.z + 2 * grad.x * grad.y * hess2.x +
+                2 * grad.x * grad.z * hess2.y + 2 * grad.y * grad.z * hess2.z));
 
+  y2a_c = vrhoC[0] -
+          (2 * sigma[0] * v2rhosigmaC[0] +
+           2 * (hess1.x + hess1.y + hess1.z) * vsigmaC[0] +
+           4 * v2sigmaC[0] *
+               (grad.x * grad.x * hess1.x + grad.y * grad.y * hess1.y +
+                grad.z * grad.z * hess1.z + 2 * grad.x * grad.y * hess2.x +
+                2 * grad.x * grad.z * hess2.y + 2 * grad.y * grad.z * hess2.z));
 
-    y2a_c = vrhoC[0] - (2 * sigma[0] * v2rhosigmaC[0]
-            + 2 * (hess1.x + hess1.y + hess1.z) * vsigmaC[0]
-            + 4 * v2sigmaC[0] * (grad.x * grad.x * hess1.x + grad.y * grad.y * hess1.y + grad.z * grad.z * hess1.z + 2 * grad.x * grad.y * hess2.x + 2 * grad.x * grad.z * hess2.y + 2 * grad.y * grad.z * hess2.z));
+  y2a = fact_exchange * y2a_x + y2a_c;
 
-    y2a = fact_exchange * y2a_x + y2a_c;
-
-    return;
+  return;
 }
 
 //////////////////////////////////////////////////////////////
@@ -371,116 +335,99 @@ void LibxcProxy_cuda <T, width>::doGGA(T dens,
 // grad: gradient value in each point
 // hess1:
 // hess2:
-// ex: here goes the results after calling xc_gga from libxc for the exchange functional
-// ec: here goes the results after calling xc_gga from libxc for the correlation functional
-// y2a:
+// ex: here goes the results after calling xc_gga from libxc for the exchange
+// functional ec: here goes the results after calling xc_gga from libxc for the
+// correlation functional y2a:
 //
 template <class T, int width>
-void LibxcProxy_cuda <T, width>::doGGA(T* dens,
-    const int number_of_points,
-    const G2G::vec_type<T, width>* grad,
-    const G2G::vec_type<T, width>* hess1,
-    const G2G::vec_type<T, width>* hess2,
-    T* ex,
-    T* ec,
-    T* y2a)
-{
-    //printf("LibxcProxy_cuda::doGGA cpu multiple (...) \n");
+void LibxcProxy_cuda<T, width>::doGGA(T* dens, const int number_of_points,
+                                      const G2G::vec_type<T, width>* grad,
+                                      const G2G::vec_type<T, width>* hess1,
+                                      const G2G::vec_type<T, width>* hess2,
+                                      T* ex, T* ec, T* y2a) {
+  // printf("LibxcProxy_cuda::doGGA cpu multiple (...) \n");
 
-    int array_size = sizeof(double)*number_of_points;
-    double* rho = (double*)malloc(array_size);
-    for (int i=0; i<number_of_points; i++) {
-	rho[i] = (double)dens[i];
-    }
+  int array_size = sizeof(double) * number_of_points;
+  double* rho = (double*)malloc(array_size);
+  for (int i = 0; i < number_of_points; i++) {
+    rho[i] = (double)dens[i];
+  }
 
-    // Libxc needs the 'contracted gradient'
-    double* sigma = (double*)malloc(array_size);
-    for (int i=0; i< number_of_points; i++) {
-	sigma[i] = (double)((grad[i].x * grad[i].x) + (grad[i].y * grad[i].y) + (grad[i].z * grad[i].z));
-    }
-    double* exchange = (double*)malloc(array_size);
-    double* correlation = (double*)malloc(array_size);
+  // Libxc needs the 'contracted gradient'
+  double* sigma = (double*)malloc(array_size);
+  for (int i = 0; i < number_of_points; i++) {
+    sigma[i] = (double)((grad[i].x * grad[i].x) + (grad[i].y * grad[i].y) +
+                        (grad[i].z * grad[i].z));
+  }
+  double* exchange = (double*)malloc(array_size);
+  double* correlation = (double*)malloc(array_size);
 
-    // The outputs for exchange
-    double* vrho = (double*)malloc(array_size);
-    double* vsigma = (double*)malloc(array_size);
-    double* v2rho = (double*)malloc(array_size);
-    double* v2rhosigma = (double*)malloc(array_size);
-    double* v2sigma = (double*)malloc(array_size);
+  // The outputs for exchange
+  double* vrho = (double*)malloc(array_size);
+  double* vsigma = (double*)malloc(array_size);
+  double* v2rho = (double*)malloc(array_size);
+  double* v2rhosigma = (double*)malloc(array_size);
+  double* v2sigma = (double*)malloc(array_size);
 
-    // The outputs for correlation
-    double* vrhoC = (double*)malloc(array_size);
-    double* vsigmaC = (double*)malloc(array_size);
-    double* v2rhoC = (double*)malloc(array_size);
-    double* v2rhosigmaC = (double*)malloc(array_size);
-    double* v2sigmaC = (double*)malloc(array_size);
+  // The outputs for correlation
+  double* vrhoC = (double*)malloc(array_size);
+  double* vsigmaC = (double*)malloc(array_size);
+  double* v2rhoC = (double*)malloc(array_size);
+  double* v2rhosigmaC = (double*)malloc(array_size);
+  double* v2sigmaC = (double*)malloc(array_size);
 
-    // Exchange values
-    xc_gga_cuda (&funcForExchange, number_of_points,
-                rho,
-                sigma,
-                exchange,
-                vrho,
-                vsigma,
-                v2rho,
-                v2rhosigma,
-                v2sigma,
-                NULL, NULL, NULL, NULL);
+  // Exchange values
+  xc_gga_cuda(&funcForExchange, number_of_points, rho, sigma, exchange, vrho,
+              vsigma, v2rho, v2rhosigma, v2sigma, NULL, NULL, NULL, NULL);
 
-    // Now the correlation value.
-    xc_gga_cuda (&funcForCorrelation, number_of_points,
-                rho,
-                sigma,
-                correlation,
-                vrhoC,
-                vsigmaC,
-                v2rhoC,
-                v2rhosigmaC,
-                v2sigmaC,
-                NULL, NULL, NULL, NULL);
+  // Now the correlation value.
+  xc_gga_cuda(&funcForCorrelation, number_of_points, rho, sigma, correlation,
+              vrhoC, vsigmaC, v2rhoC, v2rhosigmaC, v2sigmaC, NULL, NULL, NULL,
+              NULL);
 
-    for (int i=0; i<number_of_points; i++) {
-	ex[i] = exchange[i];
-        ec[i] = correlation[i];
-        // Merge the results for the derivatives.
-        vrho[i] += vrhoC[i];
-        vsigma[i] += vsigmaC[i];
-        v2rho[i] += v2rhoC[i];
-        v2rhosigma[i] += v2rhosigmaC[i];
-        v2sigma[i] += v2sigmaC[i];
+  for (int i = 0; i < number_of_points; i++) {
+    ex[i] = exchange[i];
+    ec[i] = correlation[i];
+    // Merge the results for the derivatives.
+    vrho[i] += vrhoC[i];
+    vsigma[i] += vsigmaC[i];
+    v2rho[i] += v2rhoC[i];
+    v2rhosigma[i] += v2rhosigmaC[i];
+    v2sigma[i] += v2sigmaC[i];
 
-	// Now, compute y2a value.
-        y2a[i] = vrho[i] - (2 * sigma[i] * v2rhosigma[i]
-	        + 2 * (hess1[i].x + hess1[i].y + hess1[i].z) * vsigma[i]
-    		+ 4 * v2sigma[i] * (grad[i].x * grad[i].x * hess1[i].x +
-				    grad[i].y * grad[i].y * hess1[i].y +
-				    grad[i].z * grad[i].z * hess1[i].z +
-				    2 * grad[i].x * grad[i].y * hess2[i].x +
-				    2 * grad[i].x * grad[i].z * hess2[i].y +
-				    2 * grad[i].y * grad[i].z * hess2[i].z));
-    }
+    // Now, compute y2a value.
+    y2a[i] = vrho[i] - (2 * sigma[i] * v2rhosigma[i] +
+                        2 * (hess1[i].x + hess1[i].y + hess1[i].z) * vsigma[i] +
+                        4 * v2sigma[i] *
+                            (grad[i].x * grad[i].x * hess1[i].x +
+                             grad[i].y * grad[i].y * hess1[i].y +
+                             grad[i].z * grad[i].z * hess1[i].z +
+                             2 * grad[i].x * grad[i].y * hess2[i].x +
+                             2 * grad[i].x * grad[i].z * hess2[i].y +
+                             2 * grad[i].y * grad[i].z * hess2[i].z));
+  }
 
-    // Free memory.
-    free(rho);
-    free(sigma);
-    free(exchange);
-    free(correlation);
+  // Free memory.
+  free(rho);
+  free(sigma);
+  free(exchange);
+  free(correlation);
 
-    // The outputs for exchange
-    free(vrho);
-    free(vsigma);
-    free(v2rho);
-    free(v2rhosigma);
-    free(v2sigma);
+  // The outputs for exchange
+  free(vrho);
+  free(vsigma);
+  free(v2rho);
+  free(v2rhosigma);
+  free(v2sigma);
 
-    // The outputs for correlation
-    free(vrhoC);
-    free(vsigmaC);
-    free(v2rhoC);
-    free(v2rhosigmaC);
-    free(v2sigmaC);
+  // The outputs for correlation
+  free(vrhoC);
+  free(vsigmaC);
+  free(v2rhoC);
+  free(v2rhosigmaC);
+  free(v2sigmaC);
 
-    return;
+  return;
 }
 
 //////////////////////////////////////////////////////////////
@@ -490,939 +437,933 @@ void LibxcProxy_cuda <T, width>::doGGA(T* dens,
 // rho: pointer for the density array.
 // sigma: contracted gradient array.
 // number_of_points: the size of all the input arrays.
-// v2rho2: second partial derivative of the energy per unit volume in terms of the density.
-// v2rhosigma: second partial derivative of the energy per unit volume in terms of the density and sigma.
-// v2sigma2: second partial derivative of the energy per unit volume in terms of sigma.
+// v2rho2: second partial derivative of the energy per unit volume in terms of
+// the density. v2rhosigma: second partial derivative of the energy per unit
+// volume in terms of the density and sigma. v2sigma2: second partial derivative
+// of the energy per unit volume in terms of sigma.
 //
 template <class T, int width>
-void LibxcProxy_cuda <T, width>::doGGA (T* rho,
-    T* sigma,
-    const int number_of_points,
-    T* v2rho2,
-    T* v2rhosigma,
-    T* v2sigma2)
-{
-    int array_size = sizeof(double)*number_of_points;
+void LibxcProxy_cuda<T, width>::doGGA(T* rho, T* sigma,
+                                      const int number_of_points, T* v2rho2,
+                                      T* v2rhosigma, T* v2sigma2) {
+  int array_size = sizeof(double) * number_of_points;
 
-    // The outputs for exchange
-    double* v2rho2X = (double*)malloc(array_size);
-    double* v2rhosigmaX = (double*)malloc(array_size);
-    double* v2sigma2X = (double*)malloc(array_size);
+  // The outputs for exchange
+  double* v2rho2X = (double*)malloc(array_size);
+  double* v2rhosigmaX = (double*)malloc(array_size);
+  double* v2sigma2X = (double*)malloc(array_size);
 
-    // The outputs for correlation
-    double* v2rho2C = (double*)malloc(array_size);
-    double* v2rhosigmaC = (double*)malloc(array_size);
-    double* v2sigma2C = (double*)malloc(array_size);
+  // The outputs for correlation
+  double* v2rho2C = (double*)malloc(array_size);
+  double* v2rhosigmaC = (double*)malloc(array_size);
+  double* v2sigma2C = (double*)malloc(array_size);
 
-    // Exchange values
-    xc_gga_fxc_cuda (&funcForExchange, number_of_points,
-                rho,
-                sigma,
-                v2rho2X,
-                v2rhosigmaX,
-                v2sigma2X);
+  // Exchange values
+  xc_gga_fxc_cuda(&funcForExchange, number_of_points, rho, sigma, v2rho2X,
+                  v2rhosigmaX, v2sigma2X);
 
-    // Now the correlation value.
-    xc_gga_fxc_cuda (&funcForCorrelation, number_of_points,
-                rho,
-                sigma,
-                v2rho2C,
-                v2rhosigmaC,
-                v2sigma2C);
+  // Now the correlation value.
+  xc_gga_fxc_cuda(&funcForCorrelation, number_of_points, rho, sigma, v2rho2C,
+                  v2rhosigmaC, v2sigma2C);
 
-    for (int i=0; i<number_of_points; i++) {
-        // Merge the results for the derivatives.
-        v2rho2[i] = v2rho2X[i] + v2rho2C[i];
-        v2rhosigma[i] = v2rhosigmaX[i] + v2rhosigmaC[i];
-        v2sigma2[i] += v2sigma2X[i] + v2sigma2C[i];
-    }
+  for (int i = 0; i < number_of_points; i++) {
+    // Merge the results for the derivatives.
+    v2rho2[i] = v2rho2X[i] + v2rho2C[i];
+    v2rhosigma[i] = v2rhosigmaX[i] + v2rhosigmaC[i];
+    v2sigma2[i] += v2sigma2X[i] + v2sigma2C[i];
+  }
 
-    // Free memory
-    // The outputs for exchange
-    free(v2rho2X);
-    free(v2rhosigmaX);
-    free(v2sigma2X);
+  // Free memory
+  // The outputs for exchange
+  free(v2rho2X);
+  free(v2rhosigmaX);
+  free(v2sigma2X);
 
-    // The outputs for correlation
-    free(v2rho2C);
-    free(v2rhosigmaC);
-    free(v2sigma2C);
+  // The outputs for correlation
+  free(v2rho2C);
+  free(v2rhosigmaC);
+  free(v2sigma2C);
 
-    return;
+  return;
 }
 
 #ifdef __CUDACC__
 
 template <class T, int width>
-__global__ void local_coef_gpu(double* tred, double* cruz, double* Coef,double* v2rho2,
-                               double* v2rhosigma,double* v2sigma2,double* vsigma, 
-                               const int npoints,double fact_ex,const bool exchange) 
-{
-   double fex;
-   int i = blockDim.x * blockIdx.x + threadIdx.x;
+__global__ void local_coef_gpu(double* tred, double* cruz, double* Coef,
+                               double* v2rho2, double* v2rhosigma,
+                               double* v2sigma2, double* vsigma,
+                               const int npoints, double fact_ex,
+                               const bool exchange) {
+  double fex;
+  int i = blockDim.x * blockIdx.x + threadIdx.x;
 
-   fex = fact_ex;
+  fex = fact_ex;
 
-   if ( i < npoints ) {
+  if (i < npoints) {
+    if (exchange) {  // EXCHANGE
 
-     if ( exchange ) { // EXCHANGE
+      Coef[i] =
+          (2.0f * tred[i] * v2rho2[i] + 8.0f * cruz[i] * v2rhosigma[i]) * fex;
+      Coef[npoints + i] =
+          (8.0f * tred[i] * v2rhosigma[i] + 32.0f * cruz[i] * v2sigma2[i]) *
+          fex;
+      Coef[2 * npoints + i] = 4.0f * vsigma[i] * fex;
 
-       Coef[i] = (2.0f * tred[i] * v2rho2[i] + 8.0f * cruz[i] * v2rhosigma[i]) * fex;
-       Coef[npoints+i] = (8.0f * tred[i] * v2rhosigma[i] + 32.0f * cruz[i] * v2sigma2[i]) * fex;
-       Coef[2*npoints+i] = 4.0f * vsigma[i] * fex;
+    } else {  // CORRELATION
 
-     } else { // CORRELATION
+      Coef[i] += 2.0f * tred[i] * v2rho2[i] + 8.0f * cruz[i] * v2rhosigma[i];
+      Coef[npoints + i] +=
+          8.0f * tred[i] * v2rhosigma[i] + 32.0f * cruz[i] * v2sigma2[i];
+      Coef[2 * npoints + i] += 4.0f * vsigma[i];
 
-       Coef[i] += 2.0f * tred[i] * v2rho2[i] + 8.0f * cruz[i] * v2rhosigma[i];
-       Coef[npoints+i] += 8.0f * tred[i] * v2rhosigma[i] + 32.0f * cruz[i] * v2sigma2[i];
-       Coef[2*npoints+i] += 4.0f * vsigma[i];
+    }  // end if exc-corr
 
-     } // end if exc-corr
-
-   } // end if points
+  }  // end if points
 }
 #endif
-
 
 // GPU VERSION
 template <class T, int width>
-void LibxcProxy_cuda <T, width>::coefLR (const int npoints, double* rho,
-               double* sigma, double* red, double* cruz, double* lrCoef) // GPU
+void LibxcProxy_cuda<T, width>::coefLR(const int npoints, double* rho,
+                                       double* sigma, double* red, double* cruz,
+                                       double* lrCoef)  // GPU
 {
 #ifdef __CUDACC__
 
-   int size = sizeof(double) * npoints;
-   cudaError_t err = cudaSuccess;
+  int size = sizeof(double) * npoints;
+  cudaError_t err = cudaSuccess;
 
-// Outputs libxc
-   double* vrho       = NULL;
-   double* vsigma     = NULL;
-   double* v2rho2     = NULL;
-   double* v2rhosigma = NULL;
-   double* v2sigma2   = NULL;
-   double* energy     = NULL;
+  // Outputs libxc
+  double* vrho = NULL;
+  double* vsigma = NULL;
+  double* v2rho2 = NULL;
+  double* v2rhosigma = NULL;
+  double* v2sigma2 = NULL;
+  double* energy = NULL;
 
-// Allocate Outputs
-   err = cudaMalloc((void**)&vrho,size);
-   if (err != cudaSuccess) {
-      printf("Error to allocate vrho");
-      exit(EXIT_FAILURE);
-   }
+  // Allocate Outputs
+  err = cudaMalloc((void**)&vrho, size);
+  if (err != cudaSuccess) {
+    printf("Error to allocate vrho");
+    exit(EXIT_FAILURE);
+  }
 
-   err = cudaMalloc((void**)&vsigma,size);
-   if (err != cudaSuccess) {
-      printf("Error to allocate vsigma");
-      exit(EXIT_FAILURE);
-   }
+  err = cudaMalloc((void**)&vsigma, size);
+  if (err != cudaSuccess) {
+    printf("Error to allocate vsigma");
+    exit(EXIT_FAILURE);
+  }
 
-   err = cudaMalloc((void**)&v2rho2,size);
-   if (err != cudaSuccess) {
-      printf("Error to allocate v2rho2");
-      exit(EXIT_FAILURE);
-   }
+  err = cudaMalloc((void**)&v2rho2, size);
+  if (err != cudaSuccess) {
+    printf("Error to allocate v2rho2");
+    exit(EXIT_FAILURE);
+  }
 
-   err = cudaMalloc((void**)&v2rhosigma,size);
-   if (err != cudaSuccess) {
-      printf("Error to allocate v2rhosigma");
-      exit(EXIT_FAILURE);
-   }
+  err = cudaMalloc((void**)&v2rhosigma, size);
+  if (err != cudaSuccess) {
+    printf("Error to allocate v2rhosigma");
+    exit(EXIT_FAILURE);
+  }
 
-   err = cudaMalloc((void**)&v2sigma2,size);
-   if (err != cudaSuccess) {
-      printf("Error to allocate v2sigma2");
-      exit(EXIT_FAILURE);
-   }
+  err = cudaMalloc((void**)&v2sigma2, size);
+  if (err != cudaSuccess) {
+    printf("Error to allocate v2sigma2");
+    exit(EXIT_FAILURE);
+  }
 
-   err = cudaMalloc((void**)&energy,size);
-   if (err != cudaSuccess) {
-      printf("Error to allocate energy");
-      exit(EXIT_FAILURE);
-   }
+  err = cudaMalloc((void**)&energy, size);
+  if (err != cudaSuccess) {
+    printf("Error to allocate energy");
+    exit(EXIT_FAILURE);
+  }
 
-   cudaMemset(energy,0.0f,size);
-   cudaMemset(vrho,0.0f,size);
-   cudaMemset(vsigma,0.0f,size);
-   cudaMemset(v2rho2,0.0f,size);
-   cudaMemset(v2rhosigma,0.0f,size);
-   cudaMemset(v2sigma2,0.0f,size);
+  cudaMemset(energy, 0.0f, size);
+  cudaMemset(vrho, 0.0f, size);
+  cudaMemset(vsigma, 0.0f, size);
+  cudaMemset(v2rho2, 0.0f, size);
+  cudaMemset(v2rhosigma, 0.0f, size);
+  cudaMemset(v2sigma2, 0.0f, size);
 
-// Call LIBXC for Exchange
-   try {
-       xc_gga_cuda(&funcForExchange,npoints,
-               rho,
-               sigma,
-               energy,
-               vrho,
-               vsigma,
-               v2rho2,
-               v2rhosigma,
-               v2sigma2,
-               NULL, NULL, NULL, NULL);
-   } catch (int exception) {
-       fprintf (stderr, "Exception ocurred calling xc_gga for Exchange '%d' \n", exception);
-       return;
-   }
+  // Call LIBXC for Exchange
+  try {
+    xc_gga_cuda(&funcForExchange, npoints, rho, sigma, energy, vrho, vsigma,
+                v2rho2, v2rhosigma, v2sigma2, NULL, NULL, NULL, NULL);
+  } catch (int exception) {
+    fprintf(stderr, "Exception ocurred calling xc_gga for Exchange '%d' \n",
+            exception);
+    return;
+  }
 
-   int threadsPerBlock = 256;
-   int blocksPerGrid = (npoints + threadsPerBlock - 1) / threadsPerBlock;
+  int threadsPerBlock = 256;
+  int blocksPerGrid = (npoints + threadsPerBlock - 1) / threadsPerBlock;
 
-// Obtain coef of Exchange
-   local_coef_gpu<T,width> <<<blocksPerGrid,threadsPerBlock>>>(red,cruz,
-   lrCoef,v2rho2,v2rhosigma,v2sigma2,vsigma,npoints,fact_exchange,true);
+  // Obtain coef of Exchange
+  local_coef_gpu<T, width><<<blocksPerGrid, threadsPerBlock>>>(
+      red, cruz, lrCoef, v2rho2, v2rhosigma, v2sigma2, vsigma, npoints,
+      fact_exchange, true);
 
-   cudaMemset(energy,0.0f,size);
-   cudaMemset(vrho,0.0f,size);
-   cudaMemset(vsigma,0.0f,size);
-   cudaMemset(v2rho2,0.0f,size);
-   cudaMemset(v2rhosigma,0.0f,size);
-   cudaMemset(v2sigma2,0.0f,size);
+  cudaMemset(energy, 0.0f, size);
+  cudaMemset(vrho, 0.0f, size);
+  cudaMemset(vsigma, 0.0f, size);
+  cudaMemset(v2rho2, 0.0f, size);
+  cudaMemset(v2rhosigma, 0.0f, size);
+  cudaMemset(v2sigma2, 0.0f, size);
 
-// Call LIBXC for Coerrelation
-   try {
-       xc_gga_cuda(&funcForCorrelation,npoints,
-               rho,
-               sigma,
-               energy,
-               vrho,
-               vsigma,
-               v2rho2,
-               v2rhosigma,
-               v2sigma2,
-               NULL, NULL, NULL, NULL);
-   } catch (int exception) {
-       fprintf (stderr, "Exception ocurred calling xc_gga for Exchange '%d' \n", exception);
-       return;
-   }
+  // Call LIBXC for Coerrelation
+  try {
+    xc_gga_cuda(&funcForCorrelation, npoints, rho, sigma, energy, vrho, vsigma,
+                v2rho2, v2rhosigma, v2sigma2, NULL, NULL, NULL, NULL);
+  } catch (int exception) {
+    fprintf(stderr, "Exception ocurred calling xc_gga for Exchange '%d' \n",
+            exception);
+    return;
+  }
 
-// Obtain coef of Coerrelation
-   local_coef_gpu<T,width> <<<blocksPerGrid,threadsPerBlock>>>(red,cruz,
-   lrCoef,v2rho2,v2rhosigma,v2sigma2,vsigma,npoints,0.0f,false);
+  // Obtain coef of Coerrelation
+  local_coef_gpu<T, width><<<blocksPerGrid, threadsPerBlock>>>(
+      red, cruz, lrCoef, v2rho2, v2rhosigma, v2sigma2, vsigma, npoints, 0.0f,
+      false);
 
-/*
-   double* v2rho2_cpu = (double*) malloc(3*size);
-   memset(v2rho2_cpu,0.0f,3*size);
-   err = cudaMemcpy(v2rho2_cpu,lrCoef,3*size,cudaMemcpyDeviceToHost);
-   if (err != cudaSuccess) cout << "caca copy" << endl;
-   for (int i=0; i<3*npoints; i++)
-      printf("point(%d)=\t%f\t%f\t%f\n",i,v2rho2_cpu[i],v2rho2_cpu[npoints+i],v2rho2_cpu[2*npoints+i]);
-      //printf("point(%d)=\t%f\n",i,v2rho2_cpu[i]);
+  /*
+     double* v2rho2_cpu = (double*) malloc(3*size);
+     memset(v2rho2_cpu,0.0f,3*size);
+     err = cudaMemcpy(v2rho2_cpu,lrCoef,3*size,cudaMemcpyDeviceToHost);
+     if (err != cudaSuccess) cout << "caca copy" << endl;
+     for (int i=0; i<3*npoints; i++)
+        printf("point(%d)=\t%f\t%f\t%f\n",i,v2rho2_cpu[i],v2rho2_cpu[npoints+i],v2rho2_cpu[2*npoints+i]);
+        //printf("point(%d)=\t%f\n",i,v2rho2_cpu[i]);
 
-   exit(-1);
-*/
+     exit(-1);
+  */
 
-// Free memory
-   cudaFree(vrho);       vrho = NULL;
-   cudaFree(vsigma);     vsigma = NULL;
-   cudaFree(v2rho2);     v2rho2 = NULL;
-   cudaFree(v2rhosigma); v2rhosigma = NULL;
-   cudaFree(v2sigma2);   v2sigma2 = NULL;
-   cudaFree(energy);     energy = NULL;
+  // Free memory
+  cudaFree(vrho);
+  vrho = NULL;
+  cudaFree(vsigma);
+  vsigma = NULL;
+  cudaFree(v2rho2);
+  v2rho2 = NULL;
+  cudaFree(v2rhosigma);
+  v2rhosigma = NULL;
+  cudaFree(v2sigma2);
+  v2sigma2 = NULL;
+  cudaFree(energy);
+  energy = NULL;
 
 #endif
-   return;
+  return;
 }
 
 #ifdef __CUDACC__
 
 template <class T, int width>
-__global__ void Zv_exchange(const int npoints,double* td,
-           G2G::vec_type<T,WIDTH>* dxyz, G2G::vec_type<T,WIDTH>* txyz,
-           double* Coef,double* v2rho2, double* v2rhosigma, double* v2sigma2,
-           double* v3rho3,double* v3rho2sigma,double* v3rhosigma2,double* v3sigma3,double fact_ex)
+__global__ void Zv_exchange(const int npoints, double* td,
+                            G2G::vec_type<T, WIDTH>* dxyz,
+                            G2G::vec_type<T, WIDTH>* txyz, double* Coef,
+                            double* v2rho2, double* v2rhosigma,
+                            double* v2sigma2, double* v3rho3,
+                            double* v3rho2sigma, double* v3rhosigma2,
+                            double* v3sigma3, double fact_ex)
 
 {
-   double fex = fact_ex;
-   int i = blockDim.x * blockIdx.x + threadIdx.x;
+  double fex = fact_ex;
+  int i = blockDim.x * blockIdx.x + threadIdx.x;
 
-   double DUMNV[2],DUMGRV[4],DUMXX[4];
-   double C[10];
+  double DUMNV[2], DUMGRV[4], DUMXX[4];
+  double C[10];
 
-   if ( i < npoints ) {
-      DUMNV[0] = DUMNV[1] = td[i];
+  if (i < npoints) {
+    DUMNV[0] = DUMNV[1] = td[i];
 
-      DUMGRV[0]=DUMGRV[1]=txyz[i].x*dxyz[i].x*0.5f + txyz[i].y*dxyz[i].y*0.5f + txyz[i].z*dxyz[i].z*0.5f;
-      DUMGRV[2]=DUMGRV[3]=DUMGRV[0];
+    DUMGRV[0] = DUMGRV[1] = txyz[i].x * dxyz[i].x * 0.5f +
+                            txyz[i].y * dxyz[i].y * 0.5f +
+                            txyz[i].z * dxyz[i].z * 0.5f;
+    DUMGRV[2] = DUMGRV[3] = DUMGRV[0];
 
-      DUMXX[0]=DUMXX[1]=txyz[i].x*txyz[i].x + txyz[i].y*txyz[i].y + txyz[i].z*txyz[i].z;
-      DUMXX[2]=DUMXX[3]=DUMXX[0];
+    DUMXX[0] = DUMXX[1] =
+        txyz[i].x * txyz[i].x + txyz[i].y * txyz[i].y + txyz[i].z * txyz[i].z;
+    DUMXX[2] = DUMXX[3] = DUMXX[0];
 
-      C[0]=2.0f*DUMXX[0];
-      C[1]=DUMNV[0]*DUMNV[0];
-      C[2]=2.0f*DUMNV[0]*DUMGRV[0];
-      C[3]=2.0f*DUMGRV[0]*DUMNV[0];
-      C[4]=DUMGRV[0]*DUMNV[0];
-      C[5]=DUMNV[0]*DUMGRV[0];
-      C[6]=4.0f*DUMGRV[0]*DUMGRV[0];
-      C[7]=2.0f*DUMGRV[0]*DUMGRV[0];
-      C[8]=2.0f*DUMGRV[0]*DUMGRV[0];
-      C[9]=DUMGRV[0]*DUMGRV[0];
+    C[0] = 2.0f * DUMXX[0];
+    C[1] = DUMNV[0] * DUMNV[0];
+    C[2] = 2.0f * DUMNV[0] * DUMGRV[0];
+    C[3] = 2.0f * DUMGRV[0] * DUMNV[0];
+    C[4] = DUMGRV[0] * DUMNV[0];
+    C[5] = DUMNV[0] * DUMGRV[0];
+    C[6] = 4.0f * DUMGRV[0] * DUMGRV[0];
+    C[7] = 2.0f * DUMGRV[0] * DUMGRV[0];
+    C[8] = 2.0f * DUMGRV[0] * DUMGRV[0];
+    C[9] = DUMGRV[0] * DUMGRV[0];
 
-      double XDUMA=0.0f;
-      double XDUMAG=0.0f;
-      XDUMA  = C[0] * 4.00f * v2rhosigma[i];
-      XDUMAG = C[0] * 16.0f * v2sigma2[i];
-      XDUMA += C[1] * 4.00f * v3rho3[i];
-      XDUMAG+= C[1] * 16.0f * v3rho2sigma[i];
-      XDUMA += C[2] * 8.00f * v3rho2sigma[i];
-      XDUMAG+= C[2] * 32.0f * v3rhosigma2[i];
-      XDUMA += C[3] * 8.00f * v3rho2sigma[i];
-      XDUMAG+= C[3] * 32.0f * v3rhosigma2[i];
-      XDUMA += C[6] * 16.0f * v3rhosigma2[i];
-      XDUMAG+= C[6] * 64.0f * v3sigma3[i];
+    double XDUMA = 0.0f;
+    double XDUMAG = 0.0f;
+    XDUMA = C[0] * 4.00f * v2rhosigma[i];
+    XDUMAG = C[0] * 16.0f * v2sigma2[i];
+    XDUMA += C[1] * 4.00f * v3rho3[i];
+    XDUMAG += C[1] * 16.0f * v3rho2sigma[i];
+    XDUMA += C[2] * 8.00f * v3rho2sigma[i];
+    XDUMAG += C[2] * 32.0f * v3rhosigma2[i];
+    XDUMA += C[3] * 8.00f * v3rho2sigma[i];
+    XDUMAG += C[3] * 32.0f * v3rhosigma2[i];
+    XDUMA += C[6] * 16.0f * v3rhosigma2[i];
+    XDUMAG += C[6] * 64.0f * v3sigma3[i];
 
-      double XDUMAGEA=0.0f;
-      XDUMAGEA  = 4.0f * DUMNV[0]  * 4.0f * v2rhosigma[i];
-      XDUMAGEA += 8.0f * DUMGRV[1] * 8.0f * v2sigma2[i];
+    double XDUMAGEA = 0.0f;
+    XDUMAGEA = 4.0f * DUMNV[0] * 4.0f * v2rhosigma[i];
+    XDUMAGEA += 8.0f * DUMGRV[1] * 8.0f * v2sigma2[i];
 
-      Coef[i]   = XDUMA * fex;
-      Coef[npoints+i] = XDUMAG * fex;
-      Coef[npoints*2+i] = XDUMAGEA * fex;
-   }
+    Coef[i] = XDUMA * fex;
+    Coef[npoints + i] = XDUMAG * fex;
+    Coef[npoints * 2 + i] = XDUMAGEA * fex;
+  }
 }
 #endif
 
 #ifdef __CUDACC__
 
 template <class T, int width>
-__global__ void Zv_coulomb(const int npoints,double* td,
-           G2G::vec_type<T,WIDTH>* dxyz, G2G::vec_type<T,WIDTH>* txyz,
-           double* Coef, double* v2rhosigma, double* v2sigma2,
-           double* v3rho3,double* v3rho2sigma,double* v3rhosigma2,double* v3sigma3)
-{
-   int i = blockDim.x * blockIdx.x + threadIdx.x;
-   double DUMNV[2],DUMGRV[4],DUMXX[4];
-   double C[20];
+__global__ void Zv_coulomb(const int npoints, double* td,
+                           G2G::vec_type<T, WIDTH>* dxyz,
+                           G2G::vec_type<T, WIDTH>* txyz, double* Coef,
+                           double* v2rhosigma, double* v2sigma2, double* v3rho3,
+                           double* v3rho2sigma, double* v3rhosigma2,
+                           double* v3sigma3) {
+  int i = blockDim.x * blockIdx.x + threadIdx.x;
+  double DUMNV[2], DUMGRV[4], DUMXX[4];
+  double C[20];
 
+  if (i < npoints) {
+    DUMNV[0] = DUMNV[1] = td[i];
 
-   if ( i < npoints ) {
-      DUMNV[0] = DUMNV[1] = td[i];
+    DUMGRV[0] = DUMGRV[1] = txyz[i].x * dxyz[i].x * 0.5f +
+                            txyz[i].y * dxyz[i].y * 0.5f +
+                            txyz[i].z * dxyz[i].z * 0.5f;
+    DUMGRV[2] = DUMGRV[3] = DUMGRV[0];
 
-      DUMGRV[0]=DUMGRV[1]=txyz[i].x*dxyz[i].x*0.5f + txyz[i].y*dxyz[i].y*0.5f + txyz[i].z*dxyz[i].z*0.5f;
-      DUMGRV[2]=DUMGRV[3]=DUMGRV[0];
+    DUMXX[0] = DUMXX[1] =
+        txyz[i].x * txyz[i].x + txyz[i].y * txyz[i].y + txyz[i].z * txyz[i].z;
+    DUMXX[2] = DUMXX[3] = DUMXX[0];
 
-      DUMXX[0]=DUMXX[1]=txyz[i].x*txyz[i].x + txyz[i].y*txyz[i].y + txyz[i].z*txyz[i].z;
-      DUMXX[2]=DUMXX[3]=DUMXX[0];
+    C[0] = 2.0f * DUMXX[0];
+    C[1] = DUMNV[0] * DUMNV[0];
+    C[2] = 2.0f * DUMNV[0] * DUMGRV[0];
+    C[3] = 2.0f * DUMGRV[0] * DUMNV[0];
+    C[4] = DUMGRV[0] * DUMNV[0];
+    C[5] = DUMNV[0] * DUMGRV[0];
+    C[6] = 4.0f * DUMGRV[0] * DUMGRV[0];
+    C[7] = 2.0f * DUMGRV[0] * DUMGRV[0];
+    C[8] = 2.0f * DUMGRV[0] * DUMGRV[0];
+    C[9] = DUMGRV[0] * DUMGRV[0];
 
-      C[0]=2.0f*DUMXX[0];
-      C[1]=DUMNV[0]*DUMNV[0];
-      C[2]=2.0f*DUMNV[0]*DUMGRV[0];
-      C[3]=2.0f*DUMGRV[0]*DUMNV[0];
-      C[4]=DUMGRV[0]*DUMNV[0];
-      C[5]=DUMNV[0]*DUMGRV[0];
-      C[6]=4.0f*DUMGRV[0]*DUMGRV[0];
-      C[7]=2.0f*DUMGRV[0]*DUMGRV[0];
-      C[8]=2.0f*DUMGRV[0]*DUMGRV[0];
-      C[9]=DUMGRV[0]*DUMGRV[0];
+    double CDUMA = 0.0f;
+    double CDUMAG1 = 0.0f;
+    double CDUMAG2 = 0.0f;
+    CDUMA = C[0] * v2rhosigma[i];
+    CDUMAG1 = C[0] * 2.0f * v2sigma2[i];
+    CDUMAG2 = C[0] * v2sigma2[i] * 2.0f;
+    CDUMA = CDUMA + C[1] * v3rho3[i];
+    CDUMAG1 = CDUMAG1 + C[1] * 2.0f * v3rho2sigma[i];
+    CDUMAG2 = CDUMAG2 + C[1] * v3rho2sigma[i] * 2.0f;
+    CDUMA = CDUMA + C[2] * v3rho2sigma[i];
+    CDUMAG1 = CDUMAG1 + C[2] * 2.0f * v3rhosigma2[i];
+    CDUMAG2 = CDUMAG2 + C[2] * v3rhosigma2[i] * 2.0f;
+    CDUMA = CDUMA + C[3] * v3rho2sigma[i];
+    CDUMAG1 = CDUMAG1 + C[3] * 2.0f * v3rhosigma2[i];
+    CDUMAG2 = CDUMAG2 + C[3] * v3rhosigma2[i] * 2.0f;
+    CDUMA = CDUMA + C[4] * v3rho2sigma[i] * 2.0f;
+    CDUMAG1 = CDUMAG1 + C[4] * 2.0f * v3rhosigma2[i] * 2.0f;
+    CDUMAG2 = CDUMAG2 + C[4] * v3rhosigma2[i] * 4.0f;
+    CDUMA = CDUMA + C[5] * v3rho2sigma[i] * 2.0f;
+    CDUMAG1 = CDUMAG1 + C[5] * 2.0f * v3rhosigma2[i] * 2.0f;
+    CDUMAG2 = CDUMAG2 + C[5] * v3rhosigma2[i] * 4.0f;
+    CDUMA = CDUMA + C[6] * v3rhosigma2[i];
+    CDUMAG1 = CDUMAG1 + C[6] * 2.0f * v3sigma3[i];
+    CDUMAG2 = CDUMAG2 + C[6] * v3sigma3[i] * 2.0f;
+    CDUMA = CDUMA + C[7] * v3rhosigma2[i] * 2.0f;
+    CDUMAG1 = CDUMAG1 + C[7] * 2.0f * v3sigma3[i] * 2.0f;
+    CDUMAG2 = CDUMAG2 + C[7] * v3sigma3[i] * 4.0f;
+    CDUMA = CDUMA + C[8] * v3rhosigma2[i] * 2.0f;
+    CDUMAG1 = CDUMAG1 + C[8] * 2.0f * v3sigma3[i] * 2.0f;
+    CDUMAG2 = CDUMAG2 + C[8] * v3sigma3[i] * 4.0f;
+    CDUMA = CDUMA + C[9] * v3rhosigma2[i] * 4.0f;
+    CDUMAG1 = CDUMAG1 + C[9] * 2.0f * v3sigma3[i] * 4.0f;
+    CDUMAG2 = CDUMAG2 + C[9] * v3sigma3[i] * 8.0f;
 
-      double CDUMA=0.0f;
-      double CDUMAG1=0.0f;
-      double CDUMAG2=0.0f;
-      CDUMA=C[0]*v2rhosigma[i];
-      CDUMAG1=C[0]*2.0f*v2sigma2[i];
-      CDUMAG2=C[0]*v2sigma2[i]*2.0f;
-      CDUMA=CDUMA+C[1]*v3rho3[i];
-      CDUMAG1=CDUMAG1+C[1]*2.0f*v3rho2sigma[i];
-      CDUMAG2=CDUMAG2+C[1]*v3rho2sigma[i]*2.0f;
-      CDUMA=CDUMA+C[2]*v3rho2sigma[i];
-      CDUMAG1=CDUMAG1+C[2]*2.0f*v3rhosigma2[i];
-      CDUMAG2=CDUMAG2+C[2]*v3rhosigma2[i]*2.0f;
-      CDUMA=CDUMA+C[3]*v3rho2sigma[i];
-      CDUMAG1=CDUMAG1+C[3]*2.0f*v3rhosigma2[i];
-      CDUMAG2=CDUMAG2+C[3]*v3rhosigma2[i]*2.0f;
-      CDUMA=CDUMA+C[4]*v3rho2sigma[i]*2.0f;
-      CDUMAG1=CDUMAG1+C[4]*2.0f*v3rhosigma2[i]*2.0f;
-      CDUMAG2=CDUMAG2+C[4]*v3rhosigma2[i]*4.0f;
-      CDUMA=CDUMA+C[5]*v3rho2sigma[i]*2.0f;
-      CDUMAG1=CDUMAG1+C[5]*2.0f*v3rhosigma2[i]*2.0f;
-      CDUMAG2=CDUMAG2+C[5]*v3rhosigma2[i]*4.0f;
-      CDUMA=CDUMA+C[6]*v3rhosigma2[i];
-      CDUMAG1=CDUMAG1+C[6]*2.0f*v3sigma3[i];
-      CDUMAG2=CDUMAG2+C[6]*v3sigma3[i]*2.0f;
-      CDUMA=CDUMA+C[7]*v3rhosigma2[i]*2.0f;
-      CDUMAG1=CDUMAG1+C[7]*2.0f*v3sigma3[i]*2.0f;
-      CDUMAG2=CDUMAG2+C[7]*v3sigma3[i]*4.0f;
-      CDUMA=CDUMA+C[8]*v3rhosigma2[i]*2.0f;
-      CDUMAG1=CDUMAG1+C[8]*2.0f*v3sigma3[i]*2.0f;
-      CDUMAG2=CDUMAG2+C[8]*v3sigma3[i]*4.0f;
-      CDUMA=CDUMA+C[9]*v3rhosigma2[i]*4.0f;
-      CDUMAG1=CDUMAG1+C[9]*2.0f*v3sigma3[i]*4.0f;
-      CDUMAG2=CDUMAG2+C[9]*v3sigma3[i]*8.0f;
+    C[0] = 2.0f * DUMXX[1];
+    C[1] = DUMNV[1] * DUMNV[1];
+    C[2] = 2.0f * DUMNV[1] * DUMGRV[1];
+    C[3] = 2.0f * DUMGRV[1] * DUMNV[1];
+    C[4] = DUMGRV[1] * DUMNV[1];
+    C[5] = DUMNV[1] * DUMGRV[1];
+    C[6] = 4.0f * DUMGRV[1] * DUMGRV[1];
+    C[7] = 2.0f * DUMGRV[1] * DUMGRV[1];
+    C[8] = 2.0f * DUMGRV[1] * DUMGRV[1];
+    C[9] = DUMGRV[1] * DUMGRV[1];
 
-      C[0]=2.0f*DUMXX[1];
-      C[1]=DUMNV[1]*DUMNV[1];
-      C[2]=2.0f*DUMNV[1]*DUMGRV[1];
-      C[3]=2.0f*DUMGRV[1]*DUMNV[1];
-      C[4]=DUMGRV[1]*DUMNV[1];
-      C[5]=DUMNV[1]*DUMGRV[1];
-      C[6]=4.0f*DUMGRV[1]*DUMGRV[1];
-      C[7]=2.0f*DUMGRV[1]*DUMGRV[1];
-      C[8]=2.0f*DUMGRV[1]*DUMGRV[1];
-      C[9]=DUMGRV[1]*DUMGRV[1];
+    CDUMA = CDUMA + C[0] * v2rhosigma[i];
+    CDUMAG1 = CDUMAG1 + C[0] * 2.0f * v2sigma2[i];
+    CDUMAG2 = CDUMAG2 + C[0] * v2sigma2[i] * 2.0f;
+    CDUMA = CDUMA + C[1] * v3rho3[i];
+    CDUMAG1 = CDUMAG1 + C[1] * 2.0f * v3rho2sigma[i];
+    CDUMAG2 = CDUMAG2 + C[1] * v3rho2sigma[i] * 2.0f;
+    CDUMA = CDUMA + C[2] * v3rho2sigma[i];
+    CDUMAG1 = CDUMAG1 + C[2] * 2.0f * v3rhosigma2[i];
+    CDUMAG2 = CDUMAG2 + C[2] * v3rhosigma2[i] * 2.0f;
+    CDUMA = CDUMA + C[3] * v3rho2sigma[i];
+    CDUMAG1 = CDUMAG1 + C[3] * 2.0f * v3rhosigma2[i];
+    CDUMAG2 = CDUMAG2 + C[3] * v3rhosigma2[i] * 2.0f;
+    CDUMA = CDUMA + C[4] * v3rho2sigma[i] * 2.0f;
+    CDUMAG1 = CDUMAG1 + C[4] * 2.0f * v3rhosigma2[i] * 2.0f;
+    CDUMAG2 = CDUMAG2 + C[4] * v3rhosigma2[i] * 4.0f;
+    CDUMA = CDUMA + C[5] * v3rho2sigma[i] * 2.0f;
+    CDUMAG1 = CDUMAG1 + C[5] * 2.0f * v3rhosigma2[i] * 2.0f;
+    CDUMAG2 = CDUMAG2 + C[5] * v3rhosigma2[i] * 4.0f;
+    CDUMA = CDUMA + C[6] * v3rhosigma2[i];
+    CDUMAG1 = CDUMAG1 + C[6] * 2.0f * v3sigma3[i];
+    CDUMAG2 = CDUMAG2 + C[6] * v3sigma3[i] * 2.0f;
+    CDUMA = CDUMA + C[7] * v3rhosigma2[i] * 2.0f;
+    CDUMAG1 = CDUMAG1 + C[7] * 2.0f * v3sigma3[i] * 2.0f;
+    CDUMAG2 = CDUMAG2 + C[7] * v3sigma3[i] * 4.0f;
+    CDUMA = CDUMA + C[8] * v3rhosigma2[i] * 2.0f;
+    CDUMAG1 = CDUMAG1 + C[8] * 2.0f * v3sigma3[i] * 2.0f;
+    CDUMAG2 = CDUMAG2 + C[8] * v3sigma3[i] * 4.0f;
+    CDUMA = CDUMA + C[9] * v3rhosigma2[i] * 4.0f;
+    CDUMAG1 = CDUMAG1 + C[9] * 2.0f * v3sigma3[i] * 4.0f;
+    CDUMAG2 = CDUMAG2 + C[9] * v3sigma3[i] * 8.0f;
 
+    C[10] = DUMXX[2];
+    C[11] = DUMNV[0] * DUMNV[1];
+    C[12] = 2.0f * DUMNV[0] * DUMGRV[1];
+    C[13] = 2.0f * DUMGRV[0] * DUMNV[1];
+    C[14] = DUMNV[0] * DUMGRV[3];
+    C[15] = DUMGRV[2] * DUMNV[1];
+    C[16] = 4.0f * DUMGRV[0] * DUMGRV[1];
+    C[17] = 2.0f * DUMGRV[0] * DUMGRV[3];
+    C[18] = 2.0f * DUMGRV[2] * DUMGRV[1];
+    C[19] = DUMGRV[2] * DUMGRV[3];
 
-      CDUMA=CDUMA+C[0]*v2rhosigma[i];
-      CDUMAG1=CDUMAG1+C[0]*2.0f*v2sigma2[i];
-      CDUMAG2=CDUMAG2+C[0]*v2sigma2[i]*2.0f;
-      CDUMA=CDUMA+C[1]*v3rho3[i];
-      CDUMAG1=CDUMAG1+C[1]*2.0f*v3rho2sigma[i];
-      CDUMAG2=CDUMAG2+C[1]*v3rho2sigma[i]*2.0f;
-      CDUMA=CDUMA+C[2]*v3rho2sigma[i];
-      CDUMAG1=CDUMAG1+C[2]*2.0f*v3rhosigma2[i];
-      CDUMAG2=CDUMAG2+C[2]*v3rhosigma2[i]*2.0f;
-      CDUMA=CDUMA+C[3]*v3rho2sigma[i];
-      CDUMAG1=CDUMAG1+C[3]*2.0f*v3rhosigma2[i];
-      CDUMAG2=CDUMAG2+C[3]*v3rhosigma2[i]*2.0f;
-      CDUMA=CDUMA+C[4]*v3rho2sigma[i]*2.0f;
-      CDUMAG1=CDUMAG1+C[4]*2.0f*v3rhosigma2[i]*2.0f;
-      CDUMAG2=CDUMAG2+C[4]*v3rhosigma2[i]*4.0f;
-      CDUMA=CDUMA+C[5]*v3rho2sigma[i]*2.0f;
-      CDUMAG1=CDUMAG1+C[5]*2.0f*v3rhosigma2[i]*2.0f;
-      CDUMAG2=CDUMAG2+C[5]*v3rhosigma2[i]*4.0f;
-      CDUMA=CDUMA+C[6]*v3rhosigma2[i];
-      CDUMAG1=CDUMAG1+C[6]*2.0f*v3sigma3[i];
-      CDUMAG2=CDUMAG2+C[6]*v3sigma3[i]*2.0f;
-      CDUMA=CDUMA+C[7]*v3rhosigma2[i]*2.0f;
-      CDUMAG1=CDUMAG1+C[7]*2.0f*v3sigma3[i]*2.0f;
-      CDUMAG2=CDUMAG2+C[7]*v3sigma3[i]*4.0f;
-      CDUMA=CDUMA+C[8]*v3rhosigma2[i]*2.0f;
-      CDUMAG1=CDUMAG1+C[8]*2.0f*v3sigma3[i]*2.0f;
-      CDUMAG2=CDUMAG2+C[8]*v3sigma3[i]*4.0f;
-      CDUMA=CDUMA+C[9]*v3rhosigma2[i]*4.0f;
-      CDUMAG1=CDUMAG1+C[9]*2.0f*v3sigma3[i]*4.0f;
-      CDUMAG2=CDUMAG2+C[9]*v3sigma3[i]*8.0f;
+    CDUMA = CDUMA + C[10] * v2rhosigma[i] * 2.0f;
+    CDUMAG1 = CDUMAG1 + C[10] * 2.0f * v2sigma2[i] * 2.0f;
+    CDUMAG2 = CDUMAG2 + C[10] * v2sigma2[i] * 4.0f;
+    CDUMA = CDUMA + C[11] * v3rho3[i];
+    CDUMAG1 = CDUMAG1 + C[11] * 2.0f * v3rho2sigma[i];
+    CDUMAG2 = CDUMAG2 + C[11] * v3rho2sigma[i] * 2.0f;
+    CDUMA = CDUMA + C[12] * v3rho2sigma[i];
+    CDUMAG1 = CDUMAG1 + C[12] * 2.0f * v3rhosigma2[i];
+    CDUMAG2 = CDUMAG2 + C[12] * v3rhosigma2[i] * 2.0f;
+    CDUMA = CDUMA + C[13] * v3rho2sigma[i];
+    CDUMAG1 = CDUMAG1 + C[13] * 2.0f * v3rhosigma2[i];
+    CDUMAG2 = CDUMAG2 + C[13] * v3rhosigma2[i] * 2.0f;
+    CDUMA = CDUMA + C[14] * v3rho2sigma[i] * 2.0f;
+    CDUMAG1 = CDUMAG1 + C[14] * 2.0f * v3rhosigma2[i] * 2.0f;
+    CDUMAG2 = CDUMAG2 + C[14] * v3rhosigma2[i] * 4.0f;
+    CDUMA = CDUMA + C[15] * v3rho2sigma[i] * 2.0f;
+    CDUMAG1 = CDUMAG1 + C[15] * 2.0f * v3rhosigma2[i] * 2.0f;
+    CDUMAG2 = CDUMAG2 + C[15] * v3rhosigma2[i] * 4.0f;
+    CDUMA = CDUMA + C[16] * v3rhosigma2[i];
+    CDUMAG1 = CDUMAG1 + C[16] * 2.0f * v3sigma3[i];
+    CDUMAG2 = CDUMAG2 + C[16] * v3sigma3[i] * 2.0f;
+    CDUMA = CDUMA + C[17] * v3rhosigma2[i] * 2.0f;
+    CDUMAG1 = CDUMAG1 + C[17] * 2.0f * v3sigma3[i] * 2.0f;
+    CDUMAG2 = CDUMAG2 + C[17] * v3sigma3[i] * 4.0f;
+    CDUMA = CDUMA + C[18] * v3rhosigma2[i] * 2.0f;
+    CDUMAG1 = CDUMAG1 + C[18] * 2.0f * v3sigma3[i] * 2.0f;
+    CDUMAG2 = CDUMAG2 + C[18] * v3sigma3[i] * 4.0f;
+    CDUMA = CDUMA + C[19] * v3rhosigma2[i] * 4.0f;
+    CDUMAG1 = CDUMAG1 + C[19] * 2.0f * v3sigma3[i] * 4.0f;
+    CDUMAG2 = CDUMAG2 + C[19] * v3sigma3[i] * 8.0f;
 
+    C[10] = DUMXX[2];
+    C[11] = DUMNV[0] * DUMNV[1];
+    C[12] = 2.0f * DUMNV[0] * DUMGRV[1];
+    C[13] = 2.0f * DUMGRV[0] * DUMNV[1];
+    C[14] = DUMNV[0] * DUMGRV[3];
+    C[15] = DUMGRV[2] * DUMNV[1];
+    C[16] = 4.0f * DUMGRV[0] * DUMGRV[1];
+    C[17] = 2.0f * DUMGRV[0] * DUMGRV[3];
+    C[18] = 2.0f * DUMGRV[2] * DUMGRV[1];
+    C[19] = DUMGRV[2] * DUMGRV[3];
 
-      C[10]=DUMXX[2];
-      C[11]=DUMNV[0]*DUMNV[1];
-      C[12]=2.0f*DUMNV[0]*DUMGRV[1];
-      C[13]=2.0f*DUMGRV[0]*DUMNV[1];
-      C[14]=DUMNV[0]*DUMGRV[3];
-      C[15]=DUMGRV[2]*DUMNV[1];
-      C[16]=4.0f*DUMGRV[0]*DUMGRV[1];
-      C[17]=2.0f*DUMGRV[0]*DUMGRV[3];
-      C[18]=2.0f*DUMGRV[2]*DUMGRV[1];
-      C[19]=DUMGRV[2]*DUMGRV[3];
+    CDUMA = CDUMA + C[10] * v2rhosigma[i] * 2.0f;
+    CDUMAG1 = CDUMAG1 + C[10] * 2.0f * v2sigma2[i] * 2.0f;
+    CDUMAG2 = CDUMAG2 + C[10] * v2sigma2[i] * 4.0f;
+    CDUMA = CDUMA + C[11] * v3rho3[i];
+    CDUMAG1 = CDUMAG1 + C[11] * 2.0f * v3rho2sigma[i];
+    CDUMAG2 = CDUMAG2 + C[11] * v3rho2sigma[i] * 2.0f;
+    CDUMA = CDUMA + C[12] * v3rho2sigma[i];
+    CDUMAG1 = CDUMAG1 + C[12] * 2.0f * v3rhosigma2[i];
+    CDUMAG2 = CDUMAG2 + C[12] * v3rhosigma2[i] * 2.0f;
+    CDUMA = CDUMA + C[13] * v3rho2sigma[i];
+    CDUMAG1 = CDUMAG1 + C[13] * 2.0f * v3rhosigma2[i];
+    CDUMAG2 = CDUMAG2 + C[13] * v3rhosigma2[i] * 2.0f;
+    CDUMA = CDUMA + C[14] * v3rho2sigma[i] * 2.0f;
+    CDUMAG1 = CDUMAG1 + C[14] * 2.0f * v3rhosigma2[i] * 2.0f;
+    CDUMAG2 = CDUMAG2 + C[14] * v3rhosigma2[i] * 4.0f;
+    CDUMA = CDUMA + C[15] * v3rho2sigma[i] * 2.0f;
+    CDUMAG1 = CDUMAG1 + C[15] * 2.0f * v3rhosigma2[i] * 2.0f;
+    CDUMAG2 = CDUMAG2 + C[15] * v3rhosigma2[i] * 4.0f;
+    CDUMA = CDUMA + C[16] * v3rhosigma2[i];
+    CDUMAG1 = CDUMAG1 + C[16] * 2.0f * v3sigma3[i];
+    CDUMAG2 = CDUMAG2 + C[16] * v3sigma3[i] * 2.0f;
+    CDUMA = CDUMA + C[17] * v3rhosigma2[i] * 2.0f;
+    CDUMAG1 = CDUMAG1 + C[17] * 2.0f * v3sigma3[i] * 2.0f;
+    CDUMAG2 = CDUMAG2 + C[17] * v3sigma3[i] * 4.0f;
+    CDUMA = CDUMA + C[18] * v3rhosigma2[i] * 2.0f;
+    CDUMAG1 = CDUMAG1 + C[18] * 2.0f * v3sigma3[i] * 2.0f;
+    CDUMAG2 = CDUMAG2 + C[18] * v3sigma3[i] * 4.0f;
+    CDUMA = CDUMA + C[19] * v3rhosigma2[i] * 4.0f;
+    CDUMAG1 = CDUMAG1 + C[19] * 2.0f * v3sigma3[i] * 4.0f;
+    CDUMAG2 = CDUMAG2 + C[19] * v3sigma3[i] * 8.0f;
 
+    double CDUMAGEA = 0.0f;
+    CDUMAGEA = CDUMAGEA + 4.0f * DUMNV[0] * v2rhosigma[i];
+    CDUMAGEA = CDUMAGEA + 8.0f * DUMGRV[0] * v2sigma2[i];
+    CDUMAGEA = CDUMAGEA + 4.0f * DUMGRV[2] * v2sigma2[i] * 2.0f;
+    CDUMAGEA = CDUMAGEA + 4.0f * DUMNV[1] * v2rhosigma[i];
+    CDUMAGEA = CDUMAGEA + 8.0f * DUMGRV[1] * v2sigma2[i];
+    CDUMAGEA = CDUMAGEA + 4.0f * DUMGRV[3] * v2sigma2[i] * 2.0f;
 
-      CDUMA=CDUMA+C[10]*v2rhosigma[i]*2.0f;
-      CDUMAG1=CDUMAG1+C[10]*2.0f*v2sigma2[i]*2.0f;
-      CDUMAG2=CDUMAG2+C[10]*v2sigma2[i]*4.0f;
-      CDUMA=CDUMA+C[11]*v3rho3[i];
-      CDUMAG1=CDUMAG1+C[11]*2.0f*v3rho2sigma[i];
-      CDUMAG2=CDUMAG2+C[11]*v3rho2sigma[i]*2.0f;
-      CDUMA=CDUMA+C[12]*v3rho2sigma[i];
-      CDUMAG1=CDUMAG1+C[12]*2.0f*v3rhosigma2[i];
-      CDUMAG2=CDUMAG2+C[12]*v3rhosigma2[i]*2.0f;
-      CDUMA=CDUMA+C[13]*v3rho2sigma[i];
-      CDUMAG1=CDUMAG1+C[13]*2.0f*v3rhosigma2[i];
-      CDUMAG2=CDUMAG2+C[13]*v3rhosigma2[i]*2.0f;
-      CDUMA=CDUMA+C[14]*v3rho2sigma[i]*2.0f;
-      CDUMAG1=CDUMAG1+C[14]*2.0f*v3rhosigma2[i]*2.0f;
-      CDUMAG2=CDUMAG2+C[14]*v3rhosigma2[i]*4.0f;
-      CDUMA=CDUMA+C[15]*v3rho2sigma[i]*2.0f;
-      CDUMAG1=CDUMAG1+C[15]*2.0f*v3rhosigma2[i]*2.0f;
-      CDUMAG2=CDUMAG2+C[15]*v3rhosigma2[i]*4.0f;
-      CDUMA=CDUMA+C[16]*v3rhosigma2[i];
-      CDUMAG1=CDUMAG1+C[16]*2.0f*v3sigma3[i];
-      CDUMAG2=CDUMAG2+C[16]*v3sigma3[i]*2.0f;
-      CDUMA=CDUMA+C[17]*v3rhosigma2[i]*2.0f;
-      CDUMAG1=CDUMAG1+C[17]*2.0f*v3sigma3[i]*2.0f;
-      CDUMAG2=CDUMAG2+C[17]*v3sigma3[i]*4.0f;
-      CDUMA=CDUMA+C[18]*v3rhosigma2[i]*2.0f;
-      CDUMAG1=CDUMAG1+C[18]*2.0f*v3sigma3[i]*2.0f;
-      CDUMAG2=CDUMAG2+C[18]*v3sigma3[i]*4.0f;
-      CDUMA=CDUMA+C[19]*v3rhosigma2[i]*4.0f;
-      CDUMAG1=CDUMAG1+C[19]*2.0f*v3sigma3[i]*4.0f;
-      CDUMAG2=CDUMAG2+C[19]*v3sigma3[i]*8.0f;
+    double CDUMAGEC = 0.0f;
+    CDUMAGEC = CDUMAGEC + 2.0f * DUMNV[0] * v2rhosigma[i] * 2.0f;
+    CDUMAGEC = CDUMAGEC + 4.0f * DUMGRV[0] * v2sigma2[i] * 2.0f;
+    CDUMAGEC = CDUMAGEC + 2.0f * DUMGRV[2] * v2sigma2[i] * 4.0f;
+    CDUMAGEC = CDUMAGEC + 2.0f * DUMNV[1] * v2rhosigma[i] * 2.0f;
+    CDUMAGEC = CDUMAGEC + 4.0f * DUMGRV[1] * v2sigma2[i] * 2.0f;
+    CDUMAGEC = CDUMAGEC + 2.0f * DUMGRV[3] * v2sigma2[i] * 4.0f;
 
-
-      C[10]=DUMXX[2];
-      C[11]=DUMNV[0]*DUMNV[1];
-      C[12]=2.0f*DUMNV[0]*DUMGRV[1];
-      C[13]=2.0f*DUMGRV[0]*DUMNV[1];
-      C[14]=DUMNV[0]*DUMGRV[3];
-      C[15]=DUMGRV[2]*DUMNV[1];
-      C[16]=4.0f*DUMGRV[0]*DUMGRV[1];
-      C[17]=2.0f*DUMGRV[0]*DUMGRV[3];
-      C[18]=2.0f*DUMGRV[2]*DUMGRV[1];
-      C[19]=DUMGRV[2]*DUMGRV[3];
-
-      CDUMA=CDUMA+C[10]*v2rhosigma[i]*2.0f;
-      CDUMAG1=CDUMAG1+C[10]*2.0f*v2sigma2[i]*2.0f;
-      CDUMAG2=CDUMAG2+C[10]*v2sigma2[i]*4.0f;
-      CDUMA=CDUMA+C[11]*v3rho3[i];
-      CDUMAG1=CDUMAG1+C[11]*2.0f*v3rho2sigma[i];
-      CDUMAG2=CDUMAG2+C[11]*v3rho2sigma[i]*2.0f;
-      CDUMA=CDUMA+C[12]*v3rho2sigma[i];
-      CDUMAG1=CDUMAG1+C[12]*2.0f*v3rhosigma2[i];
-      CDUMAG2=CDUMAG2+C[12]*v3rhosigma2[i]*2.0f;
-      CDUMA=CDUMA+C[13]*v3rho2sigma[i];
-      CDUMAG1=CDUMAG1+C[13]*2.0f*v3rhosigma2[i];
-      CDUMAG2=CDUMAG2+C[13]*v3rhosigma2[i]*2.0f;
-      CDUMA=CDUMA+C[14]*v3rho2sigma[i]*2.0f;
-      CDUMAG1=CDUMAG1+C[14]*2.0f*v3rhosigma2[i]*2.0f;
-      CDUMAG2=CDUMAG2+C[14]*v3rhosigma2[i]*4.0f;
-      CDUMA=CDUMA+C[15]*v3rho2sigma[i]*2.0f;
-      CDUMAG1=CDUMAG1+C[15]*2.0f*v3rhosigma2[i]*2.0f;
-      CDUMAG2=CDUMAG2+C[15]*v3rhosigma2[i]*4.0f;
-      CDUMA=CDUMA+C[16]*v3rhosigma2[i];
-      CDUMAG1=CDUMAG1+C[16]*2.0f*v3sigma3[i];
-      CDUMAG2=CDUMAG2+C[16]*v3sigma3[i]*2.0f;
-      CDUMA=CDUMA+C[17]*v3rhosigma2[i]*2.0f;
-      CDUMAG1=CDUMAG1+C[17]*2.0f*v3sigma3[i]*2.0f;
-      CDUMAG2=CDUMAG2+C[17]*v3sigma3[i]*4.0f;
-      CDUMA=CDUMA+C[18]*v3rhosigma2[i]*2.0f;
-      CDUMAG1=CDUMAG1+C[18]*2.0f*v3sigma3[i]*2.0f;
-      CDUMAG2=CDUMAG2+C[18]*v3sigma3[i]*4.0f;
-      CDUMA=CDUMA+C[19]*v3rhosigma2[i]*4.0f;
-      CDUMAG1=CDUMAG1+C[19]*2.0f*v3sigma3[i]*4.0f;
-      CDUMAG2=CDUMAG2+C[19]*v3sigma3[i]*8.0f;
-
-      double CDUMAGEA=0.0f;
-      CDUMAGEA=CDUMAGEA+4.0f*DUMNV[0]*v2rhosigma[i];
-      CDUMAGEA=CDUMAGEA+8.0f*DUMGRV[0]*v2sigma2[i];
-      CDUMAGEA=CDUMAGEA+4.0f*DUMGRV[2]*v2sigma2[i]*2.0f;
-      CDUMAGEA=CDUMAGEA+4.0f*DUMNV[1]*v2rhosigma[i];
-      CDUMAGEA=CDUMAGEA+8.0f*DUMGRV[1]*v2sigma2[i];
-      CDUMAGEA=CDUMAGEA+4.0f*DUMGRV[3]*v2sigma2[i]*2.0f;
-
-      double CDUMAGEC=0.0f;
-      CDUMAGEC=CDUMAGEC+2.0f*DUMNV[0]*v2rhosigma[i]*2.0f;
-      CDUMAGEC=CDUMAGEC+4.0f*DUMGRV[0]*v2sigma2[i]*2.0f;
-      CDUMAGEC=CDUMAGEC+2.0f*DUMGRV[2]*v2sigma2[i]*4.0f;
-      CDUMAGEC=CDUMAGEC+2.0f*DUMNV[1]*v2rhosigma[i]*2.0f;
-      CDUMAGEC=CDUMAGEC+4.0f*DUMGRV[1]*v2sigma2[i]*2.0f;
-      CDUMAGEC=CDUMAGEC+2.0f*DUMGRV[3]*v2sigma2[i]*4.0f;
-
-      Coef[i]   += CDUMA;
-      Coef[npoints+i] += CDUMAG1+CDUMAG2;
-      Coef[npoints*2+i] += CDUMAGEA+CDUMAGEC;
-   }
+    Coef[i] += CDUMA;
+    Coef[npoints + i] += CDUMAG1 + CDUMAG2;
+    Coef[npoints * 2 + i] += CDUMAGEA + CDUMAGEC;
+  }
 }
 #endif
 
 // GPU VERSION OF CoefZV
 template <class T, int width>
-void LibxcProxy_cuda <T, width>::coefZv(const int npoints, double* rho,
-               double* sigma, double* red, G2G::vec_type<T,WIDTH>* dxyz, 
-               G2G::vec_type<T,WIDTH>* txyz, double* lrCoef)
-{
+void LibxcProxy_cuda<T, width>::coefZv(const int npoints, double* rho,
+                                       double* sigma, double* red,
+                                       G2G::vec_type<T, WIDTH>* dxyz,
+                                       G2G::vec_type<T, WIDTH>* txyz,
+                                       double* lrCoef) {
 #ifdef __CUDACC__
 
-   int size = sizeof(double) * npoints;
-   cudaError_t err = cudaSuccess;
+  int size = sizeof(double) * npoints;
+  cudaError_t err = cudaSuccess;
 
-// Outputs libxc
-   double* vrho        = NULL;
-   double* vsigma      = NULL;
-   double* v2rho2      = NULL;
-   double* v2rhosigma  = NULL;
-   double* v2sigma2    = NULL;
-   double* v3rho3      = NULL;
-   double* v3rho2sigma = NULL;
-   double* v3rhosigma2 = NULL;
-   double* v3sigma3    = NULL;
-   double* energy      = NULL;
+  // Outputs libxc
+  double* vrho = NULL;
+  double* vsigma = NULL;
+  double* v2rho2 = NULL;
+  double* v2rhosigma = NULL;
+  double* v2sigma2 = NULL;
+  double* v3rho3 = NULL;
+  double* v3rho2sigma = NULL;
+  double* v3rhosigma2 = NULL;
+  double* v3sigma3 = NULL;
+  double* energy = NULL;
 
-// Allocate Outputs
-   err = cudaMalloc((void**)&vrho,size);
-   if (err != cudaSuccess) {
-      printf("Error to allocate vrho");
-      exit(EXIT_FAILURE);
-   }
+  // Allocate Outputs
+  err = cudaMalloc((void**)&vrho, size);
+  if (err != cudaSuccess) {
+    printf("Error to allocate vrho");
+    exit(EXIT_FAILURE);
+  }
 
-   err = cudaMalloc((void**)&vsigma,size);
-   if (err != cudaSuccess) {
-      printf("Error to allocate vsigma");
-      exit(EXIT_FAILURE);
-   }
+  err = cudaMalloc((void**)&vsigma, size);
+  if (err != cudaSuccess) {
+    printf("Error to allocate vsigma");
+    exit(EXIT_FAILURE);
+  }
 
-   err = cudaMalloc((void**)&v2rho2,size);
-   if (err != cudaSuccess) {
-      printf("Error to allocate v2rho2");
-      exit(EXIT_FAILURE);
-   }
+  err = cudaMalloc((void**)&v2rho2, size);
+  if (err != cudaSuccess) {
+    printf("Error to allocate v2rho2");
+    exit(EXIT_FAILURE);
+  }
 
-   err = cudaMalloc((void**)&v2rhosigma,size);
-   if (err != cudaSuccess) {
-      printf("Error to allocate v2rhosigma");
-      exit(EXIT_FAILURE);
-   }
+  err = cudaMalloc((void**)&v2rhosigma, size);
+  if (err != cudaSuccess) {
+    printf("Error to allocate v2rhosigma");
+    exit(EXIT_FAILURE);
+  }
 
-   err = cudaMalloc((void**)&v2sigma2,size);
-   if (err != cudaSuccess) {
-      printf("Error to allocate v2sigma2");
-      exit(EXIT_FAILURE);
-   }
+  err = cudaMalloc((void**)&v2sigma2, size);
+  if (err != cudaSuccess) {
+    printf("Error to allocate v2sigma2");
+    exit(EXIT_FAILURE);
+  }
 
-   err = cudaMalloc((void**)&v3rho3,size);
-   if (err != cudaSuccess) {
-      printf("Error to allocate v3rho3");
-      exit(EXIT_FAILURE);
-   }
+  err = cudaMalloc((void**)&v3rho3, size);
+  if (err != cudaSuccess) {
+    printf("Error to allocate v3rho3");
+    exit(EXIT_FAILURE);
+  }
 
-   err = cudaMalloc((void**)&v3rho2sigma,size);
-   if (err != cudaSuccess) {
-      printf("Error to allocate v3rho2sigma");
-      exit(EXIT_FAILURE);
-   }
+  err = cudaMalloc((void**)&v3rho2sigma, size);
+  if (err != cudaSuccess) {
+    printf("Error to allocate v3rho2sigma");
+    exit(EXIT_FAILURE);
+  }
 
-   err = cudaMalloc((void**)&v3rhosigma2,size);
-   if (err != cudaSuccess) {
-      printf("Error to allocate v3rhosigma2");
-      exit(EXIT_FAILURE);
-   }
+  err = cudaMalloc((void**)&v3rhosigma2, size);
+  if (err != cudaSuccess) {
+    printf("Error to allocate v3rhosigma2");
+    exit(EXIT_FAILURE);
+  }
 
-   err = cudaMalloc((void**)&v3sigma3,size);
-   if (err != cudaSuccess) {
-      printf("Error to allocate v3sigma3");
-      exit(EXIT_FAILURE);
-   }
+  err = cudaMalloc((void**)&v3sigma3, size);
+  if (err != cudaSuccess) {
+    printf("Error to allocate v3sigma3");
+    exit(EXIT_FAILURE);
+  }
 
-   err = cudaMalloc((void**)&energy,size);
-   if (err != cudaSuccess) {
-      printf("Error to allocate energy");
-      exit(EXIT_FAILURE);
-   }
+  err = cudaMalloc((void**)&energy, size);
+  if (err != cudaSuccess) {
+    printf("Error to allocate energy");
+    exit(EXIT_FAILURE);
+  }
 
-   cudaMemset(energy,0.0f,size);
-   cudaMemset(vrho,0.0f,size);
-   cudaMemset(vsigma,0.0f,size);
-   cudaMemset(v2rho2,0.0f,size);
-   cudaMemset(v2rhosigma,0.0f,size);
-   cudaMemset(v2sigma2,0.0f,size);
-   cudaMemset(v3rho3,0.0f,size);
-   cudaMemset(v3rho2sigma,0.0f,size);
-   cudaMemset(v3rhosigma2,0.0f,size);
-   cudaMemset(v3sigma3,0.0f,size);
+  cudaMemset(energy, 0.0f, size);
+  cudaMemset(vrho, 0.0f, size);
+  cudaMemset(vsigma, 0.0f, size);
+  cudaMemset(v2rho2, 0.0f, size);
+  cudaMemset(v2rhosigma, 0.0f, size);
+  cudaMemset(v2sigma2, 0.0f, size);
+  cudaMemset(v3rho3, 0.0f, size);
+  cudaMemset(v3rho2sigma, 0.0f, size);
+  cudaMemset(v3rhosigma2, 0.0f, size);
+  cudaMemset(v3sigma3, 0.0f, size);
 
-// Call LIBXC for Exchange
-   try {
-       xc_gga_cuda(&funcForExchange,npoints,
-               rho, sigma,
-               energy,
-               vrho, vsigma,
-               v2rho2, v2rhosigma, v2sigma2,
-               v3rho3, v3rho2sigma, v3rhosigma2, v3sigma3);
-   } catch (int exception) {
-       fprintf (stderr, "Exception ocurred calling xc_gga for Exchange '%d' \n", exception);
-       return;
-   }
-
-   int threadsPerBlock = 256;
-   int blocksPerGrid = (npoints + threadsPerBlock - 1) / threadsPerBlock;
-
-   Zv_exchange<T,width><<<blocksPerGrid,threadsPerBlock>>>(npoints,red,
-                        dxyz,txyz,lrCoef,v2rho2,v2rhosigma,v2sigma2,
-                        v3rho3,v3rho2sigma,v3rhosigma2,v3sigma3,fact_exchange);
-
-   cudaMemset(energy,0.0f,size);
-   cudaMemset(vrho,0.0f,size);
-   cudaMemset(vsigma,0.0f,size);
-   cudaMemset(v2rho2,0.0f,size);
-   cudaMemset(v2rhosigma,0.0f,size);
-   cudaMemset(v2sigma2,0.0f,size);
-   cudaMemset(v3rho3,0.0f,size);
-   cudaMemset(v3rho2sigma,0.0f,size);
-   cudaMemset(v3rhosigma2,0.0f,size);
-   cudaMemset(v3sigma3,0.0f,size);
-
-// Call LIBXC for Coerrelation
-   try {
-       xc_gga_cuda(&funcForCorrelation,npoints,
-               rho,
-               sigma,
-               energy,
-               vrho,
-               vsigma,
-               v2rho2,
-               v2rhosigma,
-               v2sigma2,
-               v3rho3, v3rho2sigma, v3rhosigma2, v3sigma3);
-   } catch (int exception) {
-       fprintf (stderr, "Exception ocurred calling xc_gga for Exchange '%d' \n", exception);
-       return;
-   }
-
-   Zv_coulomb<T,width><<<blocksPerGrid,threadsPerBlock>>>(npoints,red,
-                        dxyz,txyz,lrCoef,v2rhosigma,v2sigma2,
-                        v3rho3,v3rho2sigma,v3rhosigma2,v3sigma3);
-
-   cudaFree(vrho);        vrho = NULL;
-   cudaFree(vsigma);      vsigma = NULL;
-   cudaFree(v2rho2);      v2rho2 = NULL;
-   cudaFree(v2rhosigma);  v2rhosigma = NULL;
-   cudaFree(v2sigma2);    v2sigma2 = NULL;
-   cudaFree(v3rho3);      v3rho3 = NULL;
-   cudaFree(v3rho2sigma); v3rho2sigma = NULL;
-   cudaFree(v3rhosigma2); v3rhosigma2 = NULL;
-   cudaFree(v3sigma3);    v3sigma3 = NULL;
-   cudaFree(energy);      energy = NULL;
-
-/*
-   double* coef_cpu = (double*) malloc(3*size);
-   double* red_cpu = (double*) malloc(size);
-   memset(coef_cpu,0.0f,3*size);
-   err = cudaMemcpy(coef_cpu,lrCoef,3*size,cudaMemcpyDeviceToHost);
-   err = cudaMemcpy(red_cpu,red,size,cudaMemcpyDeviceToHost);
-   if (err != cudaSuccess) cout << "caca copy" << endl;
-   for (int i=0; i<npoints; i++)
-      printf("%d\t%f\t%f\t%f\t%f\n",i,red_cpu[i],coef_cpu[3*i],coef_cpu[3*i+1],coef_cpu[3*i+2]);
-      //printf("point(%d)=\t%f\n",i,v2rho2_cpu[i]);
-   exit(-1);
-*/
-
-
-#endif
-
-   return;
-}
-
-#ifdef __CUDACC__
-
-template <class T, int width>
-__global__ void save_derivs(const int npoints,const double fact_ex,const int xch,
-           // INPUTS //
-           const T* vrho_in, const T* vsigma_in, const T* v2rho2_in, const T* v2rhosigma_in, const T* v2sigma2_in,
-           const T* v3rho3_in, const T* v3rho2sigma_in, const T* v3rhosigma2_in, const T* v3sigma3_in,
-           // OUTPUTS //
-           G2G::vec_type<T,2>* vrho, G2G::vec_type<T,2>* vsigma, G2G::vec_type<T,2>* v2rho2,
-           G2G::vec_type<T,2>* v2rhosigma, G2G::vec_type<T,2>* v2sigma2, G2G::vec_type<T,2>* v3rho3,
-           G2G::vec_type<T,2>* v3rho2sigma, G2G::vec_type<T,2>* v3rhosigma2, G2G::vec_type<T,2>* v3sigma3)
-{
- 
-   const double fex = fact_ex;
-   int i = blockDim.x * blockIdx.x + threadIdx.x;
-
-   if ( i < npoints ) {
-      if ( xch == 0 ) {
-         vrho[i].x = vrho_in[i] * fex; vsigma[i].x = vsigma_in[i] * fex;
-         v2rho2[i].x = v2rho2_in[i] * fex; v2rhosigma[i].x = v2rhosigma_in[i] * fex; 
-         v2sigma2[i].x = v2sigma2_in[i] * fex;
-         v3rho3[i].x = v3rho3_in[i] * fex; v3rho2sigma[i].x = v3rho2sigma_in[i] * fex; 
-         v3rhosigma2[i].x = v3rhosigma2_in[i] * fex; v3sigma3[i].x = v3sigma3_in[i] * fex;
-      } else {
-         vrho[i].y = vrho_in[i]; vsigma[i].y = vsigma_in[i];
-         v2rho2[i].y = v2rho2_in[i]; v2rhosigma[i].y = v2rhosigma_in[i];
-         v2sigma2[i].y = v2sigma2_in[i];
-         v3rho3[i].y = v3rho3_in[i]; v3rho2sigma[i].y = v3rho2sigma_in[i]; 
-         v3rhosigma2[i].y = v3rhosigma2_in[i]; v3sigma3[i].y = v3sigma3_in[i];
-      }
-   }
-}
-
-#endif
-
-template <class T, int width>
-void LibxcProxy_cuda<T,width>::obtain_gpu_der(const int npoints,
-     T* rho, T* sigma,
-     // outputs //
-     G2G::vec_type<T,2>* vrho,
-     G2G::vec_type<T,2>* vsigma,
-     G2G::vec_type<T,2>* v2rho2,
-     G2G::vec_type<T,2>* v2rhosigma,
-     G2G::vec_type<T,2>* v2sigma2,
-     G2G::vec_type<T,2>* v3rho3,
-     G2G::vec_type<T,2>* v3rho2sigma,
-     G2G::vec_type<T,2>* v3rhosigma2,
-     G2G::vec_type<T,2>* v3sigma3)
-{
-#ifdef __CUDACC__
-   int size = sizeof(double) * npoints;
-   cudaError_t err = cudaSuccess;
-
-// Local libxc Variables
-   double* lvrho        = NULL;
-   double* lvsigma      = NULL;
-   double* lv2rho2      = NULL;
-   double* lv2rhosigma  = NULL;
-   double* lv2sigma2    = NULL;
-   double* lv3rho3      = NULL;
-   double* lv3rho2sigma = NULL;
-   double* lv3rhosigma2 = NULL;
-   double* lv3sigma3    = NULL;
-   double* energy       = NULL;
-
-// Allocate Outputs
-   err = cudaMalloc((void**)&lvrho,size);
-   if (err != cudaSuccess) {
-      printf("Error to allocate lvrho");
-      exit(EXIT_FAILURE);
-   }
-
-   err = cudaMalloc((void**)&lvsigma,size);
-   if (err != cudaSuccess) {
-      printf("Error to allocate lvsigma");
-      exit(EXIT_FAILURE);
-   }
-
-   err = cudaMalloc((void**)&lv2rho2,size);
-   if (err != cudaSuccess) {
-      printf("Error to allocate lv2rho2");
-      exit(EXIT_FAILURE);
-   }
-
-   err = cudaMalloc((void**)&lv2rhosigma,size);
-   if (err != cudaSuccess) {
-      printf("Error to allocate lv2rhosigma");
-      exit(EXIT_FAILURE);
-   }
-
-   err = cudaMalloc((void**)&lv2sigma2,size);
-   if (err != cudaSuccess) {
-      printf("Error to allocate vl2sigma2");
-      exit(EXIT_FAILURE);
-   }
-
-   err = cudaMalloc((void**)&lv3rho3,size);
-   if (err != cudaSuccess) {
-      printf("Error to allocate lv3rho3");
-      exit(EXIT_FAILURE);
-   }
-
-   err = cudaMalloc((void**)&lv3rho2sigma,size);
-   if (err != cudaSuccess) {
-      printf("Error to allocate vl3rho2sigma");
-      exit(EXIT_FAILURE);
-   }
-
-   err = cudaMalloc((void**)&lv3rhosigma2,size);
-   if (err != cudaSuccess) {
-      printf("Error to allocate lv3rhosigma2");
-      exit(EXIT_FAILURE);
-   }
-
-   err = cudaMalloc((void**)&lv3sigma3,size);
-   if (err != cudaSuccess) {
-      printf("Error to allocate lv3sigma3");
-      exit(EXIT_FAILURE);
-   }
-
-   err = cudaMalloc((void**)&energy,size);
-   if (err != cudaSuccess) {
-      printf("Error to allocate energy");
-      exit(EXIT_FAILURE);
-   }
-
-   cudaMemset(energy,0.0f,size);
-   cudaMemset(lvrho,0.0f,size);
-   cudaMemset(lvsigma,0.0f,size);
-   cudaMemset(lv2rho2,0.0f,size);
-   cudaMemset(lv2rhosigma,0.0f,size);
-   cudaMemset(lv2sigma2,0.0f,size);
-   cudaMemset(lv3rho3,0.0f,size);
-   cudaMemset(lv3rho2sigma,0.0f,size);
-   cudaMemset(lv3rhosigma2,0.0f,size);
-   cudaMemset(lv3sigma3,0.0f,size);
-
-// Call LIBXC for Exchange
-   try {
-       xc_gga_cuda(&funcForExchange,npoints,
-               rho, sigma,
-               energy,
-               lvrho, lvsigma,
-               lv2rho2, lv2rhosigma, lv2sigma2,
-               lv3rho3, lv3rho2sigma, lv3rhosigma2, lv3sigma3);
-   } catch (int exception) {
-       fprintf (stderr, "Exception ocurred calling xc_gga for Exchange '%d' \n", exception);
-       return;
-   }
-
-   int threadsPerBlock = 256;
-   int blocksPerGrid = (npoints + threadsPerBlock - 1) / threadsPerBlock;
-
-   save_derivs<T,width><<<blocksPerGrid,threadsPerBlock>>>(npoints,fact_exchange,0,
-              // INPUTS //
-              lvrho, lvsigma, lv2rho2, lv2rhosigma, lv2sigma2, lv3rho3,
-              lv3rho2sigma, lv3rhosigma2, lv3sigma3,
-              // OUTPUTS //
-              vrho, vsigma, v2rho2, v2rhosigma, v2sigma2, v3rho3,
-              v3rho2sigma, v3rhosigma2, v3sigma3);
-
-   cudaMemset(energy,0.0f,size);
-   cudaMemset(lvrho,0.0f,size);
-   cudaMemset(lvsigma,0.0f,size);
-   cudaMemset(lv2rho2,0.0f,size);
-   cudaMemset(lv2rhosigma,0.0f,size);
-   cudaMemset(lv2sigma2,0.0f,size);
-   cudaMemset(lv3rho3,0.0f,size);
-   cudaMemset(lv3rho2sigma,0.0f,size);
-   cudaMemset(lv3rhosigma2,0.0f,size);
-   cudaMemset(lv3sigma3,0.0f,size);
-
-// Call LIBXC for Coerrelation
-   try {
-       xc_gga_cuda(&funcForCorrelation,npoints,
-               rho, sigma, energy,
-               lvrho, lvsigma, lv2rho2, lv2rhosigma, lv2sigma2, 
-               lv3rho3, lv3rho2sigma, lv3rhosigma2, lv3sigma3);
-   } catch (int exception) {
-       fprintf (stderr, "Exception ocurred calling xc_gga for Exchange '%d' \n", exception);
-       return;
-   }
-
-   save_derivs<T,width><<<blocksPerGrid,threadsPerBlock>>>(npoints,0.0f,1,
-              // INPUTS //
-              lvrho, lvsigma, lv2rho2, lv2rhosigma, lv2sigma2, lv3rho3,
-              lv3rho2sigma, lv3rhosigma2, lv3sigma3,
-              // OUTPUTS //
-              vrho, vsigma, v2rho2, v2rhosigma, v2sigma2, v3rho3,
-              v3rho2sigma, v3rhosigma2, v3sigma3);
-
-   cudaFree(lvrho);        lvrho = NULL;
-   cudaFree(lvsigma);      lvsigma = NULL;
-   cudaFree(lv2rho2);      lv2rho2 = NULL;
-   cudaFree(lv2rhosigma);  lv2rhosigma = NULL;
-   cudaFree(lv2sigma2);    lv2sigma2 = NULL;
-   cudaFree(lv3rho3);      lv3rho3 = NULL;
-   cudaFree(lv3rho2sigma); lv3rho2sigma = NULL;
-   cudaFree(lv3rhosigma2); lv3rhosigma2 = NULL;
-   cudaFree(lv3sigma3);    lv3sigma3 = NULL;
-   cudaFree(energy);       energy = NULL;
-#endif
-
-}
-
-
-template <class T, int width>
-void LibxcProxy_cuda <T, width>::doGGA (T rho,
-               T sigma,
-               T* v2rho2,
-               T v2rhosigma,
-               T v2sigma2)
-{
-    const double dens = rho;
-    const double sig = sigma;
-
-    // The outputs for exchange
-    double v2rho2X = 0.0;
-    double v2rhosigmaX = 0.0;
-    double v2sigma2X = 0.0;
-
-    // The outputs for correlation
-    double v2rho2C = 0.0;
-    double v2rhosigmaC = 0.0;
-    double v2sigma2C = 0.0;
-
-    // Exchange values
-    xc_gga_fxc_cuda (&funcForExchange,1,
-                &dens,
-                &sig,
-                &v2rho2X,
-                &v2rhosigmaX,
-                &v2sigma2X);
-
-    // Correlation values
-    xc_gga_fxc_cuda (&funcForCorrelation,1,
-                &dens,
-                &sig,
-                &v2rho2C,
-                &v2rhosigmaC,
-                &v2sigma2C);
-
-
-    *v2rho2 = v2rho2C + v2rho2X;
+  // Call LIBXC for Exchange
+  try {
+    xc_gga_cuda(&funcForExchange, npoints, rho, sigma, energy, vrho, vsigma,
+                v2rho2, v2rhosigma, v2sigma2, v3rho3, v3rho2sigma, v3rhosigma2,
+                v3sigma3);
+  } catch (int exception) {
+    fprintf(stderr, "Exception ocurred calling xc_gga for Exchange '%d' \n",
+            exception);
     return;
+  }
+
+  int threadsPerBlock = 256;
+  int blocksPerGrid = (npoints + threadsPerBlock - 1) / threadsPerBlock;
+
+  Zv_exchange<T, width><<<blocksPerGrid, threadsPerBlock>>>(
+      npoints, red, dxyz, txyz, lrCoef, v2rho2, v2rhosigma, v2sigma2, v3rho3,
+      v3rho2sigma, v3rhosigma2, v3sigma3, fact_exchange);
+
+  cudaMemset(energy, 0.0f, size);
+  cudaMemset(vrho, 0.0f, size);
+  cudaMemset(vsigma, 0.0f, size);
+  cudaMemset(v2rho2, 0.0f, size);
+  cudaMemset(v2rhosigma, 0.0f, size);
+  cudaMemset(v2sigma2, 0.0f, size);
+  cudaMemset(v3rho3, 0.0f, size);
+  cudaMemset(v3rho2sigma, 0.0f, size);
+  cudaMemset(v3rhosigma2, 0.0f, size);
+  cudaMemset(v3sigma3, 0.0f, size);
+
+  // Call LIBXC for Coerrelation
+  try {
+    xc_gga_cuda(&funcForCorrelation, npoints, rho, sigma, energy, vrho, vsigma,
+                v2rho2, v2rhosigma, v2sigma2, v3rho3, v3rho2sigma, v3rhosigma2,
+                v3sigma3);
+  } catch (int exception) {
+    fprintf(stderr, "Exception ocurred calling xc_gga for Exchange '%d' \n",
+            exception);
+    return;
+  }
+
+  Zv_coulomb<T, width><<<blocksPerGrid, threadsPerBlock>>>(
+      npoints, red, dxyz, txyz, lrCoef, v2rhosigma, v2sigma2, v3rho3,
+      v3rho2sigma, v3rhosigma2, v3sigma3);
+
+  cudaFree(vrho);
+  vrho = NULL;
+  cudaFree(vsigma);
+  vsigma = NULL;
+  cudaFree(v2rho2);
+  v2rho2 = NULL;
+  cudaFree(v2rhosigma);
+  v2rhosigma = NULL;
+  cudaFree(v2sigma2);
+  v2sigma2 = NULL;
+  cudaFree(v3rho3);
+  v3rho3 = NULL;
+  cudaFree(v3rho2sigma);
+  v3rho2sigma = NULL;
+  cudaFree(v3rhosigma2);
+  v3rhosigma2 = NULL;
+  cudaFree(v3sigma3);
+  v3sigma3 = NULL;
+  cudaFree(energy);
+  energy = NULL;
+
+  /*
+     double* coef_cpu = (double*) malloc(3*size);
+     double* red_cpu = (double*) malloc(size);
+     memset(coef_cpu,0.0f,3*size);
+     err = cudaMemcpy(coef_cpu,lrCoef,3*size,cudaMemcpyDeviceToHost);
+     err = cudaMemcpy(red_cpu,red,size,cudaMemcpyDeviceToHost);
+     if (err != cudaSuccess) cout << "caca copy" << endl;
+     for (int i=0; i<npoints; i++)
+        printf("%d\t%f\t%f\t%f\t%f\n",i,red_cpu[i],coef_cpu[3*i],coef_cpu[3*i+1],coef_cpu[3*i+2]);
+        //printf("point(%d)=\t%f\n",i,v2rho2_cpu[i]);
+     exit(-1);
+  */
+
+#endif
+
+  return;
+}
+
+#ifdef __CUDACC__
+
+template <class T, int width>
+__global__ void save_derivs(
+    const int npoints, const double fact_ex, const int xch,
+    // INPUTS //
+    const T* vrho_in, const T* vsigma_in, const T* v2rho2_in,
+    const T* v2rhosigma_in, const T* v2sigma2_in, const T* v3rho3_in,
+    const T* v3rho2sigma_in, const T* v3rhosigma2_in, const T* v3sigma3_in,
+    // OUTPUTS //
+    G2G::vec_type<T, 2>* vrho, G2G::vec_type<T, 2>* vsigma,
+    G2G::vec_type<T, 2>* v2rho2, G2G::vec_type<T, 2>* v2rhosigma,
+    G2G::vec_type<T, 2>* v2sigma2, G2G::vec_type<T, 2>* v3rho3,
+    G2G::vec_type<T, 2>* v3rho2sigma, G2G::vec_type<T, 2>* v3rhosigma2,
+    G2G::vec_type<T, 2>* v3sigma3) {
+  const double fex = fact_ex;
+  int i = blockDim.x * blockIdx.x + threadIdx.x;
+
+  if (i < npoints) {
+    if (xch == 0) {
+      vrho[i].x = vrho_in[i] * fex;
+      vsigma[i].x = vsigma_in[i] * fex;
+      v2rho2[i].x = v2rho2_in[i] * fex;
+      v2rhosigma[i].x = v2rhosigma_in[i] * fex;
+      v2sigma2[i].x = v2sigma2_in[i] * fex;
+      v3rho3[i].x = v3rho3_in[i] * fex;
+      v3rho2sigma[i].x = v3rho2sigma_in[i] * fex;
+      v3rhosigma2[i].x = v3rhosigma2_in[i] * fex;
+      v3sigma3[i].x = v3sigma3_in[i] * fex;
+    } else {
+      vrho[i].y = vrho_in[i];
+      vsigma[i].y = vsigma_in[i];
+      v2rho2[i].y = v2rho2_in[i];
+      v2rhosigma[i].y = v2rhosigma_in[i];
+      v2sigma2[i].y = v2sigma2_in[i];
+      v3rho3[i].y = v3rho3_in[i];
+      v3rho2sigma[i].y = v3rho2sigma_in[i];
+      v3rhosigma2[i].y = v3rhosigma2_in[i];
+      v3sigma3[i].y = v3sigma3_in[i];
+    }
+  }
+}
+
+#endif
+
+template <class T, int width>
+void LibxcProxy_cuda<T, width>::obtain_gpu_der(
+    const int npoints, T* rho, T* sigma,
+    // outputs //
+    G2G::vec_type<T, 2>* vrho, G2G::vec_type<T, 2>* vsigma,
+    G2G::vec_type<T, 2>* v2rho2, G2G::vec_type<T, 2>* v2rhosigma,
+    G2G::vec_type<T, 2>* v2sigma2, G2G::vec_type<T, 2>* v3rho3,
+    G2G::vec_type<T, 2>* v3rho2sigma, G2G::vec_type<T, 2>* v3rhosigma2,
+    G2G::vec_type<T, 2>* v3sigma3) {
+#ifdef __CUDACC__
+  int size = sizeof(double) * npoints;
+  cudaError_t err = cudaSuccess;
+
+  // Local libxc Variables
+  double* lvrho = NULL;
+  double* lvsigma = NULL;
+  double* lv2rho2 = NULL;
+  double* lv2rhosigma = NULL;
+  double* lv2sigma2 = NULL;
+  double* lv3rho3 = NULL;
+  double* lv3rho2sigma = NULL;
+  double* lv3rhosigma2 = NULL;
+  double* lv3sigma3 = NULL;
+  double* energy = NULL;
+
+  // Allocate Outputs
+  err = cudaMalloc((void**)&lvrho, size);
+  if (err != cudaSuccess) {
+    printf("Error to allocate lvrho");
+    exit(EXIT_FAILURE);
+  }
+
+  err = cudaMalloc((void**)&lvsigma, size);
+  if (err != cudaSuccess) {
+    printf("Error to allocate lvsigma");
+    exit(EXIT_FAILURE);
+  }
+
+  err = cudaMalloc((void**)&lv2rho2, size);
+  if (err != cudaSuccess) {
+    printf("Error to allocate lv2rho2");
+    exit(EXIT_FAILURE);
+  }
+
+  err = cudaMalloc((void**)&lv2rhosigma, size);
+  if (err != cudaSuccess) {
+    printf("Error to allocate lv2rhosigma");
+    exit(EXIT_FAILURE);
+  }
+
+  err = cudaMalloc((void**)&lv2sigma2, size);
+  if (err != cudaSuccess) {
+    printf("Error to allocate vl2sigma2");
+    exit(EXIT_FAILURE);
+  }
+
+  err = cudaMalloc((void**)&lv3rho3, size);
+  if (err != cudaSuccess) {
+    printf("Error to allocate lv3rho3");
+    exit(EXIT_FAILURE);
+  }
+
+  err = cudaMalloc((void**)&lv3rho2sigma, size);
+  if (err != cudaSuccess) {
+    printf("Error to allocate vl3rho2sigma");
+    exit(EXIT_FAILURE);
+  }
+
+  err = cudaMalloc((void**)&lv3rhosigma2, size);
+  if (err != cudaSuccess) {
+    printf("Error to allocate lv3rhosigma2");
+    exit(EXIT_FAILURE);
+  }
+
+  err = cudaMalloc((void**)&lv3sigma3, size);
+  if (err != cudaSuccess) {
+    printf("Error to allocate lv3sigma3");
+    exit(EXIT_FAILURE);
+  }
+
+  err = cudaMalloc((void**)&energy, size);
+  if (err != cudaSuccess) {
+    printf("Error to allocate energy");
+    exit(EXIT_FAILURE);
+  }
+
+  cudaMemset(energy, 0.0f, size);
+  cudaMemset(lvrho, 0.0f, size);
+  cudaMemset(lvsigma, 0.0f, size);
+  cudaMemset(lv2rho2, 0.0f, size);
+  cudaMemset(lv2rhosigma, 0.0f, size);
+  cudaMemset(lv2sigma2, 0.0f, size);
+  cudaMemset(lv3rho3, 0.0f, size);
+  cudaMemset(lv3rho2sigma, 0.0f, size);
+  cudaMemset(lv3rhosigma2, 0.0f, size);
+  cudaMemset(lv3sigma3, 0.0f, size);
+
+  // Call LIBXC for Exchange
+  try {
+    xc_gga_cuda(&funcForExchange, npoints, rho, sigma, energy, lvrho, lvsigma,
+                lv2rho2, lv2rhosigma, lv2sigma2, lv3rho3, lv3rho2sigma,
+                lv3rhosigma2, lv3sigma3);
+  } catch (int exception) {
+    fprintf(stderr, "Exception ocurred calling xc_gga for Exchange '%d' \n",
+            exception);
+    return;
+  }
+
+  int threadsPerBlock = 256;
+  int blocksPerGrid = (npoints + threadsPerBlock - 1) / threadsPerBlock;
+
+  save_derivs<T, width><<<blocksPerGrid, threadsPerBlock>>>(
+      npoints, fact_exchange, 0,
+      // INPUTS //
+      lvrho, lvsigma, lv2rho2, lv2rhosigma, lv2sigma2, lv3rho3, lv3rho2sigma,
+      lv3rhosigma2, lv3sigma3,
+      // OUTPUTS //
+      vrho, vsigma, v2rho2, v2rhosigma, v2sigma2, v3rho3, v3rho2sigma,
+      v3rhosigma2, v3sigma3);
+
+  cudaMemset(energy, 0.0f, size);
+  cudaMemset(lvrho, 0.0f, size);
+  cudaMemset(lvsigma, 0.0f, size);
+  cudaMemset(lv2rho2, 0.0f, size);
+  cudaMemset(lv2rhosigma, 0.0f, size);
+  cudaMemset(lv2sigma2, 0.0f, size);
+  cudaMemset(lv3rho3, 0.0f, size);
+  cudaMemset(lv3rho2sigma, 0.0f, size);
+  cudaMemset(lv3rhosigma2, 0.0f, size);
+  cudaMemset(lv3sigma3, 0.0f, size);
+
+  // Call LIBXC for Coerrelation
+  try {
+    xc_gga_cuda(&funcForCorrelation, npoints, rho, sigma, energy, lvrho,
+                lvsigma, lv2rho2, lv2rhosigma, lv2sigma2, lv3rho3, lv3rho2sigma,
+                lv3rhosigma2, lv3sigma3);
+  } catch (int exception) {
+    fprintf(stderr, "Exception ocurred calling xc_gga for Exchange '%d' \n",
+            exception);
+    return;
+  }
+
+  save_derivs<T, width><<<blocksPerGrid, threadsPerBlock>>>(
+      npoints, 0.0f, 1,
+      // INPUTS //
+      lvrho, lvsigma, lv2rho2, lv2rhosigma, lv2sigma2, lv3rho3, lv3rho2sigma,
+      lv3rhosigma2, lv3sigma3,
+      // OUTPUTS //
+      vrho, vsigma, v2rho2, v2rhosigma, v2sigma2, v3rho3, v3rho2sigma,
+      v3rhosigma2, v3sigma3);
+
+  cudaFree(lvrho);
+  lvrho = NULL;
+  cudaFree(lvsigma);
+  lvsigma = NULL;
+  cudaFree(lv2rho2);
+  lv2rho2 = NULL;
+  cudaFree(lv2rhosigma);
+  lv2rhosigma = NULL;
+  cudaFree(lv2sigma2);
+  lv2sigma2 = NULL;
+  cudaFree(lv3rho3);
+  lv3rho3 = NULL;
+  cudaFree(lv3rho2sigma);
+  lv3rho2sigma = NULL;
+  cudaFree(lv3rhosigma2);
+  lv3rhosigma2 = NULL;
+  cudaFree(lv3sigma3);
+  lv3sigma3 = NULL;
+  cudaFree(energy);
+  energy = NULL;
+#endif
+}
+
+template <class T, int width>
+void LibxcProxy_cuda<T, width>::doGGA(T rho, T sigma, T* v2rho2, T v2rhosigma,
+                                      T v2sigma2) {
+  const double dens = rho;
+  const double sig = sigma;
+
+  // The outputs for exchange
+  double v2rho2X = 0.0;
+  double v2rhosigmaX = 0.0;
+  double v2sigma2X = 0.0;
+
+  // The outputs for correlation
+  double v2rho2C = 0.0;
+  double v2rhosigmaC = 0.0;
+  double v2sigma2C = 0.0;
+
+  // Exchange values
+  xc_gga_fxc_cuda(&funcForExchange, 1, &dens, &sig, &v2rho2X, &v2rhosigmaX,
+                  &v2sigma2X);
+
+  // Correlation values
+  xc_gga_fxc_cuda(&funcForCorrelation, 1, &dens, &sig, &v2rho2C, &v2rhosigmaC,
+                  &v2sigma2C);
+
+  *v2rho2 = v2rho2C + v2rho2X;
+  return;
 }
 
 #ifdef __CUDACC__
@@ -1434,120 +1375,118 @@ void LibxcProxy_cuda <T, width>::doGGA (T rho,
 // calling Libxc.
 //
 template <class T, int width>
-__global__ void joinResults(
-		    double* ex, double* exchange,
-		    double* ec, double* correlation,
-		    double* vrho, double* vrhoC,
-		    double* vsigma, double* vsigmaC,
-		    double* v2rho, double* v2rhoC,
-		    double* v2rhosigma, double* v2rhosigmaC,
-		    double* v2sigma, double* v2sigmaC,
-		    double* y2a,
-		    const double* sigma,
-		    const G2G::vec_type<double, width>* grad,
-		    const G2G::vec_type<double, width>* hess1,
-		    const G2G::vec_type<double, width>* hess2,
-		    int numElements,double fEE)
-{
-    int i = blockDim.x * blockIdx.x + threadIdx.x;
+__global__ void joinResults(double* ex, double* exchange, double* ec,
+                            double* correlation, double* vrho, double* vrhoC,
+                            double* vsigma, double* vsigmaC, double* v2rho,
+                            double* v2rhoC, double* v2rhosigma,
+                            double* v2rhosigmaC, double* v2sigma,
+                            double* v2sigmaC, double* y2a, const double* sigma,
+                            const G2G::vec_type<double, width>* grad,
+                            const G2G::vec_type<double, width>* hess1,
+                            const G2G::vec_type<double, width>* hess2,
+                            int numElements, double fEE) {
+  int i = blockDim.x * blockIdx.x + threadIdx.x;
 
-    if (i < numElements)
-    {
-	ex[i] = fEE * exchange[i];
-	ec[i] = correlation[i];
+  if (i < numElements) {
+    ex[i] = fEE * exchange[i];
+    ec[i] = correlation[i];
 
-	// Merge the results for the derivatives.
-/*
-	vrho[i] += vrhoC[i];
-        vsigma[i] += vsigmaC[i];
-        v2rho[i] += v2rhoC[i];
-        v2rhosigma[i] += v2rhosigmaC[i];
-        v2sigma[i] += v2sigmaC[i];
-*/
-	vrho[i]       = fEE * vrho[i] + vrhoC[i];
-        vsigma[i]     = fEE * vsigma[i] + vsigmaC[i];
-        v2rho[i]      = fEE * v2rho[i] + v2rhoC[i];
-        v2rhosigma[i] = fEE * v2rhosigma[i] + v2rhosigmaC[i];
-        v2sigma[i]    = fEE * v2sigma[i] + v2sigmaC[i];
-        // Now, compute y2a value.
-	y2a[i] = vrho[i] - (2 * sigma[i] * v2rhosigma[i]
-            + 2 * (hess1[i].x + hess1[i].y + hess1[i].z) * vsigma[i]
-            + 4 * v2sigma[i] * (grad[i].x * grad[i].x * hess1[i].x +
-					    grad[i].y * grad[i].y * hess1[i].y +
-					    grad[i].z * grad[i].z * hess1[i].z +
-					    2 * grad[i].x * grad[i].y * hess2[i].x +
-					    2 * grad[i].x * grad[i].z * hess2[i].y +
-					    2 * grad[i].y * grad[i].z * hess2[i].z));
-    }
+    // Merge the results for the derivatives.
+    /*
+            vrho[i] += vrhoC[i];
+            vsigma[i] += vsigmaC[i];
+            v2rho[i] += v2rhoC[i];
+            v2rhosigma[i] += v2rhosigmaC[i];
+            v2sigma[i] += v2sigmaC[i];
+    */
+    vrho[i] = fEE * vrho[i] + vrhoC[i];
+    vsigma[i] = fEE * vsigma[i] + vsigmaC[i];
+    v2rho[i] = fEE * v2rho[i] + v2rhoC[i];
+    v2rhosigma[i] = fEE * v2rhosigma[i] + v2rhosigmaC[i];
+    v2sigma[i] = fEE * v2sigma[i] + v2sigmaC[i];
+    // Now, compute y2a value.
+    y2a[i] = vrho[i] - (2 * sigma[i] * v2rhosigma[i] +
+                        2 * (hess1[i].x + hess1[i].y + hess1[i].z) * vsigma[i] +
+                        4 * v2sigma[i] *
+                            (grad[i].x * grad[i].x * hess1[i].x +
+                             grad[i].y * grad[i].y * hess1[i].y +
+                             grad[i].z * grad[i].z * hess1[i].z +
+                             2 * grad[i].x * grad[i].y * hess2[i].x +
+                             2 * grad[i].x * grad[i].z * hess2[i].y +
+                             2 * grad[i].y * grad[i].z * hess2[i].z));
+  }
 }
 
 /////////////////////////////////////
 // Conversion KERNELS
 //
 // Utils for data type conversion from lio to libxc
-__forceinline__ __global__ void convertFloatToDouble(const float* input, double* output, int numElements)
-{
-    int i = blockDim.x * blockIdx.x + threadIdx.x;
-    if (i < numElements)
-    {
-	output[i] = (double)input[i];
-    }
+__forceinline__ __global__ void convertFloatToDouble(const float* input,
+                                                     double* output,
+                                                     int numElements) {
+  int i = blockDim.x * blockIdx.x + threadIdx.x;
+  if (i < numElements) {
+    output[i] = (double)input[i];
+  }
 }
 
-__forceinline__ __global__ void convertDoubleToFloat(const double* input, float* output, int numElements)
-{
-    int i = blockDim.x * blockIdx.x + threadIdx.x;
-    if (i < numElements)
-    {
-	output[i] = (float)input[i];
-    }
+__forceinline__ __global__ void convertDoubleToFloat(const double* input,
+                                                     float* output,
+                                                     int numElements) {
+  int i = blockDim.x * blockIdx.x + threadIdx.x;
+  if (i < numElements) {
+    output[i] = (float)input[i];
+  }
 }
 
-__forceinline__ __global__ void convertFloatToDouble(const G2G::vec_type<float,4>* input, G2G::vec_type<double,4>* output, int numElements)
-{
-    int i = blockDim.x * blockIdx.x + threadIdx.x;
-    if (i < numElements)
-    {
-	//float x, y, z, _w;
-	output[i].x = (double)(input[i].x);
-	output[i].y = (double)(input[i].y);
-	output[i].z = (double)(input[i].z);
-	output[i].w = (double)(input[i].w);
-    }
-}
-
-// Esto es para engañar al compilador pq el FLAG FULL_DOUBLE
-// a veces permite que T sea double y se rompe todo.
-__forceinline__ __global__ void convertDoubleToFloat(const double* input, double* output, int numElements)
-{
-    return;
+__forceinline__ __global__ void convertFloatToDouble(
+    const G2G::vec_type<float, 4>* input, G2G::vec_type<double, 4>* output,
+    int numElements) {
+  int i = blockDim.x * blockIdx.x + threadIdx.x;
+  if (i < numElements) {
+    // float x, y, z, _w;
+    output[i].x = (double)(input[i].x);
+    output[i].y = (double)(input[i].y);
+    output[i].z = (double)(input[i].z);
+    output[i].w = (double)(input[i].w);
+  }
 }
 
 // Esto es para engañar al compilador pq el FLAG FULL_DOUBLE
 // a veces permite que T sea double y se rompe todo.
-__forceinline__ __global__ void convertFloatToDouble(const double* input, double* output, int numElements)
-{
-    return;
+__forceinline__ __global__ void convertDoubleToFloat(const double* input,
+                                                     double* output,
+                                                     int numElements) {
+  return;
 }
 
 // Esto es para engañar al compilador pq el FLAG FULL_DOUBLE
 // a veces permite que T sea double y se rompe todo.
-__forceinline__ __global__ void convertFloatToDouble(const G2G::vec_type<double,4>* input, G2G::vec_type<double,4>* output, int numElements)
-{
-    return;
+__forceinline__ __global__ void convertFloatToDouble(const double* input,
+                                                     double* output,
+                                                     int numElements) {
+  return;
 }
 
-__forceinline__ __global__ void convertDoubleToFloat(const G2G::vec_type<double,4>* input, G2G::vec_type<float,4>* output, int numElements)
-{
-    int i = blockDim.x * blockIdx.x + threadIdx.x;
-    if (i < numElements)
-    {
-	//float x, y, z, _w;
-	output[i].x = (float)(input[i].x);
-	output[i].y = (float)(input[i].y);
-	output[i].z = (float)(input[i].z);
-	output[i].w = (float)(input[i].w);
-    }
+// Esto es para engañar al compilador pq el FLAG FULL_DOUBLE
+// a veces permite que T sea double y se rompe todo.
+__forceinline__ __global__ void convertFloatToDouble(
+    const G2G::vec_type<double, 4>* input, G2G::vec_type<double, 4>* output,
+    int numElements) {
+  return;
+}
+
+__forceinline__ __global__ void convertDoubleToFloat(
+    const G2G::vec_type<double, 4>* input, G2G::vec_type<float, 4>* output,
+    int numElements) {
+  int i = blockDim.x * blockIdx.x + threadIdx.x;
+  if (i < numElements) {
+    // float x, y, z, _w;
+    output[i].x = (float)(input[i].x);
+    output[i].y = (float)(input[i].y);
+    output[i].z = (float)(input[i].z);
+    output[i].w = (float)(input[i].w);
+  }
 }
 
 // end Conversion KERNELS
@@ -1562,396 +1501,359 @@ __forceinline__ __global__ void convertDoubleToFloat(const G2G::vec_type<double,
 // dens: pointer for the density array
 // number_of_points: the size of all the input arrays
 // contracted_grad: the contracted grad for libxc
-// grad: 
+// grad:
 // hess1:
 // hess2:
-// ex: here goes the results after calling xc_gga from libxc for the exchange functional
-// ec: here goes the results after calling xc_gga from libxc for the correlation functional
+// ex: here goes the results after calling xc_gga from libxc for the exchange
+// functional ec: here goes the results after calling xc_gga from libxc for the
+// correlation functional
 //
 // Note: all the pointer data are pointers in CUDA memory.
 //
 template <class T, int width>
-void LibxcProxy_cuda <T, width>::doGGA(T* dens,
-    const int number_of_points,
-    const T* contracted_grad,
-    const G2G::vec_type<T, width>* grad,
-    const G2G::vec_type<T, width>* hess1,
-    const G2G::vec_type<T, width>* hess2,
-    T* ex,
-    T* ec,
-    T* y2a)
-{
+void LibxcProxy_cuda<T, width>::doGGA(T* dens, const int number_of_points,
+                                      const T* contracted_grad,
+                                      const G2G::vec_type<T, width>* grad,
+                                      const G2G::vec_type<T, width>* hess1,
+                                      const G2G::vec_type<T, width>* hess2,
+                                      T* ex, T* ec, T* y2a) {
 #ifdef __CUDACC__
-    //printf("doGGA - GPU, exact %f\n",fact_exchange);
-    //printf("Number of points: %u\n", number_of_points);
+  // printf("doGGA - GPU, exact %f\n",fact_exchange);
+  // printf("Number of points: %u\n", number_of_points);
 
-    // Este flag esta asi ya que a veces lio utiliza precision mixta
-    // y solo en tiempo de ejecucion podemos saber que tipos
-    // de datos esta utilizando.
-    bool full_double = (sizeof(T) == 8);
+  // Este flag esta asi ya que a veces lio utiliza precision mixta
+  // y solo en tiempo de ejecucion podemos saber que tipos
+  // de datos esta utilizando.
+  bool full_double = (sizeof(T) == 8);
 
-    // Variables for the Kernels
-    int threadsPerBlock = 256;
-    int blocksPerGrid = (number_of_points + threadsPerBlock - 1) / threadsPerBlock;
+  // Variables for the Kernels
+  int threadsPerBlock = 256;
+  int blocksPerGrid =
+      (number_of_points + threadsPerBlock - 1) / threadsPerBlock;
 
-    cudaError_t err = cudaSuccess;
+  cudaError_t err = cudaSuccess;
 
-    // All the arrays for libxc must be of double*
-    int array_size = sizeof(double) * number_of_points;
-    int vec_size = sizeof(G2G::vec_type<double,width>) * number_of_points;
+  // All the arrays for libxc must be of double*
+  int array_size = sizeof(double) * number_of_points;
+  int vec_size = sizeof(G2G::vec_type<double, width>) * number_of_points;
 
-    double* rho = NULL;
-    double* sigma = NULL;
+  double* rho = NULL;
+  double* sigma = NULL;
 
-    double* ex_double = NULL;
-    double* ec_double = NULL;
-    double* y2a_double = NULL;
-    G2G::vec_type<double, width>* grad_double = NULL;
-    G2G::vec_type<double, width>* hess1_double = NULL;
-    G2G::vec_type<double, width>* hess2_double = NULL;
+  double* ex_double = NULL;
+  double* ec_double = NULL;
+  double* y2a_double = NULL;
+  G2G::vec_type<double, width>* grad_double = NULL;
+  G2G::vec_type<double, width>* hess1_double = NULL;
+  G2G::vec_type<double, width>* hess2_double = NULL;
 
-    err = cudaMalloc((void**)&rho, array_size);
-    if (err != cudaSuccess)
-    {
-        fprintf(stderr, "Failed to allocate device rho si!\n");
-        exit(EXIT_FAILURE);
+  err = cudaMalloc((void**)&rho, array_size);
+  if (err != cudaSuccess) {
+    fprintf(stderr, "Failed to allocate device rho si!\n");
+    exit(EXIT_FAILURE);
+  }
+
+  err = cudaMalloc((void**)&sigma, array_size);
+  if (err != cudaSuccess) {
+    fprintf(stderr, "Failed to allocate device sigma!\n");
+    exit(EXIT_FAILURE);
+  }
+
+  // Si el tipo de datos es float, creamos los arrays para copiar
+  // los inputs y convertirlos a floats.
+  if (!full_double) {
+    err = cudaMalloc((void**)&ex_double, array_size);
+    if (err != cudaSuccess) {
+      fprintf(stderr, "Failed to allocate device ex_double!\n");
+      exit(EXIT_FAILURE);
+    }
+    cudaMemset(ex_double, 0, array_size);
+
+    err = cudaMalloc((void**)&ec_double, array_size);
+    if (err != cudaSuccess) {
+      fprintf(stderr, "Failed to allocate device ec_double!\n");
+      exit(EXIT_FAILURE);
+    }
+    cudaMemset(ec_double, 0, array_size);
+
+    err = cudaMalloc((void**)&y2a_double, array_size);
+    if (err != cudaSuccess) {
+      fprintf(stderr, "Failed to allocate device y2a_double!\n");
+      exit(EXIT_FAILURE);
+    }
+    cudaMemset(y2a_double, 0, array_size);
+
+    err = cudaMalloc((void**)&grad_double, vec_size);
+    if (err != cudaSuccess) {
+      fprintf(stderr, "Failed to allocate device grad_double!\n");
+      exit(EXIT_FAILURE);
     }
 
-    err = cudaMalloc((void**)&sigma, array_size);
-    if (err != cudaSuccess)
-    {
-        fprintf(stderr, "Failed to allocate device sigma!\n");
-	exit(EXIT_FAILURE);
+    err = cudaMalloc((void**)&hess1_double, vec_size);
+    if (err != cudaSuccess) {
+      fprintf(stderr, "Failed to allocate device hess1_double!\n");
+      exit(EXIT_FAILURE);
     }
 
-    // Si el tipo de datos es float, creamos los arrays para copiar
-    // los inputs y convertirlos a floats.
-    if (!full_double) {
-	err = cudaMalloc((void**)&ex_double, array_size);
-        if (err != cudaSuccess)
-        {
-	    fprintf(stderr, "Failed to allocate device ex_double!\n");
-    	    exit(EXIT_FAILURE);
-        }
-	cudaMemset(ex_double,0,array_size);
+    err = cudaMalloc((void**)&hess2_double, vec_size);
+    if (err != cudaSuccess) {
+      fprintf(stderr, "Failed to allocate device hess2_double!\n");
+      exit(EXIT_FAILURE);
+    }
+  }
 
-        err = cudaMalloc((void**)&ec_double, array_size);
-	if (err != cudaSuccess)
-        {
-	    fprintf(stderr, "Failed to allocate device ec_double!\n");
-	    exit(EXIT_FAILURE);
-        }
-	cudaMemset(ec_double,0,array_size);
-
-        err = cudaMalloc((void**)&y2a_double, array_size);
-	if (err != cudaSuccess)
-        {
-    	    fprintf(stderr, "Failed to allocate device y2a_double!\n");
-	    exit(EXIT_FAILURE);
-        }
-	cudaMemset(y2a_double,0,array_size);
-
-        err = cudaMalloc((void**)&grad_double, vec_size);
-	if (err != cudaSuccess)
-	{
-	    fprintf(stderr, "Failed to allocate device grad_double!\n");
-    	    exit(EXIT_FAILURE);
-        }
-
-	err = cudaMalloc((void**)&hess1_double, vec_size);
-        if (err != cudaSuccess)
-	{
-	    fprintf(stderr, "Failed to allocate device hess1_double!\n");
-	    exit(EXIT_FAILURE);
-        }
-
-	err = cudaMalloc((void**)&hess2_double, vec_size);
-        if (err != cudaSuccess)
-	{
-	    fprintf(stderr, "Failed to allocate device hess2_double!\n");
-	    exit(EXIT_FAILURE);
-        }
+  // Preparamos los datos.
+  if (full_double) {
+    err = cudaMemcpy(rho, dens, array_size, cudaMemcpyDeviceToDevice);
+    if (err != cudaSuccess) {
+      fprintf(stderr, "Failed to copy data from dens->rho\n");
     }
 
-    // Preparamos los datos.
-    if (full_double) {
-	err = cudaMemcpy(rho, dens, array_size, cudaMemcpyDeviceToDevice);
-        if (err != cudaSuccess)
-	{
-	    fprintf(stderr, "Failed to copy data from dens->rho\n");
-        }
-
-	err = cudaMemcpy(sigma, contracted_grad, array_size, cudaMemcpyDeviceToDevice);
-        if (err != cudaSuccess)
-	{
-	    fprintf(stderr, "Failed to copy data from contracted_grad->sigma\n");
-	}
-
-        // Usamos los datos como vienen ya que son todos doubles.
-	ex_double = (double*)ex;
-	ec_double = (double*)ec;
-        y2a_double = (double*)y2a;
-	grad_double = (G2G::vec_type<double,4>*)grad;
-        hess1_double = (G2G::vec_type<double,4>*)hess1;
-        hess2_double = (G2G::vec_type<double,4>*)hess2;
-
-    } else {
-	// Como los inputs son float, los convertimos para libxc
-	convertFloatToDouble<<<blocksPerGrid, threadsPerBlock>>>(dens, rho, number_of_points);
-	convertFloatToDouble<<<blocksPerGrid, threadsPerBlock>>>(contracted_grad, sigma, number_of_points);
-        convertFloatToDouble<<<blocksPerGrid, threadsPerBlock>>>(grad, grad_double, number_of_points);
-	convertFloatToDouble<<<blocksPerGrid, threadsPerBlock>>>(hess1, hess1_double, number_of_points);
-        convertFloatToDouble<<<blocksPerGrid, threadsPerBlock>>>(hess2, hess2_double, number_of_points);
+    err = cudaMemcpy(sigma, contracted_grad, array_size,
+                     cudaMemcpyDeviceToDevice);
+    if (err != cudaSuccess) {
+      fprintf(stderr, "Failed to copy data from contracted_grad->sigma\n");
     }
 
-    // Preparamos los arrays de salida.
-    double* exchange = NULL;
-    err = cudaMalloc((void **)&exchange, array_size);
-    if (err != cudaSuccess)
-    {
-        fprintf(stderr, "Failed to allocate device exchange!\n");
-        exit(EXIT_FAILURE);
-    }
+    // Usamos los datos como vienen ya que son todos doubles.
+    ex_double = (double*)ex;
+    ec_double = (double*)ec;
+    y2a_double = (double*)y2a;
+    grad_double = (G2G::vec_type<double, 4>*)grad;
+    hess1_double = (G2G::vec_type<double, 4>*)hess1;
+    hess2_double = (G2G::vec_type<double, 4>*)hess2;
 
-    double* correlation = NULL;
-    err = cudaMalloc((void **)&correlation, array_size);
-    if (err != cudaSuccess)
-    {
-        fprintf(stderr, "Failed to allocate device correlation!\n");
-        exit(EXIT_FAILURE);
-    }
+  } else {
+    // Como los inputs son float, los convertimos para libxc
+    convertFloatToDouble<<<blocksPerGrid, threadsPerBlock>>>(dens, rho,
+                                                             number_of_points);
+    convertFloatToDouble<<<blocksPerGrid, threadsPerBlock>>>(
+        contracted_grad, sigma, number_of_points);
+    convertFloatToDouble<<<blocksPerGrid, threadsPerBlock>>>(grad, grad_double,
+                                                             number_of_points);
+    convertFloatToDouble<<<blocksPerGrid, threadsPerBlock>>>(
+        hess1, hess1_double, number_of_points);
+    convertFloatToDouble<<<blocksPerGrid, threadsPerBlock>>>(
+        hess2, hess2_double, number_of_points);
+  }
 
-    cudaMemset(exchange,0,array_size);
-    cudaMemset(correlation,0,array_size);
+  // Preparamos los arrays de salida.
+  double* exchange = NULL;
+  err = cudaMalloc((void**)&exchange, array_size);
+  if (err != cudaSuccess) {
+    fprintf(stderr, "Failed to allocate device exchange!\n");
+    exit(EXIT_FAILURE);
+  }
 
-    // The outputs for exchange
-    double* vrho = NULL;
-    double* vsigma = NULL;
-    double* v2rho = NULL;
-    double* v2rhosigma = NULL;
-    double* v2sigma = NULL;
+  double* correlation = NULL;
+  err = cudaMalloc((void**)&correlation, array_size);
+  if (err != cudaSuccess) {
+    fprintf(stderr, "Failed to allocate device correlation!\n");
+    exit(EXIT_FAILURE);
+  }
 
-    err = cudaMalloc((void **)&vrho, array_size);
-    if (err != cudaSuccess)
-    {
-        fprintf(stderr, "Failed to allocate device vrho!\n");
-        exit(EXIT_FAILURE);
-    }
+  cudaMemset(exchange, 0, array_size);
+  cudaMemset(correlation, 0, array_size);
 
-    err = cudaMalloc((void **)&vsigma, array_size);
-    if (err != cudaSuccess)
-    {
-        fprintf(stderr, "Failed to allocate device vsigma!\n");
-        exit(EXIT_FAILURE);
-    }
+  // The outputs for exchange
+  double* vrho = NULL;
+  double* vsigma = NULL;
+  double* v2rho = NULL;
+  double* v2rhosigma = NULL;
+  double* v2sigma = NULL;
 
-    err = cudaMalloc((void **)&v2rho, array_size);
-    if (err != cudaSuccess)
-    {
-        fprintf(stderr, "Failed to allocate device v2rho!\n");
-        exit(EXIT_FAILURE);
-    }
+  err = cudaMalloc((void**)&vrho, array_size);
+  if (err != cudaSuccess) {
+    fprintf(stderr, "Failed to allocate device vrho!\n");
+    exit(EXIT_FAILURE);
+  }
 
-    err = cudaMalloc((void **)&v2rhosigma, array_size);
-    if (err != cudaSuccess)
-    {
-        fprintf(stderr, "Failed to allocate device v2rhosigma!\n");
-        exit(EXIT_FAILURE);
-    }
+  err = cudaMalloc((void**)&vsigma, array_size);
+  if (err != cudaSuccess) {
+    fprintf(stderr, "Failed to allocate device vsigma!\n");
+    exit(EXIT_FAILURE);
+  }
 
-    err = cudaMalloc((void **)&v2sigma, array_size);
-    if (err != cudaSuccess)
-    {
-        fprintf(stderr, "Failed to allocate device v2sigma!\n");
-        exit(EXIT_FAILURE);
-    }
+  err = cudaMalloc((void**)&v2rho, array_size);
+  if (err != cudaSuccess) {
+    fprintf(stderr, "Failed to allocate device v2rho!\n");
+    exit(EXIT_FAILURE);
+  }
 
-    // Clear arrays
-    cudaMemset(vrho, 0, array_size);
-    cudaMemset(vsigma, 0, array_size);
-    cudaMemset(v2rho, 0, array_size);
-    cudaMemset(v2rhosigma, 0, array_size);
-    cudaMemset(v2sigma, 0, array_size);
+  err = cudaMalloc((void**)&v2rhosigma, array_size);
+  if (err != cudaSuccess) {
+    fprintf(stderr, "Failed to allocate device v2rhosigma!\n");
+    exit(EXIT_FAILURE);
+  }
 
-    // The outputs for correlation
-    double* vrhoC = NULL;
-    double* vsigmaC = NULL;
-    double* v2rhoC = NULL;
-    double* v2rhosigmaC = NULL;
-    double* v2sigmaC = NULL;
+  err = cudaMalloc((void**)&v2sigma, array_size);
+  if (err != cudaSuccess) {
+    fprintf(stderr, "Failed to allocate device v2sigma!\n");
+    exit(EXIT_FAILURE);
+  }
 
-    err = cudaMalloc((void **)&vrhoC, array_size);
-    if (err != cudaSuccess)
-    {
-        fprintf(stderr, "Failed to allocate device vrhoC!\n");
-        exit(EXIT_FAILURE);
-    }
+  // Clear arrays
+  cudaMemset(vrho, 0, array_size);
+  cudaMemset(vsigma, 0, array_size);
+  cudaMemset(v2rho, 0, array_size);
+  cudaMemset(v2rhosigma, 0, array_size);
+  cudaMemset(v2sigma, 0, array_size);
 
-    err = cudaMalloc((void **)&vsigmaC, array_size);
-    if (err != cudaSuccess)
-    {
-        fprintf(stderr, "Failed to allocate device vsigmaC!\n");
-        exit(EXIT_FAILURE);
-    }
+  // The outputs for correlation
+  double* vrhoC = NULL;
+  double* vsigmaC = NULL;
+  double* v2rhoC = NULL;
+  double* v2rhosigmaC = NULL;
+  double* v2sigmaC = NULL;
 
-    err = cudaMalloc((void **)&v2rhoC, array_size);
-    if (err != cudaSuccess)
-    {
-        fprintf(stderr, "Failed to allocate device v2rhoC!\n");
-        exit(EXIT_FAILURE);
-    }
+  err = cudaMalloc((void**)&vrhoC, array_size);
+  if (err != cudaSuccess) {
+    fprintf(stderr, "Failed to allocate device vrhoC!\n");
+    exit(EXIT_FAILURE);
+  }
 
-    err = cudaMalloc((void **)&v2rhosigmaC, array_size);
-    if (err != cudaSuccess)
-    {
-        fprintf(stderr, "Failed to allocate device v2rhosigmaC!\n");
-        exit(EXIT_FAILURE);
-    }
+  err = cudaMalloc((void**)&vsigmaC, array_size);
+  if (err != cudaSuccess) {
+    fprintf(stderr, "Failed to allocate device vsigmaC!\n");
+    exit(EXIT_FAILURE);
+  }
 
-    err = cudaMalloc((void **)&v2sigmaC, array_size);
-    if (err != cudaSuccess)
-    {
-        fprintf(stderr, "Failed to allocate device v2sigmaC!\n");
-        exit(EXIT_FAILURE);
-    }
+  err = cudaMalloc((void**)&v2rhoC, array_size);
+  if (err != cudaSuccess) {
+    fprintf(stderr, "Failed to allocate device v2rhoC!\n");
+    exit(EXIT_FAILURE);
+  }
 
-    ///////////////////////////////////
-    // Clear arrays for correlation
-    cudaMemset(vrhoC, 0, array_size);
-    cudaMemset(vsigmaC, 0, array_size);
-    cudaMemset(v2rhoC, 0, array_size);
-    cudaMemset(v2rhosigmaC, 0, array_size);
-    cudaMemset(v2sigmaC, 0, array_size);
+  err = cudaMalloc((void**)&v2rhosigmaC, array_size);
+  if (err != cudaSuccess) {
+    fprintf(stderr, "Failed to allocate device v2rhosigmaC!\n");
+    exit(EXIT_FAILURE);
+  }
 
-    /////////////////////////////
-    // Call LIBXC for exchange
-    try {
-        xc_gga_cuda (&funcForExchange, number_of_points,
-                rho,
-                sigma,
-                exchange,
-                vrho,
-                vsigma,
-                v2rho,
-                v2rhosigma,
-                v2sigma,
-                NULL, NULL, NULL, NULL);
-    } catch (int exception) {
-        fprintf (stderr, "Exception ocurred calling xc_gga for Exchange '%d' \n", exception);
-        return;
-    }
+  err = cudaMalloc((void**)&v2sigmaC, array_size);
+  if (err != cudaSuccess) {
+    fprintf(stderr, "Failed to allocate device v2sigmaC!\n");
+    exit(EXIT_FAILURE);
+  }
 
-    ////////////////////////////////
-    // Call LIBXC for correlation
-    try {
-        // Now the correlation value.
-        xc_gga_cuda (&funcForCorrelation, number_of_points,
-                rho,
-                sigma,
-                correlation,
-                vrhoC,
-                vsigmaC,
-                v2rhoC,
-                v2rhosigmaC,
-                v2sigmaC,
-                NULL, NULL, NULL, NULL);
-    } catch (int exception) {
-        fprintf (stderr, "Exception ocurred calling xc_gga for Correlation '%d' \n", exception);
-        return;
-    }
+  ///////////////////////////////////
+  // Clear arrays for correlation
+  cudaMemset(vrhoC, 0, array_size);
+  cudaMemset(vsigmaC, 0, array_size);
+  cudaMemset(v2rhoC, 0, array_size);
+  cudaMemset(v2rhosigmaC, 0, array_size);
+  cudaMemset(v2sigmaC, 0, array_size);
 
-    ////////////////////////
-    // Gather the results
-    joinResults<T, width><<<blocksPerGrid, threadsPerBlock>>>(
-	ex_double, exchange,
-	ec_double, correlation,
-	vrho, vrhoC,
-	vsigma, vsigmaC,
-	v2rho, v2rhoC,
-	v2rhosigma, v2rhosigmaC,
-	v2sigma, v2sigmaC,
-	y2a_double,
-	sigma,
-	grad_double,
-	hess1_double,
-	hess2_double,
-	number_of_points,fact_exchange);
-
-    //////////////////////////
-    // Convert if necessary
-    if (!full_double) {
-	convertDoubleToFloat<<<blocksPerGrid, threadsPerBlock>>> (ex_double, ex, number_of_points);
-	convertDoubleToFloat<<<blocksPerGrid, threadsPerBlock>>> (ec_double, ec, number_of_points);
-        convertDoubleToFloat<<<blocksPerGrid, threadsPerBlock>>> (y2a_double, y2a, number_of_points);
-    }
-
-    /////////////////////////
-    // Free device memory
-    if (rho != NULL) {
-	cudaFree(rho);
-    }
-    if (sigma != NULL) {
-	cudaFree(sigma);
-    }
-    if (exchange != NULL) {
-	cudaFree(exchange);
-    }
-    if (correlation != NULL) {
-	cudaFree(correlation);
-    }
-    if (vrho != NULL) {
-        cudaFree(vrho);
-    }
-    if (vsigma != NULL) {
-	cudaFree(vsigma);
-    }
-    if (v2rho != NULL) {
-	cudaFree(v2rho);
-    }
-    if (v2rhosigma != NULL) {
-	cudaFree(v2rhosigma);
-    }
-    if (v2sigma != NULL) {
-	cudaFree(v2sigma);
-    }
-    if (vrhoC != NULL) {
-        cudaFree(vrhoC);
-    }
-    if (vsigmaC != NULL) {
-	cudaFree(vsigmaC);
-    }
-    if (v2rhoC != NULL) {
-	cudaFree(v2rhoC);
-    }
-    if (v2rhosigmaC != NULL) {
-	cudaFree(v2rhosigmaC);
-    }
-    if (v2sigmaC != NULL) {
-	cudaFree(v2sigmaC);
-    }
-
-    if (!full_double) {
-        if (ex_double != NULL) {
-            cudaFree(ex_double);
-        }
-        if (ec_double != NULL) {
-            cudaFree(ec_double);
-        }
-        if (y2a_double != NULL) {
-        cudaFree(y2a_double);
-        }
-        if (grad_double != NULL) {
-            cudaFree((void*)grad_double);
-    	}
-    	if (hess1_double != NULL) {
-        cudaFree((void*)hess1_double);
-    	}
-        if (hess2_double != NULL) {
-    	    cudaFree((void*)hess2_double);
-        }
-    }
-#endif
+  /////////////////////////////
+  // Call LIBXC for exchange
+  try {
+    xc_gga_cuda(&funcForExchange, number_of_points, rho, sigma, exchange, vrho,
+                vsigma, v2rho, v2rhosigma, v2sigma, NULL, NULL, NULL, NULL);
+  } catch (int exception) {
+    fprintf(stderr, "Exception ocurred calling xc_gga for Exchange '%d' \n",
+            exception);
     return;
+  }
+
+  ////////////////////////////////
+  // Call LIBXC for correlation
+  try {
+    // Now the correlation value.
+    xc_gga_cuda(&funcForCorrelation, number_of_points, rho, sigma, correlation,
+                vrhoC, vsigmaC, v2rhoC, v2rhosigmaC, v2sigmaC, NULL, NULL, NULL,
+                NULL);
+  } catch (int exception) {
+    fprintf(stderr, "Exception ocurred calling xc_gga for Correlation '%d' \n",
+            exception);
+    return;
+  }
+
+  ////////////////////////
+  // Gather the results
+  joinResults<T, width><<<blocksPerGrid, threadsPerBlock>>>(
+      ex_double, exchange, ec_double, correlation, vrho, vrhoC, vsigma, vsigmaC,
+      v2rho, v2rhoC, v2rhosigma, v2rhosigmaC, v2sigma, v2sigmaC, y2a_double,
+      sigma, grad_double, hess1_double, hess2_double, number_of_points,
+      fact_exchange);
+
+  //////////////////////////
+  // Convert if necessary
+  if (!full_double) {
+    convertDoubleToFloat<<<blocksPerGrid, threadsPerBlock>>>(ex_double, ex,
+                                                             number_of_points);
+    convertDoubleToFloat<<<blocksPerGrid, threadsPerBlock>>>(ec_double, ec,
+                                                             number_of_points);
+    convertDoubleToFloat<<<blocksPerGrid, threadsPerBlock>>>(y2a_double, y2a,
+                                                             number_of_points);
+  }
+
+  /////////////////////////
+  // Free device memory
+  if (rho != NULL) {
+    cudaFree(rho);
+  }
+  if (sigma != NULL) {
+    cudaFree(sigma);
+  }
+  if (exchange != NULL) {
+    cudaFree(exchange);
+  }
+  if (correlation != NULL) {
+    cudaFree(correlation);
+  }
+  if (vrho != NULL) {
+    cudaFree(vrho);
+  }
+  if (vsigma != NULL) {
+    cudaFree(vsigma);
+  }
+  if (v2rho != NULL) {
+    cudaFree(v2rho);
+  }
+  if (v2rhosigma != NULL) {
+    cudaFree(v2rhosigma);
+  }
+  if (v2sigma != NULL) {
+    cudaFree(v2sigma);
+  }
+  if (vrhoC != NULL) {
+    cudaFree(vrhoC);
+  }
+  if (vsigmaC != NULL) {
+    cudaFree(vsigmaC);
+  }
+  if (v2rhoC != NULL) {
+    cudaFree(v2rhoC);
+  }
+  if (v2rhosigmaC != NULL) {
+    cudaFree(v2rhosigmaC);
+  }
+  if (v2sigmaC != NULL) {
+    cudaFree(v2sigmaC);
+  }
+
+  if (!full_double) {
+    if (ex_double != NULL) {
+      cudaFree(ex_double);
+    }
+    if (ec_double != NULL) {
+      cudaFree(ec_double);
+    }
+    if (y2a_double != NULL) {
+      cudaFree(y2a_double);
+    }
+    if (grad_double != NULL) {
+      cudaFree((void*)grad_double);
+    }
+    if (hess1_double != NULL) {
+      cudaFree((void*)hess1_double);
+    }
+    if (hess2_double != NULL) {
+      cudaFree((void*)hess2_double);
+    }
+  }
+#endif
+  return;
 }
 
 //////////////////////////////////////////////////////////////
@@ -1964,17 +1866,21 @@ void LibxcProxy_cuda <T, width>::doGGA(T* dens,
 // grad:.
 // hess1:
 // hess2:
-// ex: here goes the results after calling xc_gga from libxc for the exchange functional
-// ec: here goes the results after calling xc_gga from libxc for the correlation functional
+// ex: here goes the results after calling xc_gga from libxc for the exchange
+// functional ec: here goes the results after calling xc_gga from libxc for the
+// correlation functional
 //
 // Note: all the pointer data are pointers in CUDA memory.
 //
 
 template <class T, int width>
-void LibxcProxy_cuda <T, width>::doLDA(T dens, const G2G::vec_type<T, width> &grad, const G2G::vec_type<T, width> &hess1, const G2G::vec_type<T, width> &hess2, T &ex, T &ec, T &y2a)
-{
-    //TODO: not implemented yet!
-    return;
+void LibxcProxy_cuda<T, width>::doLDA(T dens,
+                                      const G2G::vec_type<T, width>& grad,
+                                      const G2G::vec_type<T, width>& hess1,
+                                      const G2G::vec_type<T, width>& hess2,
+                                      T& ex, T& ec, T& y2a) {
+  // TODO: not implemented yet!
+  return;
 }
 
-#endif // LIBXCPROXY_CUDA_H
+#endif  // LIBXCPROXY_CUDA_H

--- a/g2g/libxc/print_utils.h
+++ b/g2g/libxc/print_utils.h
@@ -6,230 +6,236 @@
 //////////////////////////////////////
 //// PRINT UTILS
 template <class T>
-void print_array (T* data, int size) 
-{
-    printf ("[");
-    if (data == NULL) {
-	printf("empty");
-    } else {
-	for (int i=0; i<size; i++) {
-	    printf("%e,", data[i]);
-	}
+void print_array(T* data, int size) {
+  printf("[");
+  if (data == NULL) {
+    printf("empty");
+  } else {
+    for (int i = 0; i < size; i++) {
+      printf("%e,", data[i]);
     }
-    printf("]\n");
+  }
+  printf("]\n");
 }
 
 template <class T>
-void print_vec_type (G2G::vec_type<T,4>* data, int size) 
-{
-    printf ("[");
-    if (data == NULL) {
-	printf("empty");
-    } else {
-	for (int i=0; i<size; i++) {
-	    printf("(%e,%e,%e),", data[i].x, data[i].y, data[i].z);
-	}
+void print_vec_type(G2G::vec_type<T, 4>* data, int size) {
+  printf("[");
+  if (data == NULL) {
+    printf("empty");
+  } else {
+    for (int i = 0; i < size; i++) {
+      printf("(%e,%e,%e),", data[i].x, data[i].y, data[i].z);
     }
-    printf("]\n");
+  }
+  printf("]\n");
 }
 
-template <class T> 
-void print_accumulate_parameters (
-    T* energy_gpu, 
-    T* factor_gpu, 
-    T* point_weights_gpu,
-    int number_of_points,
-    int block_height,
-    T* partial_densities_gpu,
-    G2G::vec_type<T,4>* dxyz_gpu,
-    G2G::vec_type<T,4>* dd1_gpu,
-    G2G::vec_type<T,4>* dd2_gpu)
-{
+template <class T>
+void print_accumulate_parameters(T* energy_gpu, T* factor_gpu,
+                                 T* point_weights_gpu, int number_of_points,
+                                 int block_height, T* partial_densities_gpu,
+                                 G2G::vec_type<T, 4>* dxyz_gpu,
+                                 G2G::vec_type<T, 4>* dd1_gpu,
+                                 G2G::vec_type<T, 4>* dd2_gpu) {
 #ifdef __CUDACC__
-    // Bajar la info a CPU y luego imprimirla.
-    // Copy to host the matrix data in gpu memory and
-    // call the new libxcProxy.
-    G2G::vec_type<T,4>* dxyz_cpu;
-    G2G::vec_type<T,4>* dd1_cpu;
-    G2G::vec_type<T,4>* dd2_cpu;
+  // Bajar la info a CPU y luego imprimirla.
+  // Copy to host the matrix data in gpu memory and
+  // call the new libxcProxy.
+  G2G::vec_type<T, 4>* dxyz_cpu;
+  G2G::vec_type<T, 4>* dd1_cpu;
+  G2G::vec_type<T, 4>* dd2_cpu;
 
-    // Alloc memory in the host for the gpu data
-    uint size = number_of_points * sizeof(G2G::vec_type<T,4>);
-    dxyz_cpu = (G2G::vec_type<T,4> *)malloc(size);
-    dd1_cpu = (G2G::vec_type<T,4> *)malloc(size);
-    dd2_cpu = (G2G::vec_type<T,4> *)malloc(size);
+  // Alloc memory in the host for the gpu data
+  uint size = number_of_points * sizeof(G2G::vec_type<T, 4>);
+  dxyz_cpu = (G2G::vec_type<T, 4>*)malloc(size);
+  dd1_cpu = (G2G::vec_type<T, 4>*)malloc(size);
+  dd2_cpu = (G2G::vec_type<T, 4>*)malloc(size);
 
-    // Copy data from device to host.
-    if (dxyz_gpu != NULL)
-        cudaMemcpy(dxyz_cpu, dxyz_gpu, size, cudaMemcpyDeviceToHost);
-    if (dd1_gpu != NULL)
-	cudaMemcpy(dd1_cpu, dd1_gpu, size, cudaMemcpyDeviceToHost);
-    if (dd2_gpu != NULL)
-        cudaMemcpy(dd2_cpu, dd2_gpu, size, cudaMemcpyDeviceToHost);
+  // Copy data from device to host.
+  if (dxyz_gpu != NULL)
+    cudaMemcpy(dxyz_cpu, dxyz_gpu, size, cudaMemcpyDeviceToHost);
+  if (dd1_gpu != NULL)
+    cudaMemcpy(dd1_cpu, dd1_gpu, size, cudaMemcpyDeviceToHost);
+  if (dd2_gpu != NULL)
+    cudaMemcpy(dd2_cpu, dd2_gpu, size, cudaMemcpyDeviceToHost);
 
-    // Allocate the host input vectors
-    uint array_size = number_of_points * sizeof(T);
-    T *energy_cpu = (T *)malloc(array_size);
-    T *factor_cpu = (T *)malloc(array_size);
-    T *partial_densities_cpu = (T*)malloc(array_size);
-    T *point_weights_cpu = (T*)malloc(array_size);
-    if (energy_gpu != NULL) 
-        cudaMemcpy(energy_cpu, energy_gpu, array_size, cudaMemcpyDeviceToHost);
-    if (factor_gpu != NULL)
-        cudaMemcpy(factor_cpu, factor_gpu, array_size, cudaMemcpyDeviceToHost);
-    if (partial_densities_gpu != NULL)
-	cudaMemcpy(partial_densities_cpu, partial_densities_gpu, array_size, cudaMemcpyDeviceToHost);
-    if (point_weights_gpu != NULL)
-	cudaMemcpy(point_weights_cpu, point_weights_gpu, array_size, cudaMemcpyDeviceToHost);
+  // Allocate the host input vectors
+  uint array_size = number_of_points * sizeof(T);
+  T* energy_cpu = (T*)malloc(array_size);
+  T* factor_cpu = (T*)malloc(array_size);
+  T* partial_densities_cpu = (T*)malloc(array_size);
+  T* point_weights_cpu = (T*)malloc(array_size);
+  if (energy_gpu != NULL)
+    cudaMemcpy(energy_cpu, energy_gpu, array_size, cudaMemcpyDeviceToHost);
+  if (factor_gpu != NULL)
+    cudaMemcpy(factor_cpu, factor_gpu, array_size, cudaMemcpyDeviceToHost);
+  if (partial_densities_gpu != NULL)
+    cudaMemcpy(partial_densities_cpu, partial_densities_gpu, array_size,
+               cudaMemcpyDeviceToHost);
+  if (point_weights_gpu != NULL)
+    cudaMemcpy(point_weights_cpu, point_weights_gpu, array_size,
+               cudaMemcpyDeviceToHost);
 
-    printf("=========\n");
-    printf("= Data  =\n");
-    printf("=========\n");
-    printf("number_of_points:%i\n", number_of_points);
-    printf("block_height:%i\n", block_height);
-    printf("dxyz:"); print_vec_type<T>(dxyz_cpu, number_of_points);
-    printf("dd1:"); print_vec_type<T>(dd1_cpu, number_of_points);
-    printf("dd2:"); print_vec_type<T>(dd2_cpu, number_of_points);
-    printf("energy:"); print_array<T>(energy_cpu, number_of_points);
-    printf("factor:"); print_array<T>(factor_cpu, number_of_points);
-    printf("point_weights:"); print_array<T>(point_weights_cpu, number_of_points);
-    printf("partial_densities:"); print_array<T>(partial_densities_cpu, number_of_points);
-    printf("=========\n");
+  printf("=========\n");
+  printf("= Data  =\n");
+  printf("=========\n");
+  printf("number_of_points:%i\n", number_of_points);
+  printf("block_height:%i\n", block_height);
+  printf("dxyz:");
+  print_vec_type<T>(dxyz_cpu, number_of_points);
+  printf("dd1:");
+  print_vec_type<T>(dd1_cpu, number_of_points);
+  printf("dd2:");
+  print_vec_type<T>(dd2_cpu, number_of_points);
+  printf("energy:");
+  print_array<T>(energy_cpu, number_of_points);
+  printf("factor:");
+  print_array<T>(factor_cpu, number_of_points);
+  printf("point_weights:");
+  print_array<T>(point_weights_cpu, number_of_points);
+  printf("partial_densities:");
+  print_array<T>(partial_densities_cpu, number_of_points);
+  printf("=========\n");
 
-    // Free memory.
-    free(energy_cpu);
-    free(factor_cpu);
-    free(partial_densities_cpu);
-    free(dd1_cpu);
-    free(dd2_cpu);
-    free(dxyz_cpu);
+  // Free memory.
+  free(energy_cpu);
+  free(factor_cpu);
+  free(partial_densities_cpu);
+  free(dd1_cpu);
+  free(dd2_cpu);
+  free(dxyz_cpu);
 #endif
 }
 
-template <class T> 
-void print_proxy_input (
-    T* dens,
-    const int number_of_points,
-    const T* contracted_grad,
-    const G2G::vec_type<T, 4>* grad,
-    const G2G::vec_type<T, 4>* hess1,
-    const G2G::vec_type<T, 4>* hess2)
-{
+template <class T>
+void print_proxy_input(T* dens, const int number_of_points,
+                       const T* contracted_grad,
+                       const G2G::vec_type<T, 4>* grad,
+                       const G2G::vec_type<T, 4>* hess1,
+                       const G2G::vec_type<T, 4>* hess2) {
 #ifdef __CUDACC__
-    // Bajar la info a CPU y luego imprimirla.
-    // Copy to host the matrix data in gpu memory and
-    // call the new libxcProxy.
-    T* dens_cpu;
-    T* contracted_grad_cpu;
-    G2G::vec_type<T,4>* grad_cpu;
-    G2G::vec_type<T,4>* hess1_cpu;
-    G2G::vec_type<T,4>* hess2_cpu;
+  // Bajar la info a CPU y luego imprimirla.
+  // Copy to host the matrix data in gpu memory and
+  // call the new libxcProxy.
+  T* dens_cpu;
+  T* contracted_grad_cpu;
+  G2G::vec_type<T, 4>* grad_cpu;
+  G2G::vec_type<T, 4>* hess1_cpu;
+  G2G::vec_type<T, 4>* hess2_cpu;
 
-    // Alloc memory in the host for the gpu data
-    uint size = number_of_points * sizeof(G2G::vec_type<T,4>);
-    uint array_size = number_of_points * sizeof(T);
-    dens_cpu = (T*)malloc(size);
-    contracted_grad_cpu = (T*)malloc(size);
-    grad_cpu = (G2G::vec_type<T,4> *)malloc(size);
-    hess1_cpu = (G2G::vec_type<T,4> *)malloc(size);
-    hess2_cpu = (G2G::vec_type<T,4> *)malloc(size);
+  // Alloc memory in the host for the gpu data
+  uint size = number_of_points * sizeof(G2G::vec_type<T, 4>);
+  uint array_size = number_of_points * sizeof(T);
+  dens_cpu = (T*)malloc(size);
+  contracted_grad_cpu = (T*)malloc(size);
+  grad_cpu = (G2G::vec_type<T, 4>*)malloc(size);
+  hess1_cpu = (G2G::vec_type<T, 4>*)malloc(size);
+  hess2_cpu = (G2G::vec_type<T, 4>*)malloc(size);
 
-    // Copy data from device to host.
-    if (grad != NULL)
-        cudaMemcpy(grad_cpu, grad, size, cudaMemcpyDeviceToHost);
-    if (hess1 != NULL)
-	cudaMemcpy(hess1_cpu, hess1, size, cudaMemcpyDeviceToHost);
-    if (hess2 != NULL)
-        cudaMemcpy(hess2_cpu, hess2, size, cudaMemcpyDeviceToHost);
-    if (contracted_grad != NULL)
-	cudaMemcpy(contracted_grad_cpu, contracted_grad, array_size, cudaMemcpyDeviceToHost);
-    if (dens != NULL)
-	cudaMemcpy(dens_cpu, dens, array_size, cudaMemcpyDeviceToHost);
+  // Copy data from device to host.
+  if (grad != NULL) cudaMemcpy(grad_cpu, grad, size, cudaMemcpyDeviceToHost);
+  if (hess1 != NULL) cudaMemcpy(hess1_cpu, hess1, size, cudaMemcpyDeviceToHost);
+  if (hess2 != NULL) cudaMemcpy(hess2_cpu, hess2, size, cudaMemcpyDeviceToHost);
+  if (contracted_grad != NULL)
+    cudaMemcpy(contracted_grad_cpu, contracted_grad, array_size,
+               cudaMemcpyDeviceToHost);
+  if (dens != NULL)
+    cudaMemcpy(dens_cpu, dens, array_size, cudaMemcpyDeviceToHost);
 
-    printf("==============================\n");
-    printf("= Proxy input for libxc_cuda =\n");
-    printf("==============================\n");
-    printf("number_of_points:%i\n", number_of_points);
-    printf("grad:"); print_vec_type(grad_cpu, number_of_points);
-    printf("hess1:"); print_vec_type(hess1_cpu, number_of_points);
-    printf("hess2:"); print_vec_type(hess2_cpu, number_of_points);
-    printf("dens:"); print_array(dens_cpu, number_of_points);
-    printf("contracted_grad:"); print_array(contracted_grad_cpu, number_of_points);
-    printf("==============================\n");
+  printf("==============================\n");
+  printf("= Proxy input for libxc_cuda =\n");
+  printf("==============================\n");
+  printf("number_of_points:%i\n", number_of_points);
+  printf("grad:");
+  print_vec_type(grad_cpu, number_of_points);
+  printf("hess1:");
+  print_vec_type(hess1_cpu, number_of_points);
+  printf("hess2:");
+  print_vec_type(hess2_cpu, number_of_points);
+  printf("dens:");
+  print_array(dens_cpu, number_of_points);
+  printf("contracted_grad:");
+  print_array(contracted_grad_cpu, number_of_points);
+  printf("==============================\n");
 
-    // Free memory.
-    free(dens_cpu);
-    free(contracted_grad_cpu);
-    free(hess2_cpu);
-    free(hess1_cpu);
-    free(grad_cpu);
+  // Free memory.
+  free(dens_cpu);
+  free(contracted_grad_cpu);
+  free(hess2_cpu);
+  free(hess1_cpu);
+  free(grad_cpu);
 #endif
 }
 
-template <class T> 
-void print_libxc_exchange_correlation_gpu_input (
-    T* energy_gpu,
-    T* factor_gpu,
-    int points,
-    T* accumulated_density_gpu,
-    G2G::vec_type<T, 4>* dxyz_gpu,
-    G2G::vec_type<T, 4>* dd1_gpu,
-    G2G::vec_type<T, 4>* dd2_gpu)
-{
+template <class T>
+void print_libxc_exchange_correlation_gpu_input(T* energy_gpu, T* factor_gpu,
+                                                int points,
+                                                T* accumulated_density_gpu,
+                                                G2G::vec_type<T, 4>* dxyz_gpu,
+                                                G2G::vec_type<T, 4>* dd1_gpu,
+                                                G2G::vec_type<T, 4>* dd2_gpu) {
 #ifdef __CUDACC__
-    // Bajar la info a CPU y luego imprimirla.
-    // Copy to host the matrix data in gpu memory and
-    // call the new libxcProxy.
-    T* energy_cpu;
-    T* factor_cpu;
-    T* accumulated_density_cpu;
-    G2G::vec_type<T,4>* dxyz_cpu;
-    G2G::vec_type<T,4>* dd1_cpu;
-    G2G::vec_type<T,4>* dd2_cpu;
+  // Bajar la info a CPU y luego imprimirla.
+  // Copy to host the matrix data in gpu memory and
+  // call the new libxcProxy.
+  T* energy_cpu;
+  T* factor_cpu;
+  T* accumulated_density_cpu;
+  G2G::vec_type<T, 4>* dxyz_cpu;
+  G2G::vec_type<T, 4>* dd1_cpu;
+  G2G::vec_type<T, 4>* dd2_cpu;
 
-    // Alloc memory in the host for the gpu data
-    uint size = points * sizeof(G2G::vec_type<T,4>);
-    uint array_size = points * sizeof(T);
-    energy_cpu = (T*)malloc(size);
-    factor_cpu = (T*)malloc(size);
-    accumulated_density_cpu = (T*)malloc(size);
-    dxyz_cpu = (G2G::vec_type<T,4> *)malloc(size);
-    dd1_cpu = (G2G::vec_type<T,4> *)malloc(size);
-    dd2_cpu = (G2G::vec_type<T,4> *)malloc(size);
+  // Alloc memory in the host for the gpu data
+  uint size = points * sizeof(G2G::vec_type<T, 4>);
+  uint array_size = points * sizeof(T);
+  energy_cpu = (T*)malloc(size);
+  factor_cpu = (T*)malloc(size);
+  accumulated_density_cpu = (T*)malloc(size);
+  dxyz_cpu = (G2G::vec_type<T, 4>*)malloc(size);
+  dd1_cpu = (G2G::vec_type<T, 4>*)malloc(size);
+  dd2_cpu = (G2G::vec_type<T, 4>*)malloc(size);
 
-    // Copy data from device to host.
-    if (energy_gpu != NULL)
-        cudaMemcpy(energy_cpu, energy_gpu, size, cudaMemcpyDeviceToHost);
-    if (factor_gpu != NULL)
-        cudaMemcpy(factor_cpu, factor_gpu, size, cudaMemcpyDeviceToHost);
-    if (dxyz_gpu != NULL)
-	cudaMemcpy(dxyz_cpu, dxyz_gpu, size, cudaMemcpyDeviceToHost);
-    if (dd1_gpu != NULL)
-	cudaMemcpy(dd1_cpu, dd1_gpu, size, cudaMemcpyDeviceToHost);
-    if (dd2_gpu != NULL)
-        cudaMemcpy(dd2_cpu, dd2_gpu, size, cudaMemcpyDeviceToHost);
-    if (accumulated_density_gpu != NULL)
-	cudaMemcpy(accumulated_density_cpu, accumulated_density_gpu, array_size, cudaMemcpyDeviceToHost);
+  // Copy data from device to host.
+  if (energy_gpu != NULL)
+    cudaMemcpy(energy_cpu, energy_gpu, size, cudaMemcpyDeviceToHost);
+  if (factor_gpu != NULL)
+    cudaMemcpy(factor_cpu, factor_gpu, size, cudaMemcpyDeviceToHost);
+  if (dxyz_gpu != NULL)
+    cudaMemcpy(dxyz_cpu, dxyz_gpu, size, cudaMemcpyDeviceToHost);
+  if (dd1_gpu != NULL)
+    cudaMemcpy(dd1_cpu, dd1_gpu, size, cudaMemcpyDeviceToHost);
+  if (dd2_gpu != NULL)
+    cudaMemcpy(dd2_cpu, dd2_gpu, size, cudaMemcpyDeviceToHost);
+  if (accumulated_density_gpu != NULL)
+    cudaMemcpy(accumulated_density_cpu, accumulated_density_gpu, array_size,
+               cudaMemcpyDeviceToHost);
 
-    printf("=============================================\n");
-    printf("= input for libxc_exchange_correlation_gpu  =\n");
-    printf("=============================================\n");
-    printf("points:%i\n", points);
-    printf("dxyz:"); print_vec_type(dxyz_cpu, points);
-    printf("dd1:"); print_vec_type(dd1_cpu, points);
-    printf("dd2:"); print_vec_type(dd2_cpu, points);
-    printf("energy:"); print_array(energy_cpu, points);
-    printf("factor:"); print_array(factor_cpu, points);
-    printf("accumulated_density:"); print_array(accumulated_density_cpu, points);
-    printf("==============================\n");
+  printf("=============================================\n");
+  printf("= input for libxc_exchange_correlation_gpu  =\n");
+  printf("=============================================\n");
+  printf("points:%i\n", points);
+  printf("dxyz:");
+  print_vec_type(dxyz_cpu, points);
+  printf("dd1:");
+  print_vec_type(dd1_cpu, points);
+  printf("dd2:");
+  print_vec_type(dd2_cpu, points);
+  printf("energy:");
+  print_array(energy_cpu, points);
+  printf("factor:");
+  print_array(factor_cpu, points);
+  printf("accumulated_density:");
+  print_array(accumulated_density_cpu, points);
+  printf("==============================\n");
 
-    // Free memory.
-    free(energy_cpu);
-    free(factor_cpu);
-    free(accumulated_density_cpu);
-    free(dd2_cpu);
-    free(dd1_cpu);
-    free(dxyz_cpu);
+  // Free memory.
+  free(energy_cpu);
+  free(factor_cpu);
+  free(accumulated_density_cpu);
+  free(dd2_cpu);
+  free(dd1_cpu);
+  free(dxyz_cpu);
 #endif
 }
 

--- a/g2g/matrix.cpp
+++ b/g2g/matrix.cpp
@@ -14,107 +14,126 @@ namespace G2G {
  * Matrix
  ***************************/
 
-template<class T> Matrix<T>::Matrix(void) : data(NULL), width(0), height(0) /*, components(0)*/ {}
+template <class T>
+Matrix<T>::Matrix(void) : data(NULL), width(0), height(0) /*, components(0)*/ {}
 
-template<class T> Matrix<T>::~Matrix(void) { }
+template <class T>
+Matrix<T>::~Matrix(void) {}
 
-template<class T> unsigned int Matrix<T>::bytes(void) const {
-	return elements() * sizeof(T);
+template <class T>
+unsigned int Matrix<T>::bytes(void) const {
+  return elements() * sizeof(T);
 }
 
-template<class T> unsigned int Matrix<T>::elements(void) const {
-	return width * height /* * components */;
+template <class T>
+unsigned int Matrix<T>::elements(void) const {
+  return width * height /* * components */;
 }
 
-template<class T> bool Matrix<T>::is_allocated(void) const {
-	return data;
+template <class T>
+bool Matrix<T>::is_allocated(void) const {
+  return data;
 }
 
 /***************************
  * HostMatrix
  ***************************/
-template<class T> void HostMatrix<T>::alloc_data(void) {
+template <class T>
+void HostMatrix<T>::alloc_data(void) {
   assert(this->bytes() != 0);
   int bytes = this->bytes();
   int posix_return = 0;
 
   if (pinned) {
 #if GPU_KERNELS
-    cudaError_t error_status = cudaMallocHost((void**)&this->data, this->bytes());
+    cudaError_t error_status =
+        cudaMallocHost((void**)&this->data, this->bytes());
     assert(error_status == cudaSuccess);
 #else
     assert(false);
 #endif
-  }
-  else
-  {
-    posix_return = posix_memalign((void **) &this->data, 64, this->bytes());
-    if ( posix_return != 0) 
-    { 
-       std::cout <<"HostMatrix: Error in posix_memalign.\n"; 
-       exit(1);
+  } else {
+    posix_return = posix_memalign((void**)&this->data, 64, this->bytes());
+    if (posix_return != 0) {
+      std::cout << "HostMatrix: Error in posix_memalign.\n";
+      exit(1);
     };
   };
 
   assert(this->data);
 }
 
-template<class T> void HostMatrix<T>::dealloc_data(void) {
-	if (pinned) {
-    #if GPU_KERNELS
+template <class T>
+void HostMatrix<T>::dealloc_data(void) {
+  if (pinned) {
+#if GPU_KERNELS
     cudaFreeHost(this->data);
-    #else
+#else
     assert(false);
-    #endif
-  }
-	else free(this->data); //mkl_free(this->data);
+#endif
+  } else
+    free(this->data);  // mkl_free(this->data);
 }
 
-template<class T> void HostMatrix<T>::copy_to_tmp(T * dst) const {
-    memcpy(dst, this->data, this->bytes());
+template <class T>
+void HostMatrix<T>::copy_to_tmp(T* dst) const {
+  memcpy(dst, this->data, this->bytes());
 }
 
-template<class T> void HostMatrix<T>::deallocate(void) {
-	dealloc_data();
-	this->data = NULL;
+template <class T>
+void HostMatrix<T>::deallocate(void) {
+  dealloc_data();
+  this->data = NULL;
   this->width = this->height = 0;
 }
 
-template<class T> HostMatrix<T>::HostMatrix(PinnedFlag _pinned) : Matrix<T>() {
+template <class T>
+HostMatrix<T>::HostMatrix(PinnedFlag _pinned) : Matrix<T>() {
   pinned = (_pinned == Pinned);
 }
 
-template<class T> HostMatrix<T>::HostMatrix(unsigned int _width, unsigned _height, PinnedFlag _pinned) : Matrix<T>() {
+template <class T>
+HostMatrix<T>::HostMatrix(unsigned int _width, unsigned _height,
+                          PinnedFlag _pinned)
+    : Matrix<T>() {
   pinned = (_pinned == Pinned);
   resize(_width, _height);
 }
 
-template<class T> HostMatrix<T>::HostMatrix(const CudaMatrix<T>& c) : Matrix<T>(), pinned(false) {
-	*this = c;
+template <class T>
+HostMatrix<T>::HostMatrix(const CudaMatrix<T>& c) : Matrix<T>(), pinned(false) {
+  *this = c;
 }
 
-template<class T> HostMatrix<T>::HostMatrix(const HostMatrix<T>& m) : Matrix<T>(), pinned(false) {
-	*this = m;
+template <class T>
+HostMatrix<T>::HostMatrix(const HostMatrix<T>& m) : Matrix<T>(), pinned(false) {
+  *this = m;
 }
 
-template<class T> HostMatrix<T>::~HostMatrix(void) {
-	deallocate();
+template <class T>
+HostMatrix<T>::~HostMatrix(void) {
+  deallocate();
 }
 
-template<class T> HostMatrix<T>& HostMatrix<T>::resize(unsigned int _width, unsigned _height) {
-  if (_width == 0 ) throw std::runtime_error("El ancho no puede ser 0");
-  if (_height == 0 ) throw std::runtime_error("La altura no puede ser 0");
+template <class T>
+HostMatrix<T>& HostMatrix<T>::resize(unsigned int _width, unsigned _height) {
+  if (_width == 0) throw std::runtime_error("El ancho no puede ser 0");
+  if (_height == 0) throw std::runtime_error("La altura no puede ser 0");
   if (_width != this->width || _height != this->height) {
     if (this->data) dealloc_data();
-    this->width = _width; this->height = _height;
+    this->width = _width;
+    this->height = _height;
     alloc_data();
   }
 
-	return *this;
+  return *this;
 }
 
-template<class T> HostMatrix<T>& HostMatrix<T>::shrink(unsigned int _width, unsigned int _height) {
-  if (_width == 0 || _height == 0) throw std::runtime_error("La dimension no puede ser 0");
+template <class T>
+HostMatrix<T>& HostMatrix<T>::shrink(unsigned int _width,
+                                     unsigned int _height) {
+  if (_width == 0 || _height == 0)
+    throw std::runtime_error("La dimension no puede ser 0");
   if (_width != this->width || _height != this->height) {
     HostMatrix<T> temp_matrix(_width, _height);
     temp_matrix.copy_submatrix(temp_matrix, _width * _height);
@@ -122,97 +141,120 @@ template<class T> HostMatrix<T>& HostMatrix<T>::shrink(unsigned int _width, unsi
     *this = temp_matrix;
   }
 
-	return *this;
-}
-
-template<class T> HostMatrix<T>& HostMatrix<T>::zero(void) {
-  memset(this->data, 0, this->bytes());
-	return *this;
-}
-
-template<class T> HostMatrix<T>& HostMatrix<T>::fill(T value) {
-  for (uint i = 0; i < this->elements(); i++) { this->data[i] = value; }
   return *this;
 }
 
-template<class T> HostMatrix<T>& HostMatrix<T>::operator=(const HostMatrix<T>& c) {
-	assert(!this->pinned);
-
-	if (!c.data) {
-		if (this->data) { dealloc_data(); this->width = this->height = 0; this->data = NULL; }
-	}
-	else {
-		if (this->data) {
-			if (this->bytes() != c.bytes()) {
-				dealloc_data();
-				this->width = c.width; this->height = c.height;
-				alloc_data();
-			}
-		}
-		else {
-			this->width = c.width; this->height = c.height;
-			alloc_data();
-		}
-
-		copy_submatrix(c);
-	}
-
-	return *this;
+template <class T>
+HostMatrix<T>& HostMatrix<T>::zero(void) {
+  memset(this->data, 0, this->bytes());
+  return *this;
 }
 
-template <class T> HostMatrix<T>& HostMatrix<T>::operator=(const CudaMatrix<T>& c) {
-	if (!c.data) {
-		if (this->data) { dealloc_data(); this->width = this->height = 0; this->data = NULL; }
-	}
-	else {
-		if (this->data) {
-			if (this->bytes() != c.bytes()) {
-				dealloc_data();
-				this->width = c.width; this->height = c.height;
-				alloc_data();
-			}
-		}
-		else {
-			this->width = c.width; this->height = c.height;
-			alloc_data();
-		}
-
-		copy_submatrix(c);
-	}
-
-	return *this;
+template <class T>
+HostMatrix<T>& HostMatrix<T>::fill(T value) {
+  for (uint i = 0; i < this->elements(); i++) {
+    this->data[i] = value;
+  }
+  return *this;
 }
 
-template<class T> void HostMatrix<T>::copy_submatrix(const HostMatrix<T>& c, unsigned int _elements) {
-	unsigned int _bytes = (_elements == 0 ? this->bytes() : _elements * sizeof(T));
-	//cout << "bytes: " << _bytes << ", c.bytes: " << c.bytes() << endl;
-	if (_bytes > c.bytes())
+template <class T>
+HostMatrix<T>& HostMatrix<T>::operator=(const HostMatrix<T>& c) {
+  assert(!this->pinned);
+
+  if (!c.data) {
+    if (this->data) {
+      dealloc_data();
+      this->width = this->height = 0;
+      this->data = NULL;
+    }
+  } else {
+    if (this->data) {
+      if (this->bytes() != c.bytes()) {
+        dealloc_data();
+        this->width = c.width;
+        this->height = c.height;
+        alloc_data();
+      }
+    } else {
+      this->width = c.width;
+      this->height = c.height;
+      alloc_data();
+    }
+
+    copy_submatrix(c);
+  }
+
+  return *this;
+}
+
+template <class T>
+HostMatrix<T>& HostMatrix<T>::operator=(const CudaMatrix<T>& c) {
+  if (!c.data) {
+    if (this->data) {
+      dealloc_data();
+      this->width = this->height = 0;
+      this->data = NULL;
+    }
+  } else {
+    if (this->data) {
+      if (this->bytes() != c.bytes()) {
+        dealloc_data();
+        this->width = c.width;
+        this->height = c.height;
+        alloc_data();
+      }
+    } else {
+      this->width = c.width;
+      this->height = c.height;
+      alloc_data();
+    }
+
+    copy_submatrix(c);
+  }
+
+  return *this;
+}
+
+template <class T>
+void HostMatrix<T>::copy_submatrix(const HostMatrix<T>& c,
+                                   unsigned int _elements) {
+  unsigned int _bytes =
+      (_elements == 0 ? this->bytes() : _elements * sizeof(T));
+  // cout << "bytes: " << _bytes << ", c.bytes: " << c.bytes() << endl;
+  if (_bytes > c.bytes())
     throw runtime_error("Can't copy more elements than what operator has");
-	memcpy(this->data, c.data, _bytes);
+  memcpy(this->data, c.data, _bytes);
 }
 
-template<class T> void HostMatrix<T>::copy_submatrix(const CudaMatrix<T>& c, unsigned int _elements) {
-	unsigned int _bytes = (_elements == 0 ? this->bytes() : _elements * sizeof(T));
-	//cout << "bytes: " << _bytes << ", c.bytes: " << c.bytes() << endl;
-	if (_bytes > c.bytes())
+template <class T>
+void HostMatrix<T>::copy_submatrix(const CudaMatrix<T>& c,
+                                   unsigned int _elements) {
+  unsigned int _bytes =
+      (_elements == 0 ? this->bytes() : _elements * sizeof(T));
+  // cout << "bytes: " << _bytes << ", c.bytes: " << c.bytes() << endl;
+  if (_bytes > c.bytes())
     throw runtime_error("Can't copy more elements than what operator has");
 
-  #if GPU_KERNELS
-	cudaMemcpy(this->data, c.data, _bytes, cudaMemcpyDeviceToHost);
+#if GPU_KERNELS
+  cudaMemcpy(this->data, c.data, _bytes, cudaMemcpyDeviceToHost);
   cudaAssertNoError("HostMatrix::copy_submatrix");
-  #else
+#else
   assert(false);
-  #endif
+#endif
 }
 
-template<class T> void HostMatrix<T>::to_constant(const char* symbol) {
-  #if GPU_KERNELS
-	cudaMemcpyToSymbol(symbol, this->data, this->bytes(), 0, cudaMemcpyHostToDevice);
+template <class T>
+void HostMatrix<T>::to_constant(const char* symbol) {
+#if GPU_KERNELS
+  cudaMemcpyToSymbol(symbol, this->data, this->bytes(), 0,
+                     cudaMemcpyHostToDevice);
   cudaAssertNoError("to_constant");
-  #endif
+#endif
 }
 
-template<class T> void HostMatrix<T>::transpose(HostMatrix<T>& out) const {
+template <class T>
+void HostMatrix<T>::transpose(HostMatrix<T>& out) const {
   out.resize(this->height, this->width);
   out.zero();
   for (uint i = 0; i < this->width; i++) {
@@ -221,8 +263,10 @@ template<class T> void HostMatrix<T>::transpose(HostMatrix<T>& out) const {
     }
   }
 }
-template<class T> void HostMatrix<T>::copy_transpose(const CudaMatrix<T>& cuda_matrix) {
-  if (cuda_matrix.width != this->height || cuda_matrix.height != this->width) throw runtime_error("Matrix dimensions for copy_transpose don't agree");
+template <class T>
+void HostMatrix<T>::copy_transpose(const CudaMatrix<T>& cuda_matrix) {
+  if (cuda_matrix.width != this->height || cuda_matrix.height != this->width)
+    throw runtime_error("Matrix dimensions for copy_transpose don't agree");
   HostMatrix<T> cuda_matrix_copy(cuda_matrix);
   for (uint i = 0; i < cuda_matrix.width; i++) {
     for (uint j = 0; j < cuda_matrix.height; j++) {
@@ -231,11 +275,12 @@ template<class T> void HostMatrix<T>::copy_transpose(const CudaMatrix<T>& cuda_m
   }
 }
 
-template<class T> void to_constant(const char* constant, const T& value) {
-  #if GPU_KERNELS
-	cudaMemcpyToSymbol(constant, &value, sizeof(T), 0, cudaMemcpyHostToDevice);
+template <class T>
+void to_constant(const char* constant, const T& value) {
+#if GPU_KERNELS
+  cudaMemcpyToSymbol(constant, &value, sizeof(T), 0, cudaMemcpyHostToDevice);
   cudaAssertNoError("to_constant(value)");
-  #endif
+#endif
 }
 
 template void to_constant<uint>(const char* constant, const uint& value);
@@ -246,176 +291,220 @@ template void to_constant<double>(const char* constant, const double& value);
  * CudaMatrix
  ******************************/
 
-template<class T> CudaMatrix<T>::CudaMatrix(void) : Matrix<T>() { }
+template <class T>
+CudaMatrix<T>::CudaMatrix(void) : Matrix<T>() {}
 
-template<class T> CudaMatrix<T>::CudaMatrix(unsigned int _width, unsigned int _height) : Matrix<T>() {
-	resize(_width, _height);
+template <class T>
+CudaMatrix<T>::CudaMatrix(unsigned int _width, unsigned int _height)
+    : Matrix<T>() {
+  resize(_width, _height);
 }
 
-template<class T> CudaMatrix<T>& CudaMatrix<T>::resize(unsigned int _width, unsigned int _height) {
+template <class T>
+CudaMatrix<T>& CudaMatrix<T>::resize(unsigned int _width,
+                                     unsigned int _height) {
   assert(_width * _height != 0);
 
-  #if GPU_KERNELS
+#if GPU_KERNELS
   if (_width != this->width || _height != this->height) {
     if (this->data) cudaFree(this->data);
-    this->width = _width; this->height = _height;
+    this->width = _width;
+    this->height = _height;
     cudaMalloc((void**)&this->data, this->bytes());
     cudaAssertNoError("CudaMatrix::resize");
   }
-  #endif
-	return *this;
+#endif
+  return *this;
 }
 
-template<class T> CudaMatrix<T>& CudaMatrix<T>::zero(void) {
-  #if GPU_KERNELS
-	assert(this->data);
-	cudaMemset(this->data, 0, this->bytes());
+template <class T>
+CudaMatrix<T>& CudaMatrix<T>::zero(void) {
+#if GPU_KERNELS
+  assert(this->data);
+  cudaMemset(this->data, 0, this->bytes());
   cudaAssertNoError("CudaMatrix::zero");
-  #endif
-	return *this;
+#endif
+  return *this;
 }
 
-template<class T> CudaMatrix<T>::CudaMatrix(const CudaMatrix<T>& c) : Matrix<T>() {
-	*this = c;
+template <class T>
+CudaMatrix<T>::CudaMatrix(const CudaMatrix<T>& c) : Matrix<T>() {
+  *this = c;
 }
 
-template<class T> CudaMatrix<T>::CudaMatrix(const HostMatrix<T>& c) : Matrix<T>() {
-	*this = c;
+template <class T>
+CudaMatrix<T>::CudaMatrix(const HostMatrix<T>& c) : Matrix<T>() {
+  *this = c;
 }
 
-template<class T> CudaMatrix<T>::CudaMatrix(const std::vector<T>& v) : Matrix<T>() {
-	*this = v;
+template <class T>
+CudaMatrix<T>::CudaMatrix(const std::vector<T>& v) : Matrix<T>() {
+  *this = v;
 }
 
-template<class T> CudaMatrix<T>::~CudaMatrix(void) {
+template <class T>
+CudaMatrix<T>::~CudaMatrix(void) {
   deallocate();
 }
 
-template<class T> void CudaMatrix<T>::deallocate(void) {
-  #if GPU_KERNELS
-	if (this->data) cudaFree(this->data);
-	this->data = NULL;
+template <class T>
+void CudaMatrix<T>::deallocate(void) {
+#if GPU_KERNELS
+  if (this->data) cudaFree(this->data);
+  this->data = NULL;
   this->width = this->height = 0;
-  #endif
+#endif
 }
 
-template<class T> void CudaMatrix<T>::copy_submatrix(const HostMatrix<T>& c, unsigned int _elements) {
-	unsigned int _bytes = (_elements == 0 ? this->bytes() : _elements * sizeof(T));
-	//cout << "bytes: " << _bytes << ", c.bytes: " << c.bytes() << endl;
-	if (_bytes > c.bytes()) throw runtime_error("CudaMatrix: Can't copy more elements than what operand has");
+template <class T>
+void CudaMatrix<T>::copy_submatrix(const HostMatrix<T>& c,
+                                   unsigned int _elements) {
+  unsigned int _bytes =
+      (_elements == 0 ? this->bytes() : _elements * sizeof(T));
+  // cout << "bytes: " << _bytes << ", c.bytes: " << c.bytes() << endl;
+  if (_bytes > c.bytes())
+    throw runtime_error(
+        "CudaMatrix: Can't copy more elements than what operand has");
 
-  #if GPU_KERNELS
-	cudaMemcpy(this->data, c.data, _bytes, cudaMemcpyHostToDevice);
+#if GPU_KERNELS
+  cudaMemcpy(this->data, c.data, _bytes, cudaMemcpyHostToDevice);
   cudaAssertNoError("CudaMatrix::copy_submatrix");
-  #endif
+#endif
 }
 
-template<class T> void CudaMatrix<T>::copy_submatrix(const CudaMatrix<T>& c, unsigned int _elements) {
-	unsigned int _bytes = (_elements == 0 ? this->bytes() : _elements * sizeof(T));
-	if (_bytes > c.bytes()) throw runtime_error("CudaMatrix: Can't copy more elements than what operand has");
+template <class T>
+void CudaMatrix<T>::copy_submatrix(const CudaMatrix<T>& c,
+                                   unsigned int _elements) {
+  unsigned int _bytes =
+      (_elements == 0 ? this->bytes() : _elements * sizeof(T));
+  if (_bytes > c.bytes())
+    throw runtime_error(
+        "CudaMatrix: Can't copy more elements than what operand has");
 
-  #if GPU_KERNELS
-	cudaMemcpy(c.data, this->data, _bytes, cudaMemcpyDeviceToDevice);
+#if GPU_KERNELS
+  cudaMemcpy(c.data, this->data, _bytes, cudaMemcpyDeviceToDevice);
   cudaAssertNoError("CudaMatrix::copy_submatrix");
-  #endif
+#endif
 }
 
-template<class T> void CudaMatrix<T>::copy_submatrix(const std::vector<T>& v, unsigned int _elements) {
-	unsigned int _bytes = (_elements == 0 ? this->bytes() : _elements * sizeof(T));
-	if (_bytes > v.size() * sizeof(T)) throw runtime_error("CudaMatrix: Can't copy more elements than what operand has");
+template <class T>
+void CudaMatrix<T>::copy_submatrix(const std::vector<T>& v,
+                                   unsigned int _elements) {
+  unsigned int _bytes =
+      (_elements == 0 ? this->bytes() : _elements * sizeof(T));
+  if (_bytes > v.size() * sizeof(T))
+    throw runtime_error(
+        "CudaMatrix: Can't copy more elements than what operand has");
 
-  #if GPU_KERNELS
-	cudaMemcpy(this->data, (T*)&v[0], _bytes, cudaMemcpyHostToDevice);
+#if GPU_KERNELS
+  cudaMemcpy(this->data, (T*)&v[0], _bytes, cudaMemcpyHostToDevice);
   cudaAssertNoError("CudaMatrix::copy_submatrix");
-  #endif
+#endif
 }
 
-template<class T> CudaMatrix<T>& CudaMatrix<T>::operator=(const HostMatrix<T>& c) {
-  #if GPU_KERNELS
-	if (!c.data) {
-		if (this->data) { cudaFree(this->data); this->width = this->height = 0; this->data = NULL; }
-	}
-	else {
-		if (this->data) {
-			if (this->bytes() != c.bytes()) {
-				cudaFree(this->data);
-				this->width = c.width; this->height = c.height;
-				cudaMalloc((void**)&this->data, this->bytes());
-			}
-		}
-		else {
-			this->width = c.width; this->height = c.height;
-			cudaMalloc((void**)&this->data, this->bytes());
-		}
-		cudaAssertNoError("CudaMatrix::operator=");
-		copy_submatrix(c);
-	}
-  #endif
-	return *this;
-}
-
-template<class T> CudaMatrix<T>& CudaMatrix<T>::operator=(const std::vector<T>& v) {
-  #if GPU_KERNELS
-	if (v.empty()) {
-		if (this->data) { cudaFree(this->data); this->width = this->height = 0; this->data = NULL; }
-	}
-	else {
-		if (this->data) {
-			if (this->elements() != v.size()) {
-				cudaFree(this->data);
-				this->width = v.size(); this->height = 1;
-				cudaMalloc((void**)&this->data, this->bytes());
-			}
-		}
-		else {
-			this->width = v.size(); this->height = 1;
-			cudaMalloc((void**)&this->data, this->bytes());
-		}
-    cudaAssertNoError("CudaMatrix::operator=");
-		copy_submatrix(v);
-	}
-  #endif
-	return *this;
-}
-
-template<class T> CudaMatrix<T>& CudaMatrix<T>::operator=(const CudaMatrix<T>& c) {
-  #if GPU_KERNELS
-	// copies data from c, only if necessary (always frees this's data, if any)
-	if (!c.data) {
-		if (this->data) { cudaFree(this->data); this->width = this->height = 0; this->data = NULL; }
-	}
-	else {
-		if (this->data) {
-			if (this->bytes() != c.bytes()) {
-				cudaFree(this->data);
-				this->width = c.width; this->height = c.height;
-				cudaMalloc((void**)&this->data, this->bytes());
-			}
-		}
-		else {
-			this->width = c.width; this->height = c.height;
-			cudaMalloc((void**)&this->data, this->bytes());
+template <class T>
+CudaMatrix<T>& CudaMatrix<T>::operator=(const HostMatrix<T>& c) {
+#if GPU_KERNELS
+  if (!c.data) {
+    if (this->data) {
+      cudaFree(this->data);
+      this->width = this->height = 0;
+      this->data = NULL;
     }
-		cudaMemcpy(this->data, c.data, this->bytes(), cudaMemcpyDeviceToDevice);
-	}
+  } else {
+    if (this->data) {
+      if (this->bytes() != c.bytes()) {
+        cudaFree(this->data);
+        this->width = c.width;
+        this->height = c.height;
+        cudaMalloc((void**)&this->data, this->bytes());
+      }
+    } else {
+      this->width = c.width;
+      this->height = c.height;
+      cudaMalloc((void**)&this->data, this->bytes());
+    }
+    cudaAssertNoError("CudaMatrix::operator=");
+    copy_submatrix(c);
+  }
+#endif
+  return *this;
+}
+
+template <class T>
+CudaMatrix<T>& CudaMatrix<T>::operator=(const std::vector<T>& v) {
+#if GPU_KERNELS
+  if (v.empty()) {
+    if (this->data) {
+      cudaFree(this->data);
+      this->width = this->height = 0;
+      this->data = NULL;
+    }
+  } else {
+    if (this->data) {
+      if (this->elements() != v.size()) {
+        cudaFree(this->data);
+        this->width = v.size();
+        this->height = 1;
+        cudaMalloc((void**)&this->data, this->bytes());
+      }
+    } else {
+      this->width = v.size();
+      this->height = 1;
+      cudaMalloc((void**)&this->data, this->bytes());
+    }
+    cudaAssertNoError("CudaMatrix::operator=");
+    copy_submatrix(v);
+  }
+#endif
+  return *this;
+}
+
+template <class T>
+CudaMatrix<T>& CudaMatrix<T>::operator=(const CudaMatrix<T>& c) {
+#if GPU_KERNELS
+  // copies data from c, only if necessary (always frees this's data, if any)
+  if (!c.data) {
+    if (this->data) {
+      cudaFree(this->data);
+      this->width = this->height = 0;
+      this->data = NULL;
+    }
+  } else {
+    if (this->data) {
+      if (this->bytes() != c.bytes()) {
+        cudaFree(this->data);
+        this->width = c.width;
+        this->height = c.height;
+        cudaMalloc((void**)&this->data, this->bytes());
+      }
+    } else {
+      this->width = c.width;
+      this->height = c.height;
+      cudaMalloc((void**)&this->data, this->bytes());
+    }
+    cudaMemcpy(this->data, c.data, this->bytes(), cudaMemcpyDeviceToDevice);
+  }
   cudaAssertNoError("CudaMatrix::operator=");
-	#endif
-	return *this;
+#endif
+  return *this;
 }
 
 /*************************************
  * FortranMatrix
  *************************************/
-template<class T> FortranMatrix<T>::FortranMatrix(void)
-	: Matrix<T>(), fortran_width(0)
-{ }
+template <class T>
+FortranMatrix<T>::FortranMatrix(void) : Matrix<T>(), fortran_width(0) {}
 
-template<class T> FortranMatrix<T>::FortranMatrix(T* _data, unsigned int _width, unsigned int _height, unsigned int _fortran_width)
-	: Matrix<T>(), fortran_width(_fortran_width)
-{
-	this->data = _data;
-	this->width = _width; this->height = _height;
-	assert(this->data);
+template <class T>
+FortranMatrix<T>::FortranMatrix(T* _data, unsigned int _width,
+                                unsigned int _height,
+                                unsigned int _fortran_width)
+    : Matrix<T>(), fortran_width(_fortran_width) {
+  this->data = _data;
+  this->width = _width;
+  this->height = _height;
+  assert(this->data);
 }
 
 /**
@@ -427,23 +516,23 @@ template class Matrix<float>;
 template class Matrix<float3>;
 template class Matrix<uint>;
 
-template class Matrix< vec_type<float, 2> >;
-template class Matrix< vec_type<float, 3> >;
-template class Matrix< vec_type<double, 2> >;
-template class Matrix< vec_type<double, 3> >;
+template class Matrix<vec_type<float, 2> >;
+template class Matrix<vec_type<float, 3> >;
+template class Matrix<vec_type<double, 2> >;
+template class Matrix<vec_type<double, 3> >;
 
-template class HostMatrix< vec_type<float, 2> >;
-template class HostMatrix< vec_type<float, 3> >;
-template class HostMatrix< vec_type<float, 4> >;
-template class HostMatrix< vec_type<double, 2> >;
-template class HostMatrix< vec_type<double, 3> >;
-template class HostMatrix< vec_type<double, 4> >;
-template class CudaMatrix< vec_type<float, 2> >;
-template class CudaMatrix< vec_type<float, 3> >;
-template class CudaMatrix< vec_type<float, 4> >;
-template class CudaMatrix< vec_type<double, 2> >;
-template class CudaMatrix< vec_type<double, 3> >;
-template class CudaMatrix< vec_type<double, 4> >;
+template class HostMatrix<vec_type<float, 2> >;
+template class HostMatrix<vec_type<float, 3> >;
+template class HostMatrix<vec_type<float, 4> >;
+template class HostMatrix<vec_type<double, 2> >;
+template class HostMatrix<vec_type<double, 3> >;
+template class HostMatrix<vec_type<double, 4> >;
+template class CudaMatrix<vec_type<float, 2> >;
+template class CudaMatrix<vec_type<float, 3> >;
+template class CudaMatrix<vec_type<float, 4> >;
+template class CudaMatrix<vec_type<double, 2> >;
+template class CudaMatrix<vec_type<double, 3> >;
+template class CudaMatrix<vec_type<double, 4> >;
 
 template class HostMatrix<double>;
 template class HostMatrix<float>;
@@ -459,4 +548,4 @@ template class CudaMatrix<double>;
 template class FortranMatrix<double>;
 template class FortranMatrix<unsigned int>;
 
-}
+}  // namespace G2G

--- a/g2g/matrix.h
+++ b/g2g/matrix.h
@@ -11,153 +11,159 @@
 #include "scalar_vector_types.h"
 
 namespace G2G {
-  enum UpperLowerTriangle { UpperTriangle, LowerTriangle };
+enum UpperLowerTriangle { UpperTriangle, LowerTriangle };
 
-  template<class T> class Matrix {
-    public:
-      Matrix(void);
-      virtual ~Matrix(void);
+template <class T>
+class Matrix {
+ public:
+  Matrix(void);
+  virtual ~Matrix(void);
 
-      T* data;
-      unsigned int width;
-      unsigned int height;
+  T* data;
+  unsigned int width;
+  unsigned int height;
 
-      unsigned int bytes(void) const;
-      unsigned int elements(void) const;
+  unsigned int bytes(void) const;
+  unsigned int elements(void) const;
 
-      bool is_allocated(void) const;
+  bool is_allocated(void) const;
 
-      virtual void deallocate(void) = 0;
-  };
+  virtual void deallocate(void) = 0;
+};
 
-  template<class T> class CudaMatrix;
+template <class T>
+class CudaMatrix;
 
-  template<class T> class HostMatrix : public Matrix<T> {
-    public:
-      enum PinnedFlag { Pinned, NonPinned };
+template <class T>
+class HostMatrix : public Matrix<T> {
+ public:
+  enum PinnedFlag { Pinned, NonPinned };
 
-      HostMatrix(PinnedFlag pinned = NonPinned);
-      HostMatrix(unsigned int width, unsigned int height = 1, PinnedFlag pinned = NonPinned);
-      HostMatrix(const CudaMatrix<T>& c);
-      HostMatrix(const HostMatrix<T>& c);
-      ~HostMatrix(void);
+  HostMatrix(PinnedFlag pinned = NonPinned);
+  HostMatrix(unsigned int width, unsigned int height = 1,
+             PinnedFlag pinned = NonPinned);
+  HostMatrix(const CudaMatrix<T>& c);
+  HostMatrix(const HostMatrix<T>& c);
+  ~HostMatrix(void);
 
-      HostMatrix<T>& operator=(const CudaMatrix<T>& c);
-      HostMatrix<T>& operator=(const HostMatrix<T>& c);
+  HostMatrix<T>& operator=(const CudaMatrix<T>& c);
+  HostMatrix<T>& operator=(const HostMatrix<T>& c);
 
-      inline const T& operator()(unsigned int i = 0, unsigned int j = 0) const {
-        assert(i < this->width);
-        assert(j < this->height);
-        return this->data[j * this->width + i];
-      }
+  inline const T& operator()(unsigned int i = 0, unsigned int j = 0) const {
+    assert(i < this->width);
+    assert(j < this->height);
+    return this->data[j * this->width + i];
+  }
 
-      inline T& operator()(unsigned int i = 0, unsigned int j = 0) {
-        assert(i < this->width);
-        assert(j < this->height);
-        return this->data[j * this->width + i];
-      }
+  inline T& operator()(unsigned int i = 0, unsigned int j = 0) {
+    assert(i < this->width);
+    assert(j < this->height);
+    return this->data[j * this->width + i];
+  }
 
-      inline const T * row(unsigned int i = 0) const {
-        return &this->data[i * this->width];
-      }
+  inline const T* row(unsigned int i = 0) const {
+    return &this->data[i * this->width];
+  }
 
-      inline const T * asArray() const {
-        return this->data;
-      }
+  inline const T* asArray() const { return this->data; }
 
-      inline T* ptr(unsigned int i = 0, unsigned int j = 0) {
-        assert(i < this->width);
-        assert(j < this->height);
-        return &this->data[j * this->width + i];
-      }
+  inline T* ptr(unsigned int i = 0, unsigned int j = 0) {
+    assert(i < this->width);
+    assert(j < this->height);
+    return &this->data[j * this->width + i];
+  }
 
-      void copy_to_tmp(T *) const;
-      void copy_submatrix(const CudaMatrix<T>& c, unsigned int elements = 0);
-      void copy_submatrix(const HostMatrix<T>& c, unsigned int elements = 0);
+  void copy_to_tmp(T*) const;
+  void copy_submatrix(const CudaMatrix<T>& c, unsigned int elements = 0);
+  void copy_submatrix(const HostMatrix<T>& c, unsigned int elements = 0);
 
-      void copy_transpose(const CudaMatrix<T>& cuda_matrix);
-      void transpose(HostMatrix<T>& out) const;
+  void copy_transpose(const CudaMatrix<T>& cuda_matrix);
+  void transpose(HostMatrix<T>& out) const;
 
-      HostMatrix<T>& resize(unsigned int width, unsigned int height = 1);
-      HostMatrix<T>& shrink(unsigned int width, unsigned int height = 1);
-      HostMatrix<T>& zero(void);
-      HostMatrix<T>& fill(T value);
+  HostMatrix<T>& resize(unsigned int width, unsigned int height = 1);
+  HostMatrix<T>& shrink(unsigned int width, unsigned int height = 1);
+  HostMatrix<T>& zero(void);
+  HostMatrix<T>& fill(T value);
 
-      void deallocate(void);
+  void deallocate(void);
 
-      void to_constant(const char* constant);
+  void to_constant(const char* constant);
 
-    private:
-      bool pinned;
-      void alloc_data(void);
-      void dealloc_data(void);
-  };
+ private:
+  bool pinned;
+  void alloc_data(void);
+  void dealloc_data(void);
+};
 
-  template<class T> void to_constant(const char* constant, const T& value);
+template <class T>
+void to_constant(const char* constant, const T& value);
 
-  template <class T> class CudaMatrix : public Matrix<T> {
-    public:
-      CudaMatrix(void);
-      CudaMatrix(const CudaMatrix<T>& c);
-      CudaMatrix(const HostMatrix<T>& c);
-      CudaMatrix(const std::vector<T>& v);
+template <class T>
+class CudaMatrix : public Matrix<T> {
+ public:
+  CudaMatrix(void);
+  CudaMatrix(const CudaMatrix<T>& c);
+  CudaMatrix(const HostMatrix<T>& c);
+  CudaMatrix(const std::vector<T>& v);
 
-      CudaMatrix(unsigned int width, unsigned int height = 1);
-      ~CudaMatrix(void);
+  CudaMatrix(unsigned int width, unsigned int height = 1);
+  ~CudaMatrix(void);
 
-      CudaMatrix<T>& resize(unsigned int width, unsigned int height = 1);
-      CudaMatrix<T>& zero(void);
+  CudaMatrix<T>& resize(unsigned int width, unsigned int height = 1);
+  CudaMatrix<T>& zero(void);
 
-      CudaMatrix& operator=(const HostMatrix<T>& c);
-      CudaMatrix& operator=(const CudaMatrix<T>& c);
-      CudaMatrix& operator=(const std::vector<T>& v);
+  CudaMatrix& operator=(const HostMatrix<T>& c);
+  CudaMatrix& operator=(const CudaMatrix<T>& c);
+  CudaMatrix& operator=(const std::vector<T>& v);
 
-      void copy_submatrix(const HostMatrix<T>& c, unsigned int elements = 0);
-      void copy_submatrix(const CudaMatrix<T>& c, unsigned int elements = 0);
-      void copy_submatrix(const std::vector<T>& v, unsigned int elements = 0);
+  void copy_submatrix(const HostMatrix<T>& c, unsigned int elements = 0);
+  void copy_submatrix(const CudaMatrix<T>& c, unsigned int elements = 0);
+  void copy_submatrix(const std::vector<T>& v, unsigned int elements = 0);
 
-      void deallocate(void);
-  };
+  void deallocate(void);
+};
 
-  template <class T> class FortranMatrix : public Matrix<T> {
-    public:
-      FortranMatrix(void);
-      FortranMatrix(T* ptr, unsigned int width, unsigned int height = 1, unsigned int fortran_width = 1);
+template <class T>
+class FortranMatrix : public Matrix<T> {
+ public:
+  FortranMatrix(void);
+  FortranMatrix(T* ptr, unsigned int width, unsigned int height = 1,
+                unsigned int fortran_width = 1);
 
-      inline T& operator()(unsigned int x = 0, unsigned int y = 0) {
-        assert(x < this->width);
-        assert(y < this->height);
-        return this->data[y * fortran_width + x];
-      }
-      inline const T& operator()(unsigned int x = 0, unsigned int y = 0) const {
-        assert(x < this->width);
-        assert(y < this->height);
-        return this->data[y * fortran_width + x];
-      }
-      void deallocate(void) {};
+  inline T& operator()(unsigned int x = 0, unsigned int y = 0) {
+    assert(x < this->width);
+    assert(y < this->height);
+    return this->data[y * fortran_width + x];
+  }
+  inline const T& operator()(unsigned int x = 0, unsigned int y = 0) const {
+    assert(x < this->width);
+    assert(y < this->height);
+    return this->data[y * fortran_width + x];
+  }
+  void deallocate(void){};
 
-    private:
-      unsigned int fortran_width;
-  };
+ private:
+  unsigned int fortran_width;
+};
 
-  typedef HostMatrix<double> HostMatrixDouble;
-  typedef HostMatrix<double3> HostMatrixDouble3;
-  typedef HostMatrix<float> HostMatrixFloat;
-  typedef HostMatrix<float1> HostMatrixFloat1;
-  typedef HostMatrix<float3> HostMatrixFloat3;
-  typedef HostMatrix<float4> HostMatrixFloat4;
-  typedef HostMatrix<uint> HostMatrixUInt;
-  typedef HostMatrix<uint1> HostMatrixUInt1;
-  typedef HostMatrix<uint2> HostMatrixUInt2;
+typedef HostMatrix<double> HostMatrixDouble;
+typedef HostMatrix<double3> HostMatrixDouble3;
+typedef HostMatrix<float> HostMatrixFloat;
+typedef HostMatrix<float1> HostMatrixFloat1;
+typedef HostMatrix<float3> HostMatrixFloat3;
+typedef HostMatrix<float4> HostMatrixFloat4;
+typedef HostMatrix<uint> HostMatrixUInt;
+typedef HostMatrix<uint1> HostMatrixUInt1;
+typedef HostMatrix<uint2> HostMatrixUInt2;
 
-  typedef CudaMatrix<float> CudaMatrixFloat;
-  typedef CudaMatrix<float1> CudaMatrixFloat1;
-  typedef CudaMatrix<float2> CudaMatrixFloat2;
-  typedef CudaMatrix<float3> CudaMatrixFloat3;
-  typedef CudaMatrix<float4> CudaMatrixFloat4;
-  typedef CudaMatrix<uint> CudaMatrixUInt;
-  typedef CudaMatrix<uint1> CudaMatrixUInt1;
-  typedef CudaMatrix<uint2> CudaMatrixUInt2;
-}
+typedef CudaMatrix<float> CudaMatrixFloat;
+typedef CudaMatrix<float1> CudaMatrixFloat1;
+typedef CudaMatrix<float2> CudaMatrixFloat2;
+typedef CudaMatrix<float3> CudaMatrixFloat3;
+typedef CudaMatrix<float4> CudaMatrixFloat4;
+typedef CudaMatrix<uint> CudaMatrixUInt;
+typedef CudaMatrix<uint1> CudaMatrixUInt1;
+typedef CudaMatrix<uint2> CudaMatrixUInt2;
+}  // namespace G2G
 
 #endif

--- a/g2g/partition.cpp
+++ b/g2g/partition.cpp
@@ -286,9 +286,8 @@ size_t PointGroup<scalar_type>::size_in_gpu() const {
          sizeof(scalar_type);  // size in bytes according to precision
 }
 
-template<class scalar_type>
-PointGroup<scalar_type>::~PointGroup<scalar_type>() {
-}
+template <class scalar_type>
+PointGroup<scalar_type>::~PointGroup<scalar_type>() {}
 
 template <class scalar_type>
 PointGroupCPU<scalar_type>::~PointGroupCPU<scalar_type>() {
@@ -473,7 +472,7 @@ void Partition::solve(Timers& timers, bool compute_rmm, bool lda,
     }
 
     CDFTVars cdft_vars_local;
-    #pragma omp critical 
+#pragma omp critical
     this->cdft_copy_to_local(cdft_vars_local);
 
     for (uint j = 0; j < work[i].size(); j++) {
@@ -486,22 +485,22 @@ void Partition::solve(Timers& timers, bool compute_rmm, bool lda,
               ts, compute_rmm, lda, compute_forces, compute_energy,
               local_energy, spheres_energy_i, spheres_energy_c,
               spheres_energy_c1, spheres_energy_c2, fort_forces_ms[i],
-              rmm_outputs_a[i], rmm_outputs_b[i], becke_dens[i],
-              becke_spin[i], cdft_vars_local);
+              rmm_outputs_a[i], rmm_outputs_b[i], becke_dens[i], becke_spin[i],
+              cdft_vars_local);
         } else {
           cubes[ind]->solve_opened(
               ts, compute_rmm, lda, compute_forces, compute_energy,
               local_energy, spheres_energy_i, spheres_energy_c,
               spheres_energy_c1, spheres_energy_c2, fort_forces_ms[i],
-              rmm_outputs_a[i], rmm_outputs_b[i], becke_dens[i],
-              becke_spin[i], cdft_vars_local);
+              rmm_outputs_a[i], rmm_outputs_b[i], becke_dens[i], becke_spin[i],
+              cdft_vars_local);
         }
       } else {
         if (ind >= cubes.size()) {
           spheres[ind - cubes.size()]->solve_closed(
               ts, compute_rmm, lda, compute_forces, compute_energy,
-              local_energy, fort_forces_ms[i], 1, rmm_outputs[i],
-              becke_dens[i], cdft_vars_local);
+              local_energy, fort_forces_ms[i], 1, rmm_outputs[i], becke_dens[i],
+              cdft_vars_local);
         } else {
           cubes[ind]->solve_closed(ts, compute_rmm, lda, compute_forces,
                                    compute_energy, local_energy,
@@ -606,7 +605,7 @@ void Partition::solve(Timers& timers, bool compute_rmm, bool lda,
         for (int i = 0; i < becke_spin.size(); i++) {
           fortran_vars.becke_atom_spin(j) += becke_spin[i](j);
         }
-      } 
+      }
     }
   }
 
@@ -640,4 +639,4 @@ template class PointGroupCPU<float>;
 template class PointGroupGPU<float>;
 #endif
 #endif
-}
+}  // namespace G2G

--- a/g2g/partition.h
+++ b/g2g/partition.h
@@ -134,7 +134,8 @@ class PointGroup {
   virtual void solve_closed(Timers& timers, bool compute_rmm, bool lda,
                             bool compute_forces, bool compute_energy,
                             double& energy, HostMatrix<double>&, int,
-                            HostMatrix<double>&, HostMatrix<double>&, CDFTVars&) = 0;
+                            HostMatrix<double>&, HostMatrix<double>&,
+                            CDFTVars&) = 0;
 
   virtual void solve(Timers& timers, bool compute_rmm, bool lda,
                      bool compute_forces, bool compute_energy, double& energy,
@@ -143,9 +144,11 @@ class PointGroup {
 
   virtual void lr_closed_init() = 0;
   virtual void solve_closed_lr(double* T, HostMatrix<double>& Fock) = 0;
-  virtual void solve_3rd_der(double* Tmat,HostMatrix<double>& Fock,int DER) = 0;
-  virtual void solve_for_exc(double* P,double* V,HostMatrix<double>& F, int met) = 0;
-  virtual void calc_W_mat(HostMatrix<double>& , CDFTVars& ) = 0;
+  virtual void solve_3rd_der(double* Tmat, HostMatrix<double>& Fock,
+                             int DER) = 0;
+  virtual void solve_for_exc(double* P, double* V, HostMatrix<double>& F,
+                             int met) = 0;
+  virtual void calc_W_mat(HostMatrix<double>&, CDFTVars&) = 0;
 
   bool is_significative(FunctionType, double exponent, double coeff, double d2);
 
@@ -187,18 +190,21 @@ class PointGroupCPU : public PointGroup<scalar_type> {
   virtual void solve_closed(Timers& timers, bool compute_rmm, bool lda,
                             bool compute_forces, bool compute_energy,
                             double& energy, HostMatrix<double>&, int,
-                            HostMatrix<double>&, HostMatrix<double>&, CDFTVars&);
+                            HostMatrix<double>&, HostMatrix<double>&,
+                            CDFTVars&);
 
   virtual void solve(Timers& timers, bool compute_rmm, bool lda,
                      bool compute_forces, bool compute_energy, double& energy,
                      double&, double&, double&, double&, HostMatrix<double>&,
                      int, HostMatrix<double>&, bool);
 
-  virtual void get_tred_input(G2G::HostMatrix<scalar_type>& tre_input,G2G::HostMatrix<double>& source) const;
+  virtual void get_tred_input(G2G::HostMatrix<scalar_type>& tre_input,
+                              G2G::HostMatrix<double>& source) const;
   virtual void lr_closed_init();
-  virtual void solve_closed_lr(double* T,HostMatrix<double>& Fock);
-  virtual void solve_3rd_der(double* Tmat,HostMatrix<double>& Fock,int DER);
-  virtual void solve_for_exc(double* P,double* V,HostMatrix<double>& F,int met);
+  virtual void solve_closed_lr(double* T, HostMatrix<double>& Fock);
+  virtual void solve_3rd_der(double* Tmat, HostMatrix<double>& Fock, int DER);
+  virtual void solve_for_exc(double* P, double* V, HostMatrix<double>& F,
+                             int met);
   virtual void calc_W_mat(HostMatrix<double>&, CDFTVars&);
 
   typedef vec_type<scalar_type, 2> vec_type2;
@@ -212,46 +218,54 @@ class PointGroupCPU : public PointGroup<scalar_type> {
   G2G::HostMatrix<scalar_type> function_values_transposed;
 };
 
-template<class scalar_type>
-class PointGroupGPU: public PointGroup<scalar_type> {
-  public:
-    virtual ~PointGroupGPU(void);
-    virtual void deallocate();
-    virtual void compute_functions(bool, bool);
-    virtual void compute_weights(void);
-    bool is_big_group() const;
-    virtual void get_rmm_input(G2G::HostMatrix<scalar_type>& rmm_input, FortranMatrix<double>& source) const;
-    virtual void get_rmm_input(G2G::HostMatrix<scalar_type>& rmm_input) const;
-    virtual void get_rmm_input(G2G::HostMatrix<scalar_type>& rmm_input_a, G2G::HostMatrix<scalar_type>& rmm_input_b) const;
-    virtual void solve_opened(Timers& timers, bool compute_rmm, bool lda, bool compute_forces,
-                              bool compute_energy, double& energy, double &, double &, double &, double &,
-                              HostMatrix<double> &, HostMatrix<double> &, HostMatrix<double> &,
-                              HostMatrix<double>&, HostMatrix<double>&, CDFTVars&);
-    virtual void solve_closed(Timers& timers, bool compute_rmm, bool lda, bool compute_forces,
-                              bool compute_energy, double& energy, HostMatrix<double> &, int,
-                              HostMatrix<double> &, HostMatrix<double>&, CDFTVars& );
+template <class scalar_type>
+class PointGroupGPU : public PointGroup<scalar_type> {
+ public:
+  virtual ~PointGroupGPU(void);
+  virtual void deallocate();
+  virtual void compute_functions(bool, bool);
+  virtual void compute_weights(void);
+  bool is_big_group() const;
+  virtual void get_rmm_input(G2G::HostMatrix<scalar_type>& rmm_input,
+                             FortranMatrix<double>& source) const;
+  virtual void get_rmm_input(G2G::HostMatrix<scalar_type>& rmm_input) const;
+  virtual void get_rmm_input(G2G::HostMatrix<scalar_type>& rmm_input_a,
+                             G2G::HostMatrix<scalar_type>& rmm_input_b) const;
+  virtual void solve_opened(Timers& timers, bool compute_rmm, bool lda,
+                            bool compute_forces, bool compute_energy,
+                            double& energy, double&, double&, double&, double&,
+                            HostMatrix<double>&, HostMatrix<double>&,
+                            HostMatrix<double>&, HostMatrix<double>&,
+                            HostMatrix<double>&, CDFTVars&);
+  virtual void solve_closed(Timers& timers, bool compute_rmm, bool lda,
+                            bool compute_forces, bool compute_energy,
+                            double& energy, HostMatrix<double>&, int,
+                            HostMatrix<double>&, HostMatrix<double>&,
+                            CDFTVars&);
 
-    virtual void solve(Timers& timers, bool compute_rmm, bool lda, bool compute_forces,
-        bool compute_energy, double& energy, double &, double &, double &, double &,
-        HostMatrix<double> &, int, HostMatrix<double> &, bool);
+  virtual void solve(Timers& timers, bool compute_rmm, bool lda,
+                     bool compute_forces, bool compute_energy, double& energy,
+                     double&, double&, double&, double&, HostMatrix<double>&,
+                     int, HostMatrix<double>&, bool);
 
-    virtual void get_tred_input(G2G::HostMatrix<scalar_type>& tre_input,G2G::HostMatrix<double>& source) const;
-    virtual void lr_closed_init();
-    virtual void solve_closed_lr(double* T,HostMatrix<double>& Fock);
-    virtual void solve_3rd_der(double* Tmat,HostMatrix<double>& Fock,int DER);
-    virtual void solve_for_exc(double* P,double* V,HostMatrix<double>& F,int met);
-    virtual void calc_W_mat(HostMatrix<double>& , CDFTVars&);
+  virtual void get_tred_input(G2G::HostMatrix<scalar_type>& tre_input,
+                              G2G::HostMatrix<double>& source) const;
+  virtual void lr_closed_init();
+  virtual void solve_closed_lr(double* T, HostMatrix<double>& Fock);
+  virtual void solve_3rd_der(double* Tmat, HostMatrix<double>& Fock, int DER);
+  virtual void solve_for_exc(double* P, double* V, HostMatrix<double>& F,
+                             int met);
+  virtual void calc_W_mat(HostMatrix<double>&, CDFTVars&);
 
-    typedef vec_type<scalar_type,2> vec_type2;
-    typedef vec_type<scalar_type,3> vec_type3;
-    typedef vec_type<scalar_type,4> vec_type4;
-    G2G::CudaMatrix<scalar_type> function_values;
-    G2G::CudaMatrix<vec_type4> gradient_values;
-    G2G::CudaMatrix<vec_type4> hessian_values_transposed;
-    G2G::CudaMatrix<scalar_type> rmm_accum_gpu;
-    G2G::CudaMatrix< vec_type<scalar_type,4> > dxyz_accum_gpu;
-    int current_device;
-
+  typedef vec_type<scalar_type, 2> vec_type2;
+  typedef vec_type<scalar_type, 3> vec_type3;
+  typedef vec_type<scalar_type, 4> vec_type4;
+  G2G::CudaMatrix<scalar_type> function_values;
+  G2G::CudaMatrix<vec_type4> gradient_values;
+  G2G::CudaMatrix<vec_type4> hessian_values_transposed;
+  G2G::CudaMatrix<scalar_type> rmm_accum_gpu;
+  G2G::CudaMatrix<vec_type<scalar_type, 4> > dxyz_accum_gpu;
+  int current_device;
 };
 
 #if FULL_DOUBLE
@@ -263,43 +277,43 @@ typedef float base_scalar_type;
 // =======Partition Class ========//
 
 class Partition {
-  public:
-    void compute_work_partition();
-    void clear(void);
-    void regenerate(void);
+ public:
+  void compute_work_partition();
+  void clear(void);
+  void regenerate(void);
 
-    void solve(Timers& timers, bool compute_rmm,bool lda,bool compute_forces, bool compute_energy,
-               double* fort_energy_ptr, double* fort_forces_ptr, bool OPEN);
-    void compute_functions(bool forces, bool gga);
-    void compute_Wmat_global(HostMatrix<double>& fort_Wmat);
-    void rebalance(std::vector<double> &, std::vector<double> &);
+  void solve(Timers& timers, bool compute_rmm, bool lda, bool compute_forces,
+             bool compute_energy, double* fort_energy_ptr,
+             double* fort_forces_ptr, bool OPEN);
+  void compute_functions(bool forces, bool gga);
+  void compute_Wmat_global(HostMatrix<double>& fort_Wmat);
+  void rebalance(std::vector<double>&, std::vector<double>&);
 
-    void lr_init();
-    void cdft_copy_to_local(CDFTVars&);
-    void solve_lr(double* T, double* F);
-    void solve_Gxc(double* Tmat,double* F,int DER);
-    void solveForcesExc(double* P,double* V,double* F,int met);
+  void lr_init();
+  void cdft_copy_to_local(CDFTVars&);
+  void solve_lr(double* T, double* F);
+  void solve_Gxc(double* Tmat, double* F, int DER);
+  void solveForcesExc(double* P, double* V, double* F, int met);
 
-    std::vector<PointGroup<base_scalar_type>*> cubes;
-    std::vector<PointGroup<base_scalar_type>*> spheres;
+  std::vector<PointGroup<base_scalar_type>*> cubes;
+  std::vector<PointGroup<base_scalar_type>*> spheres;
 
-    std::vector< HostMatrix<double> > fort_forces_ms;
-    std::vector< HostMatrix<double> > rmm_outputs;
-    std::vector< HostMatrix<double> > rmm_outputs_a;
-    std::vector< HostMatrix<double> > rmm_outputs_b;
+  std::vector<HostMatrix<double> > fort_forces_ms;
+  std::vector<HostMatrix<double> > rmm_outputs;
+  std::vector<HostMatrix<double> > rmm_outputs_a;
+  std::vector<HostMatrix<double> > rmm_outputs_b;
 
-    // For Becke partitioning
-    std::vector< HostMatrix<double> > becke_dens;
-    std::vector< HostMatrix<double> > becke_spin;
+  // For Becke partitioning
+  std::vector<HostMatrix<double> > becke_dens;
+  std::vector<HostMatrix<double> > becke_spin;
 
-    std::vector< std::vector< int > > work;
-    std::vector< double > next;
-    std::vector< double > timeforgroup;
-
+  std::vector<std::vector<int> > work;
+  std::vector<double> next;
+  std::vector<double> timeforgroup;
 };
 
 extern int MINCOST, THRESHOLD, SPLITPOINTS;
 extern int cpu_threads, gpu_threads;
-}
+}  // namespace G2G
 
 #endif

--- a/g2g/pointxc/calc_ggaCS.h
+++ b/g2g/pointxc/calc_ggaCS.h
@@ -41,13 +41,13 @@ __host__ __device__ void calc_ggaCS(scalar_type dens,
                                     scalar_type& y2a, double fexc) {
   // hess1: xx, yy, zz  || hess2: xy, xz, yz
 #if FULL_DOUBLE
-  const scalar_type MINIMUM_DENSITY_VALUE = (scalar_type) 1e-18;
+  const scalar_type MINIMUM_DENSITY_VALUE = (scalar_type)1e-18;
 #else
-  const scalar_type MINIMUM_DENSITY_VALUE = (scalar_type) 1e-12;
+  const scalar_type MINIMUM_DENSITY_VALUE = (scalar_type)1e-12;
 #endif
   if (dens < MINIMUM_DENSITY_VALUE) {
-    ex = ec = (scalar_type) 0.0f;
-    y2a = (scalar_type) 0.0f;
+    ex = ec = (scalar_type)0.0f;
+    y2a = (scalar_type)0.0f;
     return;
   }
 
@@ -325,4 +325,4 @@ __host__ __device__ void calc_ggaCS_in(
 #undef POT_BET
 #undef POT_GAM
 #undef POT_DEL
-}
+}  // namespace G2G

--- a/g2g/pointxc/calc_ggaOS.h
+++ b/g2g/pointxc/calc_ggaOS.h
@@ -19,30 +19,30 @@ __host__ __device__ void calc_ggaOS(scalar_type dens_a, scalar_type dens_b,
                                     scalar_type& corr, scalar_type& corr1,
                                     scalar_type& corr2, scalar_type& v_a,
                                     scalar_type& v_b, int Vxc_id, double fexc) {
-  scalar_type expbe   = 0.0f;
+  scalar_type expbe = 0.0f;
   scalar_type vxpbe_a = 0.0f;
   scalar_type vxpbe_b = 0.0f;
-  scalar_type ecpbe   = 0.0f;
+  scalar_type ecpbe = 0.0f;
   scalar_type vcpbe_a = 0.0f;
   scalar_type vcpbe_b = 0.0f;
 
   exc_corr = exc = corr = corr1 = corr2 = v_a = v_b = 0.0f;
 
-  scalar_type dgrad_a   = 0.0f;
+  scalar_type dgrad_a = 0.0f;
   scalar_type delgrad_a = 0.0f;
-  scalar_type rlap_a    = 0.0f;
-  scalar_type dgrad_b   = 0.0f;
+  scalar_type rlap_a = 0.0f;
+  scalar_type dgrad_b = 0.0f;
   scalar_type delgrad_b = 0.0f;
-  scalar_type rlap_b    = 0.0f;
-  scalar_type dgrad     = 0.0f;
-  scalar_type delgrad   = 0.0f;
+  scalar_type rlap_b = 0.0f;
+  scalar_type dgrad = 0.0f;
+  scalar_type delgrad = 0.0f;
 #if FULL_DOUBLE
-   const scalar_type MINIMUM_DENSITY_VALUE = (scalar_type) 1e-18;
+  const scalar_type MINIMUM_DENSITY_VALUE = (scalar_type)1e-18;
 #else
-   const scalar_type MINIMUM_DENSITY_VALUE = (scalar_type) 1e-12;
+  const scalar_type MINIMUM_DENSITY_VALUE = (scalar_type)1e-12;
 #endif
 
-  if ((dens_a > MINIMUM_DENSITY_VALUE) || (dens_b > MINIMUM_DENSITY_VALUE)){
+  if ((dens_a > MINIMUM_DENSITY_VALUE) || (dens_b > MINIMUM_DENSITY_VALUE)) {
     if (Vxc_id == 9) {  // PBE
 
       vec_type<scalar_type, width> grad;
@@ -59,16 +59,17 @@ __host__ __device__ void calc_ggaOS(scalar_type dens_a, scalar_type dens_b,
       hess2.x = hess2_a.x + hess2_b.x;
       hess2.y = hess2_a.y + hess2_b.y;
       hess2.z = hess2_a.z + hess2_b.z;
-      
+
       scalar_type grad2_a =
           pow(grad_a.x, 2) + pow(grad_a.y, 2) + pow(grad_a.z, 2);
       dgrad_a = sqrt(grad2_a);
       delgrad_a =
           (pow(grad_a.x, 2) * hess1_a.x +
-            (scalar_type)2.0f * grad_a.x * grad_a.y * hess2_a.x +
-            (scalar_type)2.0f * grad_a.y * grad_a.z * hess2_a.z +
-            (scalar_type)2.0f * grad_a.x * grad_a.z * hess2_a.y +
-            pow(grad_a.y, 2) * hess1_a.y + pow(grad_a.z, 2) * hess1_a.z) / dgrad_a;
+           (scalar_type)2.0f * grad_a.x * grad_a.y * hess2_a.x +
+           (scalar_type)2.0f * grad_a.y * grad_a.z * hess2_a.z +
+           (scalar_type)2.0f * grad_a.x * grad_a.z * hess2_a.y +
+           pow(grad_a.y, 2) * hess1_a.y + pow(grad_a.z, 2) * hess1_a.z) /
+          dgrad_a;
       rlap_a = hess1_a.x + hess1_a.y + hess1_a.z;  // Laplacian Up
 
       // Down density
@@ -76,21 +77,23 @@ __host__ __device__ void calc_ggaOS(scalar_type dens_a, scalar_type dens_b,
           pow(grad_b.x, 2) + pow(grad_b.y, 2) + pow(grad_b.z, 2);
       dgrad_b = sqrt(grad2_b);
       delgrad_b =
-          (pow(grad_b.x, 2)  * hess1_b.x +
-            (scalar_type)2.0f * grad_b.x * grad_b.y * hess2_b.x +
-            (scalar_type)2.0f * grad_b.y * grad_b.z * hess2_b.z +
-            (scalar_type)2.0f * grad_b.x * grad_b.z * hess2_b.y +
-            pow(grad_b.y, 2)  * hess1_b.y + pow(grad_b.z, 2) * hess1_b.z) / dgrad_b;
+          (pow(grad_b.x, 2) * hess1_b.x +
+           (scalar_type)2.0f * grad_b.x * grad_b.y * hess2_b.x +
+           (scalar_type)2.0f * grad_b.y * grad_b.z * hess2_b.z +
+           (scalar_type)2.0f * grad_b.x * grad_b.z * hess2_b.y +
+           pow(grad_b.y, 2) * hess1_b.y + pow(grad_b.z, 2) * hess1_b.z) /
+          dgrad_b;
       rlap_b = hess1_b.x + hess1_b.y + hess1_b.z;
 
       // Up + Down densities
       scalar_type grad2 = pow(grad.x, 2) + pow(grad.y, 2) + pow(grad.z, 2);
       dgrad = sqrt(grad2);
-      delgrad = (pow(grad.x, 2) * hess1.x + pow(grad.y, 2) * hess1.y
-                  + pow(grad.z, 2) * hess1.z + 
-                  (scalar_type)2.0f * grad.x * grad.y * hess2.x +
-                  (scalar_type)2.0f * grad.y * grad.z * hess2.z +
-                  (scalar_type)2.0f * grad.x * grad.z * hess2.y) / dgrad;
+      delgrad = (pow(grad.x, 2) * hess1.x + pow(grad.y, 2) * hess1.y +
+                 pow(grad.z, 2) * hess1.z +
+                 (scalar_type)2.0f * grad.x * grad.y * hess2.x +
+                 (scalar_type)2.0f * grad.y * grad.z * hess2.z +
+                 (scalar_type)2.0f * grad.x * grad.z * hess2.y) /
+                dgrad;
       pbeOS_main<scalar_type>(dens_a, dgrad_a, delgrad_a, rlap_a, dens_b,
                               dgrad_b, delgrad_b, rlap_b, dgrad, delgrad, expbe,
                               vxpbe_a, vxpbe_b, ecpbe, corr1, corr2, vcpbe_a,
@@ -107,4 +110,4 @@ __host__ __device__ void calc_ggaOS(scalar_type dens_a, scalar_type dens_b,
   v_b = fexc * vxpbe_b + vcpbe_b;
   return;
 }
-}
+}  // namespace G2G

--- a/g2g/pointxc/calc_ldaCS.h
+++ b/g2g/pointxc/calc_ldaCS.h
@@ -146,4 +146,4 @@ __host__ __device__ void calc_ldaCS_in(scalar_type dens, scalar_type& ex,
 #undef POT_VOSKO_4B1
 #undef POT_VOSKO_QSQ
 #undef POT_VOSKO_B1X0
-}
+}  // namespace G2G

--- a/g2g/pointxc/gcorc.h
+++ b/g2g/pointxc/gcorc.h
@@ -22,8 +22,10 @@ template <class scalar_type>
 __host__ __device__ void gcorc1(scalar_type rtrs, scalar_type& gg,
                                 scalar_type& grrs) {
   scalar_type Q0 = -2.0f * GCORC_A0_1 * (1.0f + GCORC_A1_1 * rtrs * rtrs);
-  scalar_type Q1 = 2.0f * GCORC_A0_1 * rtrs *
-      (GCORC_B1_1 + rtrs * (GCORC_B2_1 + rtrs * (GCORC_B3_1 + GCORC_B4_1 * rtrs)));
+  scalar_type Q1 =
+      2.0f * GCORC_A0_1 * rtrs *
+      (GCORC_B1_1 +
+       rtrs * (GCORC_B2_1 + rtrs * (GCORC_B3_1 + GCORC_B4_1 * rtrs)));
   scalar_type Q2 = log(1.0f + 1.0f / Q1);
   gg = Q0 * Q2;
   scalar_type Q3 =
@@ -75,4 +77,4 @@ __host__ __device__ void gcorc3(scalar_type rtrs, scalar_type& gg,
                     rtrs * (3.0f * GCORC_B3_3 + 4.0f * GCORC_B4_3 * rtrs));
   grrs = -2.0f * GCORC_A0_3 * GCORC_A1_3 * Q2 - Q0 * Q3 / (Q1 * (1.0f + Q1));
 }  // gcorc3
-}
+}  // namespace G2G

--- a/g2g/pointxc/pbeCS.h
+++ b/g2g/pointxc/pbeCS.h
@@ -31,11 +31,10 @@ __host__ __device__ void pbeCS(scalar_type rho, scalar_type agrad,
                                scalar_type delgrad, scalar_type rlap,
                                scalar_type& expbe, scalar_type& vxpbe,
                                scalar_type& ecpbe, scalar_type& vcpbe) {
-
 #if FULL_DOUBLE
-   const scalar_type MINIMUM_DENSITY_VALUE = (scalar_type) 1e-18;
+  const scalar_type MINIMUM_DENSITY_VALUE = (scalar_type)1e-18;
 #else
-   const scalar_type MINIMUM_DENSITY_VALUE = (scalar_type) 1e-12;
+  const scalar_type MINIMUM_DENSITY_VALUE = (scalar_type)1e-12;
 #endif
 
   /*----------------------------------//
@@ -56,7 +55,6 @@ __host__ __device__ void pbeCS(scalar_type rho, scalar_type agrad,
   scalar_type fk1 = cbrt((scalar_type)CLOSEDPBE_PI32);
   scalar_type fk = fk1 * rho13;
   if (rho2 > MINIMUM_DENSITY_VALUE) {
-
     scalar_type twofk = 2.0f * fk;
     scalar_type twofk2 = twofk * twofk;
     scalar_type twofk3 = twofk * twofk2;
@@ -90,8 +88,8 @@ __host__ __device__ void pbeCS(scalar_type rho, scalar_type agrad,
     scalar_type vx4 = (u - (4.0f / 3.0f) * s3) * Fss;
     vxpbe = exlda * (vx2 - vx4 - vx3);
   } else {
-    expbe = (scalar_type) 0.0f;
-    vxpbe = (scalar_type) 0.0f;
+    expbe = (scalar_type)0.0f;
+    vxpbe = (scalar_type)0.0f;
   };
 
   /*-----------------------------------------------//
@@ -115,9 +113,9 @@ __host__ __device__ void pbeCS(scalar_type rho, scalar_type agrad,
   // COMM  = Gradient correlation potential
   //-----------------------------------------------*/
 
-  if (rho < (MINIMUM_DENSITY_VALUE * (scalar_type) 1E6)) {
-    ecpbe = (scalar_type) 0.0f;
-    vcpbe = (scalar_type) 0.0f;
+  if (rho < (MINIMUM_DENSITY_VALUE * (scalar_type)1E6)) {
+    ecpbe = (scalar_type)0.0f;
+    vcpbe = (scalar_type)0.0f;
     return;
   };
   // LSD contribution to correlation energy.
@@ -157,30 +155,35 @@ __host__ __device__ void pbeCS(scalar_type rho, scalar_type agrad,
   // GGA Contribution to the potential.
   scalar_type T6 = T4 * t2;
   scalar_type RSTHRD = rs / (scalar_type)3.0f;
-  scalar_type FAC = CLOSEDPBE_DELTA / B + (scalar_type) 1.0f;
+  scalar_type FAC = CLOSEDPBE_DELTA / B + (scalar_type)1.0f;
   scalar_type BEC = B2 * FAC / CLOSEDPBE_BETA;
   scalar_type Q8 = (Q5 + CLOSEDPBE_DELTA * Q4 * t2) * Q5;
-  scalar_type Q9 = (scalar_type) 1.0f + (scalar_type) 2.0f * B * t2;
-  scalar_type hB = -CLOSEDPBE_BETA * B * (T6 / Q8) * ((scalar_type)2.0f + B * t2);
+  scalar_type Q9 = (scalar_type)1.0f + (scalar_type)2.0f * B * t2;
+  scalar_type hB =
+      -CLOSEDPBE_BETA * B * (T6 / Q8) * ((scalar_type)2.0f + B * t2);
   scalar_type hRS = -RSTHRD * hB * BEC * ecrs;
-  scalar_type FACT0 = (scalar_type)2.0f * CLOSEDPBE_DELTA - (scalar_type)6.0f * B;
+  scalar_type FACT0 =
+      (scalar_type)2.0f * CLOSEDPBE_DELTA - (scalar_type)6.0f * B;
   scalar_type FACT1 = Q5 * Q9 + Q4 * Q9 * Q9;
-  scalar_type hBT = (scalar_type) 2.0f * CLOSEDPBE_BETA * T4 *
+  scalar_type hBT = (scalar_type)2.0f * CLOSEDPBE_BETA * T4 *
                     ((Q4 * Q5 * FACT0 - CLOSEDPBE_DELTA * FACT1) / Q8) / Q8;
   scalar_type hRST = RSTHRD * t2 * hBT * BEC * ecrs;
-  scalar_type hT = (scalar_type) 2.0f * CLOSEDPBE_BETA * (Q9 / Q8);
+  scalar_type hT = (scalar_type)2.0f * CLOSEDPBE_BETA * (Q9 / Q8);
   scalar_type FACT2 = Q4 * Q5 + B * t2 * (Q4 * Q9 + Q5);
-  scalar_type FACT3 = (scalar_type) 2.0f * B * Q5 * Q9 + CLOSEDPBE_DELTA * FACT2;
-  scalar_type hTT =
-      4.0f * CLOSEDPBE_BETA * t * ((scalar_type) 2.0f * B / Q8 - ((Q9 / Q8) * FACT3) / Q8);
-  scalar_type COMM =
-      H + hRS + hRST + t2 * hT / (scalar_type)6.0f + (scalar_type)7.0f * t2 * t * hTT / (scalar_type)6.0f;
+  scalar_type FACT3 = (scalar_type)2.0f * B * Q5 * Q9 + CLOSEDPBE_DELTA * FACT2;
+  scalar_type hTT = 4.0f * CLOSEDPBE_BETA * t *
+                    ((scalar_type)2.0f * B / Q8 - ((Q9 / Q8) * FACT3) / Q8);
+  scalar_type COMM = H + hRS + hRST + t2 * hT / (scalar_type)6.0f +
+                     (scalar_type)7.0f * t2 * t * hTT / (scalar_type)6.0f;
 
   COMM = COMM - UU * hTT - VV * hT;
   vcpbe = vclda + COMM;
 
 #ifdef _DEBUG
-  if ( COMM != COMM ) { printf("NAN in COMM, UU %E, hTT %E, VV %E, hT %E, rho %E \n", UU, hTT, VV, hT, rho);};
+  if (COMM != COMM) {
+    printf("NAN in COMM, UU %E, hTT %E, VV %E, hT %E, rho %E \n", UU, hTT, VV,
+           hT, rho);
+  };
 #endif
 }  // pbeCS
-}
+}  // namespace G2G

--- a/g2g/pointxc/pbeOS_corr.h
+++ b/g2g/pointxc/pbeOS_corr.h
@@ -235,17 +235,20 @@ __host__ __device__ void pbeOS_corr(scalar_type rho, scalar_type rs,
   scalar_type FACT5 = GZ * ((scalar_type)2.0f * hT + t * hTT) / G;
   COMM = COMM - PREF * zet - uu * hTT - vv * hT - ww * (hZT - FACT5);
 
-  #ifdef _DEBUG
-  if ( COMM != COMM ) { 
-      printf("NaN in COMM2 - hRS %E hRST %E T2 %E hT %E hTT %E \n", hRS, hRST, T2, hT, hTT);
-      printf("hTT: G3 %E t %E B %E Q8 %E Q9 %E FACT3 %E \n", G3, t, B, Q8, Q9, FACT3);
-      printf("hRST: rsthrd %E T2 %E hBT %E BEC %E ECRS %E \n", rsthrd, T2, hBT, BEC, ECRS);
-      printf("Q8: Q4 %E Q5 %E T2 %E \n", Q4, Q5, T2);
+#ifdef _DEBUG
+  if (COMM != COMM) {
+    printf("NaN in COMM2 - hRS %E hRST %E T2 %E hT %E hTT %E \n", hRS, hRST, T2,
+           hT, hTT);
+    printf("hTT: G3 %E t %E B %E Q8 %E Q9 %E FACT3 %E \n", G3, t, B, Q8, Q9,
+           FACT3);
+    printf("hRST: rsthrd %E T2 %E hBT %E BEC %E ECRS %E \n", rsthrd, T2, hBT,
+           BEC, ECRS);
+    printf("Q8: Q4 %E Q5 %E T2 %E \n", Q4, Q5, T2);
   };
-  #endif
+#endif
   dvc_a = COMM + PREF;
   dvc_b = COMM - PREF;
   // PBE POTENTIAL DONE !!!!!
   //--------------------------------------------------
 }
-}
+}  // namespace G2G

--- a/g2g/pointxc/pbeOS_exch.h
+++ b/g2g/pointxc/pbeOS_exch.h
@@ -72,4 +72,4 @@ __host__ __device__ void pbeOS_exch(scalar_type rho, scalar_type s,
 #undef EASYPBE_UM
 #undef EASYPBE_UK
 #undef EASYPBE_UL
-}
+}  // namespace G2G

--- a/g2g/pointxc/pbeOS_main.h
+++ b/g2g/pointxc/pbeOS_main.h
@@ -50,29 +50,28 @@ __host__ __device__ void pbeOS_main(
   // u = delgrad/(rho^2*(2*fk)**3) where (rho=2*up)
   // v = Laplacian/(rho*(2*fk)**2) where (rho=2*up)
   //-----------------------------------------------------*/
-   scalar_type expbe_a, expbe_b;
-   scalar_type rho13, fk1, fk, twodens2, twofk, twofk2, twofk3, s, u, v;
+  scalar_type expbe_a, expbe_b;
+  scalar_type rho13, fk1, fk, twodens2, twofk, twofk2, twofk3, s, u, v;
 
-   // The limit 1e-18 is the one set in PBE's original paper, which
-   // works in double precision. For single precision, we take 1e-12
-   // so that rho^3 is still within precision.
-   // For Ec calculation, the limit is a bit lower (1e-10).
+  // The limit 1e-18 is the one set in PBE's original paper, which
+  // works in double precision. For single precision, we take 1e-12
+  // so that rho^3 is still within precision.
+  // For Ec calculation, the limit is a bit lower (1e-10).
 #if FULL_DOUBLE
-   const scalar_type MINIMUM_DENSITY_VALUE = (scalar_type) 1e-18;
+  const scalar_type MINIMUM_DENSITY_VALUE = (scalar_type)1e-18;
 #else
-   const scalar_type MINIMUM_DENSITY_VALUE = (scalar_type) 1e-12;
+  const scalar_type MINIMUM_DENSITY_VALUE = (scalar_type)1e-12;
 #endif
 
-   // Output initialization
-   expbe = (scalar_type)0.0f;
-   ecpbe = (scalar_type)0.0f;
-   corr1 = (scalar_type)0.0f;
-   corr2 = (scalar_type)0.0f;
-   vcpbe_a = (scalar_type)0.0f;
-   vcpbe_b = (scalar_type)0.0f;
-   vxpbe_a = (scalar_type)0.0f;
-   vxpbe_b = (scalar_type)0.0f;
-
+  // Output initialization
+  expbe = (scalar_type)0.0f;
+  ecpbe = (scalar_type)0.0f;
+  corr1 = (scalar_type)0.0f;
+  corr2 = (scalar_type)0.0f;
+  vcpbe_a = (scalar_type)0.0f;
+  vcpbe_b = (scalar_type)0.0f;
+  vxpbe_a = (scalar_type)0.0f;
+  vxpbe_b = (scalar_type)0.0f;
 
   scalar_type twodens = (scalar_type)2.0f * dens_a;
   if (twodens > MINIMUM_DENSITY_VALUE) {
@@ -85,13 +84,13 @@ __host__ __device__ void pbeOS_main(
     twofk2 = twofk * twofk;
     twofk3 = twofk * twofk2;
 
-    s = ((scalar_type)2.0f * dgrad_a)   / (twodens * twofk);
-    v = ((scalar_type)2.0f * rlap_a)    / (twodens * twofk2);
+    s = ((scalar_type)2.0f * dgrad_a) / (twodens * twofk);
+    v = ((scalar_type)2.0f * rlap_a) / (twodens * twofk2);
     u = ((scalar_type)4.0f * delgrad_a) / (twodens2 * twofk3);
     pbeOS_exch(twodens, s, u, v, expbe_a, vxpbe_a);
   } else {
-    expbe_a = (scalar_type) 0.0f;
-    vxpbe_a = (scalar_type) 0.0f;
+    expbe_a = (scalar_type)0.0f;
+    vxpbe_a = (scalar_type)0.0f;
   }
 
   // Density Down
@@ -106,19 +105,21 @@ __host__ __device__ void pbeOS_main(
     twofk2 = twofk * twofk;
     twofk3 = twofk * twofk2;
 
-    s = ((scalar_type)2.0f * dgrad_b)   / (twodens * twofk);
-    v = ((scalar_type)2.0f * rlap_b)    / (twodens * twofk2);
+    s = ((scalar_type)2.0f * dgrad_b) / (twodens * twofk);
+    v = ((scalar_type)2.0f * rlap_b) / (twodens * twofk2);
     u = ((scalar_type)4.0f * delgrad_b) / (twodens2 * twofk3);
     pbeOS_exch(twodens, s, u, v, expbe_b, vxpbe_b);
   } else {
-    expbe_b = (scalar_type) 0.0f;
-    vxpbe_b = (scalar_type) 0.0f;
+    expbe_b = (scalar_type)0.0f;
+    vxpbe_b = (scalar_type)0.0f;
   }
 
   // Construct total density and contribution to Ex
   scalar_type rho = dens_a + dens_b;
-  expbe = (expbe_a * (dens_a / rho) + expbe_b * (dens_b/rho));
-  if (rho < (MINIMUM_DENSITY_VALUE * (scalar_type) 1E5)) { return; };
+  expbe = (expbe_a * (dens_a / rho) + expbe_b * (dens_b / rho));
+  if (rho < (MINIMUM_DENSITY_VALUE * (scalar_type)1E5)) {
+    return;
+  };
 
   /*-------------------------------------------------------------//
   // PBE correlation
@@ -189,17 +190,33 @@ __host__ __device__ void pbeOS_main(
   vcpbe_b = vc_b + dvc_b;
 
 #ifdef _DEBUG
-if (expbe_a != expbe_a) { printf("NaN in expbe_a \n");};
-if (expbe_b != expbe_b) { printf("NaN in expbe_b \n");};
-if (ec != ec)           { printf("NaN in ec \n");};
-if (h != h)             { printf("NaN in h \n");};
-if (vc_a != vc_a)       { printf("NaN in vc_a \n");};
-if (dvc_a != dvc_a)     { printf("NaN in dvc_a \n");};
-if (vc_b != vc_b)       { printf("NaN in vc_b \n");};
-if (dvc_b!= dvc_b)      { printf("NaN in dvc_b \n");};
+  if (expbe_a != expbe_a) {
+    printf("NaN in expbe_a \n");
+  };
+  if (expbe_b != expbe_b) {
+    printf("NaN in expbe_b \n");
+  };
+  if (ec != ec) {
+    printf("NaN in ec \n");
+  };
+  if (h != h) {
+    printf("NaN in h \n");
+  };
+  if (vc_a != vc_a) {
+    printf("NaN in vc_a \n");
+  };
+  if (dvc_a != dvc_a) {
+    printf("NaN in dvc_a \n");
+  };
+  if (vc_b != vc_b) {
+    printf("NaN in vc_b \n");
+  };
+  if (dvc_b != dvc_b) {
+    printf("NaN in dvc_b \n");
+  };
 #endif
 }  // pbeOS_main
 
 #undef EASYPBE_PI
 #undef EASYPBE_PI32
-}
+}  // namespace G2G

--- a/g2g/regenerate_partition.cpp
+++ b/g2g/regenerate_partition.cpp
@@ -59,7 +59,7 @@ int compute_becke_a(HostMatrix<double>& becke_a_in) {
   // Cambridge Structural Database. All units are in Bohrs.
   // Available data is up to Cm (Z=96), if you want more
   // go measure them.
-  cov_r( 0) = 0.0000; // For ghost atoms.
+  cov_r(0) = 0.0000;  // For ghost atoms.
   /* USING COVALENT RADII
   cov_r( 1) = 0.5858; cov_r( 2) = 0.5291; cov_r( 3) = 2.4189;
   cov_r( 4) = 1.8141; cov_r( 5) = 1.5874; cov_r( 6) = 1.3795;
@@ -96,38 +96,102 @@ int compute_becke_a(HostMatrix<double>& becke_a_in) {
   */
   // USING SLATER-BRAGG ATOMIC RADII
   // H is modified to be 0.35A instead of 0.25A
-  cov_r( 1) = 0.6614; cov_r( 2) = 2.2677; cov_r( 3) = 2.7401;
-  cov_r( 4) = 1.9842; cov_r( 5) = 1.6063; cov_r( 6) = 1.3228;
-  cov_r( 7) = 1.2283; cov_r( 8) = 1.1338; cov_r( 9) = 0.9449;
-  cov_r(10) = 3.0236; cov_r(11) = 3.4015; cov_r(12) = 2.8346;
-  cov_r(13) = 2.3622; cov_r(14) = 2.0787; cov_r(15) = 1.8897;
-  cov_r(16) = 1.8897; cov_r(17) = 1.8897; cov_r(18) = 1.3417;
-  cov_r(19) = 4.1574; cov_r(20) = 3.4015; cov_r(21) = 3.0236;
-  cov_r(22) = 2.6456; cov_r(23) = 2.5511; cov_r(24) = 2.6456;
-  cov_r(25) = 2.6456; cov_r(26) = 2.6456; cov_r(27) = 2.5511;
-  cov_r(28) = 2.5511; cov_r(29) = 2.5511; cov_r(30) = 2.5511;
-  cov_r(31) = 2.4566; cov_r(32) = 2.3622; cov_r(33) = 2.1732;
-  cov_r(34) = 2.1732; cov_r(35) = 2.1732; cov_r(36) = 1.6630;
-  cov_r(37) = 4.4409; cov_r(38) = 3.7795; cov_r(39) = 3.4015;
-  cov_r(40) = 2.9291; cov_r(41) = 2.7401; cov_r(42) = 2.7401;
-  cov_r(43) = 2.5511; cov_r(44) = 2.4566; cov_r(45) = 2.5511;
-  cov_r(46) = 2.6456; cov_r(47) = 3.0236; cov_r(48) = 2.9291;
-  cov_r(49) = 2.9291; cov_r(50) = 2.7401; cov_r(51) = 2.7401;
-  cov_r(52) = 2.6456; cov_r(53) = 2.6456; cov_r(54) = 2.0409;
-  cov_r(55) = 4.9133; cov_r(56) = 4.0629; cov_r(57) = 3.6850;
-  cov_r(58) = 3.4960; cov_r(59) = 3.4960; cov_r(60) = 3.4960;
-  cov_r(61) = 3.4960; cov_r(62) = 3.4960; cov_r(63) = 3.4960;
-  cov_r(64) = 3.4015; cov_r(65) = 3.3070; cov_r(66) = 3.3070;
-  cov_r(67) = 3.3070; cov_r(68) = 3.3070; cov_r(69) = 3.3070;
-  cov_r(70) = 3.3070; cov_r(71) = 3.3070; cov_r(72) = 2.9291;
-  cov_r(73) = 2.7401; cov_r(74) = 2.5511; cov_r(75) = 2.5511;
-  cov_r(76) = 2.4566; cov_r(77) = 2.5511; cov_r(78) = 2.5511;
-  cov_r(79) = 2.5511; cov_r(80) = 2.8346; cov_r(81) = 3.5905;
-  cov_r(82) = 3.4015; cov_r(83) = 3.0236; cov_r(84) = 3.5905;
-  cov_r(85) = 2.4000; cov_r(86) = 2.2677; cov_r(87) = 6.5763;
-  cov_r(88) = 4.0629; cov_r(89) = 3.6850; cov_r(90) = 3.4015;
-  cov_r(91) = 3.4015; cov_r(92) = 3.3070; cov_r(93) = 3.3070;
-  cov_r(94) = 3.3070; cov_r(95) = 3.3070; cov_r(96) = 3.1936;
+  cov_r(1) = 0.6614;
+  cov_r(2) = 2.2677;
+  cov_r(3) = 2.7401;
+  cov_r(4) = 1.9842;
+  cov_r(5) = 1.6063;
+  cov_r(6) = 1.3228;
+  cov_r(7) = 1.2283;
+  cov_r(8) = 1.1338;
+  cov_r(9) = 0.9449;
+  cov_r(10) = 3.0236;
+  cov_r(11) = 3.4015;
+  cov_r(12) = 2.8346;
+  cov_r(13) = 2.3622;
+  cov_r(14) = 2.0787;
+  cov_r(15) = 1.8897;
+  cov_r(16) = 1.8897;
+  cov_r(17) = 1.8897;
+  cov_r(18) = 1.3417;
+  cov_r(19) = 4.1574;
+  cov_r(20) = 3.4015;
+  cov_r(21) = 3.0236;
+  cov_r(22) = 2.6456;
+  cov_r(23) = 2.5511;
+  cov_r(24) = 2.6456;
+  cov_r(25) = 2.6456;
+  cov_r(26) = 2.6456;
+  cov_r(27) = 2.5511;
+  cov_r(28) = 2.5511;
+  cov_r(29) = 2.5511;
+  cov_r(30) = 2.5511;
+  cov_r(31) = 2.4566;
+  cov_r(32) = 2.3622;
+  cov_r(33) = 2.1732;
+  cov_r(34) = 2.1732;
+  cov_r(35) = 2.1732;
+  cov_r(36) = 1.6630;
+  cov_r(37) = 4.4409;
+  cov_r(38) = 3.7795;
+  cov_r(39) = 3.4015;
+  cov_r(40) = 2.9291;
+  cov_r(41) = 2.7401;
+  cov_r(42) = 2.7401;
+  cov_r(43) = 2.5511;
+  cov_r(44) = 2.4566;
+  cov_r(45) = 2.5511;
+  cov_r(46) = 2.6456;
+  cov_r(47) = 3.0236;
+  cov_r(48) = 2.9291;
+  cov_r(49) = 2.9291;
+  cov_r(50) = 2.7401;
+  cov_r(51) = 2.7401;
+  cov_r(52) = 2.6456;
+  cov_r(53) = 2.6456;
+  cov_r(54) = 2.0409;
+  cov_r(55) = 4.9133;
+  cov_r(56) = 4.0629;
+  cov_r(57) = 3.6850;
+  cov_r(58) = 3.4960;
+  cov_r(59) = 3.4960;
+  cov_r(60) = 3.4960;
+  cov_r(61) = 3.4960;
+  cov_r(62) = 3.4960;
+  cov_r(63) = 3.4960;
+  cov_r(64) = 3.4015;
+  cov_r(65) = 3.3070;
+  cov_r(66) = 3.3070;
+  cov_r(67) = 3.3070;
+  cov_r(68) = 3.3070;
+  cov_r(69) = 3.3070;
+  cov_r(70) = 3.3070;
+  cov_r(71) = 3.3070;
+  cov_r(72) = 2.9291;
+  cov_r(73) = 2.7401;
+  cov_r(74) = 2.5511;
+  cov_r(75) = 2.5511;
+  cov_r(76) = 2.4566;
+  cov_r(77) = 2.5511;
+  cov_r(78) = 2.5511;
+  cov_r(79) = 2.5511;
+  cov_r(80) = 2.8346;
+  cov_r(81) = 3.5905;
+  cov_r(82) = 3.4015;
+  cov_r(83) = 3.0236;
+  cov_r(84) = 3.5905;
+  cov_r(85) = 2.4000;
+  cov_r(86) = 2.2677;
+  cov_r(87) = 6.5763;
+  cov_r(88) = 4.0629;
+  cov_r(89) = 3.6850;
+  cov_r(90) = 3.4015;
+  cov_r(91) = 3.4015;
+  cov_r(92) = 3.3070;
+  cov_r(93) = 3.3070;
+  cov_r(94) = 3.3070;
+  cov_r(95) = 3.3070;
+  cov_r(96) = 3.1936;
 
   becke_a_in.zero();
   for (uint iatom = 0; iatom < fortran_vars.atoms; iatom++) {
@@ -135,10 +199,10 @@ int compute_becke_a(HostMatrix<double>& becke_a_in) {
       // Uij = (Ri - Rj) / (Ri + Rj)
       // Aij = Uij / (Uij^2 - 1)
       if (!(fortran_vars.atom_types(iatom) == fortran_vars.atom_types(jatom))) {
-        double r_i = cov_r(fortran_vars.atom_types(iatom)+1);
-        double r_j = cov_r(fortran_vars.atom_types(jatom)+1);
+        double r_i = cov_r(fortran_vars.atom_types(iatom) + 1);
+        double r_j = cov_r(fortran_vars.atom_types(jatom) + 1);
         double u_ij = (r_i - r_j) / (r_i + r_j);
-        u_ij = u_ij / (u_ij * u_ij - 1.0);        
+        u_ij = u_ij / (u_ij * u_ij - 1.0);
 
         if (u_ij > 0.5) {
           u_ij = 0.5;
@@ -146,16 +210,16 @@ int compute_becke_a(HostMatrix<double>& becke_a_in) {
           u_ij = -0.5;
         }
         becke_a_in(iatom, jatom) = u_ij;
-        becke_a_in(jatom, iatom) = -becke_a_in(iatom,jatom);
-      } 
+        becke_a_in(jatom, iatom) = -becke_a_in(iatom, jatom);
+      }
     }
   }
   return 0;
-} // compute_becke_a
+}  // compute_becke_a
 
 int compute_becke_w(HostMatrix<double>& becke_w, double3 p_pos,
-                    HostMatrix<double>& becke_a){
-  // P_i is the so-called "atomic cell function". It is 
+                    HostMatrix<double>& becke_a) {
+  // P_i is the so-called "atomic cell function". It is
   // initialized with 1.0 in order to use in the final products.
   HostMatrix<double> P_i;
   P_i.resize(fortran_vars.atoms);
@@ -171,17 +235,17 @@ int compute_becke_w(HostMatrix<double>& becke_w, double3 p_pos,
         double3 j_pos = fortran_vars.atom_positions(jatom);
         double dist_ip = sqrt((i_pos.x - p_pos.x) * (i_pos.x - p_pos.x) +
                               (i_pos.y - p_pos.y) * (i_pos.y - p_pos.y) +
-                              (i_pos.z - p_pos.z) * (i_pos.z - p_pos.z) );
+                              (i_pos.z - p_pos.z) * (i_pos.z - p_pos.z));
 
         double dist_jp = sqrt((j_pos.x - p_pos.x) * (j_pos.x - p_pos.x) +
                               (j_pos.y - p_pos.y) * (j_pos.y - p_pos.y) +
-                              (j_pos.z - p_pos.z) * (j_pos.z - p_pos.z) );
+                              (j_pos.z - p_pos.z) * (j_pos.z - p_pos.z));
 
         double dist_ij = sqrt((i_pos.x - j_pos.x) * (i_pos.x - j_pos.x) +
                               (i_pos.y - j_pos.y) * (i_pos.y - j_pos.y) +
-                              (i_pos.z - j_pos.z) * (i_pos.z - j_pos.z) );
+                              (i_pos.z - j_pos.z) * (i_pos.z - j_pos.z));
 
-        double mu_ij  = (dist_ip - dist_jp) / dist_ij;
+        double mu_ij = (dist_ip - dist_jp) / dist_ij;
 
         // The first f_beck is nu_ij, then it is calculated recursively
         // up to order 3. Finally, f_beck becomes S_ij
@@ -196,16 +260,15 @@ int compute_becke_w(HostMatrix<double>& becke_w, double3 p_pos,
     }
     P_total = P_total + P_i(iatom);
   }
-  becke_w(fortran_vars.atoms-1) = 1.0f;
-  for (uint iatom = 0; iatom < (fortran_vars.atoms-1); iatom++) {
+  becke_w(fortran_vars.atoms - 1) = 1.0f;
+  for (uint iatom = 0; iatom < (fortran_vars.atoms - 1); iatom++) {
     becke_w(iatom) = P_i(iatom) / P_total;
-    if (becke_w(iatom) < (float) 1.0E-6 ) becke_w(iatom) = 0.0f;
-    becke_w(fortran_vars.atoms-1) -= becke_w(iatom);
+    if (becke_w(iatom) < (float)1.0E-6) becke_w(iatom) = 0.0f;
+    becke_w(fortran_vars.atoms - 1) -= becke_w(iatom);
   }
 
-
   return 0;
-} // compute_becke_w
+}  // compute_becke_w
 
 int split_bins(const vector<pair<long long, int> >& costs,
                vector<vector<int> >& workloads, long long capacity) {
@@ -295,8 +358,8 @@ int getintenv(const char* str, int default_value) {
 void diagnostic() {
   printf("  Threads OMP: %d - Threads CPU: %d - Threads GPU: %d\n",
          omp_get_max_threads(), G2G::cpu_threads, G2G::gpu_threads);
-  printf("  Small cube correction: %d - Separation points: %d\n",
-         MINCOST, SPLITPOINTS);
+  printf("  Small cube correction: %d - Separation points: %d\n", MINCOST,
+         SPLITPOINTS);
 }
 
 template <class T>
@@ -470,9 +533,9 @@ void Partition::regenerate(void) {
             atom_weights.zero();
             compute_becke_w(atom_weights, point_position, becke_a);
           }
-          
-          Point point_object(atom, shell, point, point_position,
-                             point_weight, atom_weights);
+
+          Point point_object(atom, shell, point, point_position, point_weight,
+                             atom_weights);
           uint included_shells = (uint)ceil(sphere_radius * atom_shells);
 
           // Si esta capa esta muy lejos del nucleo, la modelamos como esfera,

--- a/g2g/scalar_vector_types.h
+++ b/g2g/scalar_vector_types.h
@@ -65,7 +65,7 @@ class vec_type<float, 3> {
 template <>
 class vec_type<float, 4> {
  private:
-  //float x, y, z, _w;
+  // float x, y, z, _w;
 
  public:
   /** La integracion a Libxc necesita acceder a estos componentes **/
@@ -288,6 +288,6 @@ class vec_type<int2, 4> {
   int2 x, y, z, w;
 };
 #endif
-}
+}  // namespace G2G
 
 #endif /* _SCALAR_VECTOR_TYPES_H */

--- a/g2g/timer.h
+++ b/g2g/timer.h
@@ -35,6 +35,6 @@ class Timer {
 };
 
 std::ostream& operator<<(std::ostream& o, const Timer& t);
-}
+}  // namespace G2G
 
 #endif


### PR DESCRIPTION
Just like in #109, run the tool with the changes since https://github.com/MALBECC/lio/pull/160

```
cd g2g
find . | grep -E "\.(h|cpp|cu)$" | xargs clang-format-10 -i -style=file
```
This PR might bring a lot of conflicts to others, but the solution is to run the command above *before you merge*. This should cause your diffs to be zero.

Cuda changes are now correctly formatted (after clang added support https://reviews.llvm.org/D42589) but there are a *lot*. They are all auto-generated but if people reformat-before-merge before there should be no problem.

After fixing the formatting, `cpp-lint` shows the following issues:
https://github.com/manuelF/lio/runs/4218078570?check_suite_focus=true

Likely not all of them are worth fixing, so the tool can be configured to ignore certain kind of issues, like copyright. 
(see https://android.googlesource.com/platform/art/+/master/CPPLINT.cfg for example)

I will configure it independently in a separate PR.